### PR TITLE
fix: restore masthead logo; ci: filter pull_request paths

### DIFF
--- a/.github/workflows/coverage-on-push.yaml
+++ b/.github/workflows/coverage-on-push.yaml
@@ -11,6 +11,11 @@ on:
       - pyproject.toml
       - .github/workflows/test*.yaml
   pull_request:
+    paths:
+      - src/**
+      - tests/**
+      - pyproject.toml
+      - .github/workflows/test*.yaml
 
 permissions:
   contents: read

--- a/.github/workflows/test-on-push.yaml
+++ b/.github/workflows/test-on-push.yaml
@@ -11,6 +11,11 @@ on:
       - pyproject.toml
       - .github/workflows/test*.yaml
   pull_request:
+    paths:
+      - src/**
+      - tests/**
+      - pyproject.toml
+      - .github/workflows/test*.yaml
 
 permissions:
   contents: read

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -16,3 +16,13 @@ a[href="https://bagofseeds.github.io/bagof/"]::before {
 [data-md-color-scheme="default"] a[href="https://bagofseeds.github.io/bagof/"]::before {
   background-color: #228B22;
 }
+
+[data-md-color-scheme="default"] .md-logo {
+  /* Changes the color if it uses text/currentColor */
+  color: #228B22 !important;
+}
+
+[data-md-color-scheme="default"] .md-logo svg {
+  /* Forces the color if it renders as an inline SVG path */
+  fill: #228B22 !important;
+}

--- a/zensical.toml
+++ b/zensical.toml
@@ -78,7 +78,7 @@ toggle.name = "Switch to light mode"
 # - https://zensical.org/docs/authoring/icons-emojis/#search
 # ----------------------------------------------------------------------------
 [project.theme.icon]
-logo =  "fontawesome/solid/circle-right"
+logo =  "material/sprout"
 repo = "fontawesome/brands/github"
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Two follow-ups to #3, found in review right after merge:
- **Masthead regression**: that PR changed `theme.icon.logo` to fix the nav-item icon, not realizing it also drives the header corner logo — that swapped the site's sprout logo for the arrow everywhere. Reverted `theme.icon.logo` to `material/sprout` and restored its brand-color CSS override, so the masthead is back to how it always looked. The arrow (via the index page's `icon:` front matter) stays on the nav item only, as intended.
- **CI**: `pull_request` had no `paths` filter (unlike `push`), so a docs-only PR ran the full lint + test matrix. Mirrored the same `paths` list onto `pull_request` in `test-on-push.yaml` and `coverage-on-push.yaml`.

## Verification
Rebuilt the sibling `bagof-hints` site locally with `zensical build` and screenshotted — masthead shows the sprout logo again, nav item shows the arrow.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FPpSMVqQuB4GSt3PbqibQX)_