### PR TITLE
docs: restyle nav to match parent umbrella, use arrow for package icon

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-icon: material/sprout
+icon: fontawesome/solid/circle-right
 ---
 
 --8<-- "README.md"

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,5 +1,5 @@
 :root {
-  --icon-return: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640"><!--!Font Awesome Free v7.3.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.--><path d="M576 320C576 178.6 461.4 64 320 64C178.6 64 64 178.6 64 320C64 461.4 178.6 576 320 576C461.4 576 576 461.4 576 320zM188.7 308.7L292.7 204.7C297.3 200.1 304.2 198.8 310.1 201.2C316 203.6 320 209.5 320 216L320 272L416 272C433.7 272 448 286.3 448 304L448 336C448 353.7 433.7 368 416 368L320 368L320 424C320 430.5 316.1 436.3 310.1 438.8C304.1 441.3 297.2 439.9 292.7 435.3L188.7 331.3C182.5 325.1 182.5 314.9 188.7 308.7z"/></svg>');
+  --icon-bagof: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M2 22v-2s5-2 10-2 10 2 10 2v2zm9.3-12.9c-1.2-3.9-7.3-3-7.3-3s.2 7.8 5.9 6.6C9.5 9.8 8 9 8 9c2.8 0 3 3.4 3 3.4V17h2v-4.2s0-3.9 3-4.9c0 0-2 3-2 5 7 .7 7-8.9 7-8.9s-8.9-1-9.7 5.1"/></svg>');
 }
 
 a[href="https://bagofseeds.github.io/bagof/"]::before {
@@ -9,16 +9,10 @@ a[href="https://bagofseeds.github.io/bagof/"]::before {
   height: 1.2em;
   vertical-align: text-top;
   background-color: currentColor;
-  -webkit-mask: var(--icon-return) no-repeat center / contain;
-  mask: var(--icon-return) no-repeat center / contain;
+  -webkit-mask: var(--icon-bagof) no-repeat center / contain;
+  mask: var(--icon-bagof) no-repeat center / contain;
 }
 
-[data-md-color-scheme="default"] .md-logo {
-  /* Changes the color if it uses text/currentColor */
-  color: #228B22 !important;
-}
-
-[data-md-color-scheme="default"] .md-logo svg {
-  /* Forces the color if it renders as an inline SVG path */
-  fill: #228B22 !important;
+[data-md-color-scheme="default"] a[href="https://bagofseeds.github.io/bagof/"]::before {
+  background-color: #228B22;
 }

--- a/zensical.toml
+++ b/zensical.toml
@@ -3,8 +3,8 @@
 extra_css = ["stylesheets/extra.css"]
 
 nav = [
-  {"All the Bags" = "https://bagofseeds.github.io/bagof/"},
-  {"Bag of Magic" = "index.md"},
+  {"Bag of" = "https://bagofseeds.github.io/bagof/"},
+  {"Magic" = "index.md"},
   {"API" = [
     "api/index.md",
     {"fields" = "api/fields.md"},
@@ -78,7 +78,7 @@ toggle.name = "Switch to light mode"
 # - https://zensical.org/docs/authoring/icons-emojis/#search
 # ----------------------------------------------------------------------------
 [project.theme.icon]
-logo =  "material/sprout"
+logo =  "fontawesome/solid/circle-right"
 repo = "fontawesome/brands/github"
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The "All the Bags" nav link now reads "Bag of" and shows the sprout logo in the umbrella's brand color (`#228B22`, light mode), matching how the `bagof` repo styles itself.
- The package-home nav item now reads just "Magic" and uses a mirrored circle-arrow icon (FontAwesome `circle-right`) instead of the sprout logo, for both the header logo and the nav entry — there's no meaningful per-package logo to use instead across ~9 bags, so a consistent generic icon was used instead.

## Verification
Built the sibling `bagof-hints` site locally with `zensical build` and screenshotted light/dark mode to confirm the (identical) nav pattern renders as intended.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FPpSMVqQuB4GSt3PbqibQX)_