### PR TITLE
docs: audit and fix language, formatting, and cross-references

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 `Magic` is a `dataclass`-like base built on hint-based *magic*: field
 behaviour is driven by type hints and resolved through the sibling
-[`bagof-validators`](https://github.com/bagofseeds/bagof-validators) and
-[`bagof-converters`](https://github.com/bagofseeds/bagof-converters)
+[`bagof-validators`](https://bagofseeds.github.io/bagof-validators/) and
+[`bagof-converters`](https://bagofseeds.github.io/bagof-converters/)
 packages.
 
 Unlike a `dataclass`, options are given as class keyword arguments and are

--- a/src/bagof/magic/__init__.py
+++ b/src/bagof/magic/__init__.py
@@ -32,19 +32,19 @@ some differences. Additional options are also implemented:
 
 Parameters
 ----------
-init: bool, default=True
+init : bool | str, default=True
     Generate `__init__` method
-repr : bool, default=True
+repr : bool | str, default=True
     Generate `__repr__` method
-eq : bool, default=True
+eq : bool | str, default=True
     Generate `__eq__` method
-order : bool, default=False
+order : bool | str, default=False
     Generate `__lt__` method
 unsafe_hash : bool, default=False
     Always generate `__hash__` method
 frozen : bool, default=False
     Disable `__setattr__` and `__delattr__`
-match_args : bool, default=True
+match_args : bool | str, default=False
     Generate `__match_args__` for pattern matching
 kw_only : bool, default=False
     Make all fields keyword-only by default
@@ -59,17 +59,19 @@ convert : bool, default=False
 validate : bool, default=False
     Use field type as validator if none is provided
 
+Examples
+--------
 It also differs from a standard dataclass in that field-specific options
 are assigned via annotations, rather than via a `field` function:
 
 ```python
 # - Default factories
 #   instead of x: list = field(factory=list)
-x: DefaultFactory[list, list_factory]
-x: Annotated[list, DefaultFactory(list_factory)]
+x: Factory[list, list_factory]
+x: Annotated[list, Factory(list_factory)]
 
 #   if no factory is provided, it will use the type as the default factory
-x: DefaultFactory[list] -> x: Annotated[list, DefaultFactory(list)]
+x: Factory[list] -> x: Annotated[list, Factory(list)]
 
 # - Include in the init method
 #   instead of x: int = field(init=True)
@@ -90,7 +92,7 @@ x: Annotated[int, NotKwOnly()]
 x: Annotated[int, KwOnly(False)]
 ```
 
-It supports additional features such as  automatic conversion of field
+It supports additional features such as automatic conversion of field
 values via annotations:
 
 ```python
@@ -1075,13 +1077,13 @@ def _make_mapping(
 
 
 _DOC_OPTIONS = """
-init: bool | str, default=`True`
+init : bool | str, default=True
     Generate `__init__` method.
 repr : bool | str, default=True
     Generate `__repr__` method.
 eq : bool | str, default=True
     Generate `__eq__` method.
-order : bool, default=False
+order : bool | str, default=False
     Generate `__lt__` method.
 hash : bool | str, default=None
     Generate `__hash__` method.
@@ -1090,7 +1092,7 @@ unsafe_hash : bool, default=False
     Always generate `__hash__` method.
 frozen : bool, default=False
     Disable `__setattr__` and `__delattr__`.
-match_args : bool, default=True
+match_args : bool | str, default=False
     Generate `__match_args__` for pattern matching.
 kw_only : bool, default=False
     Make all fields keyword-only by default.
@@ -1113,8 +1115,7 @@ reverse : bool, default=False
     This only affects the relative order of the fields of one class
     with respect to the fields of its base classes.
 doc : bool | str, default=True
-    Add field documentation to class docstring
-   .
+    Add field documentation to class docstring.
 """.strip()
 
 
@@ -1147,7 +1148,45 @@ class MetaMagic(ABCMeta):
 
     Other Parameters
     ----------------
-    {DOC_OPTIONS}
+    init : bool | str, default=True
+        Generate `__init__` method.
+    repr : bool | str, default=True
+        Generate `__repr__` method.
+    eq : bool | str, default=True
+        Generate `__eq__` method.
+    order : bool | str, default=False
+        Generate `__lt__` method.
+    hash : bool | str, default=None
+        Generate `__hash__` method.
+        If `None`, decide automatically.
+    unsafe_hash : bool, default=False
+        Always generate `__hash__` method.
+    frozen : bool, default=False
+        Disable `__setattr__` and `__delattr__`.
+    match_args : bool | str, default=False
+        Generate `__match_args__` for pattern matching.
+    kw_only : bool, default=False
+        Make all fields keyword-only by default.
+    positional_only : bool, default=False
+        Make all fields positional-only by default.
+    slots : bool, default=False
+        Generate `__slots__` and remove `__dict__`.
+    weakref_slot : bool, default=False
+        Generate a weakref slot in `__slots__`.
+    factory : bool, default=False
+        Use field type as factory if none is provided.
+    convert : bool, default=False
+        Use field type as converter if none is provided.
+    validate : bool, default=False
+        Use field type as validator if none is provided.
+    mapping : bool, default=False
+        Implement the `Mapping` protocol.
+    reverse : bool, default=False
+        Use the reverse MRO order to determine field order.
+        This only affects the relative order of the fields of one class
+        with respect to the fields of its base classes.
+    doc : bool | str, default=True
+        Add field documentation to class docstring.
 
     Returns
     -------
@@ -1184,7 +1223,45 @@ class Magic(metaclass=MetaMagic):
 
     Parameters
     ----------
-    {DOC_OPTIONS}
+    init : bool | str, default=True
+        Generate `__init__` method.
+    repr : bool | str, default=True
+        Generate `__repr__` method.
+    eq : bool | str, default=True
+        Generate `__eq__` method.
+    order : bool | str, default=False
+        Generate `__lt__` method.
+    hash : bool | str, default=None
+        Generate `__hash__` method.
+        If `None`, decide automatically.
+    unsafe_hash : bool, default=False
+        Always generate `__hash__` method.
+    frozen : bool, default=False
+        Disable `__setattr__` and `__delattr__`.
+    match_args : bool | str, default=False
+        Generate `__match_args__` for pattern matching.
+    kw_only : bool, default=False
+        Make all fields keyword-only by default.
+    positional_only : bool, default=False
+        Make all fields positional-only by default.
+    slots : bool, default=False
+        Generate `__slots__` and remove `__dict__`.
+    weakref_slot : bool, default=False
+        Generate a weakref slot in `__slots__`.
+    factory : bool, default=False
+        Use field type as factory if none is provided.
+    convert : bool, default=False
+        Use field type as converter if none is provided.
+    validate : bool, default=False
+        Use field type as validator if none is provided.
+    mapping : bool, default=False
+        Implement the `Mapping` protocol.
+    reverse : bool, default=False
+        Use the reverse MRO order to determine field order.
+        This only affects the relative order of the fields of one class
+        with respect to the fields of its base classes.
+    doc : bool | str, default=True
+        Add field documentation to class docstring.
     """
 
     # Set __slots__ so that inheriting classes can have slot=True
@@ -1211,7 +1288,7 @@ def magic(cls: type, **kwargs) -> type: ...
 def magic(cls: tx.Optional[type] = None, **kwargs):
     """
     Decorator for defining a Magic class.
-    See `MetaMagic` for parameters and examples.
+    See `Magic` for parameters and examples.
     """
     if cls is None:
         return partial(magic, **kwargs)

--- a/src/bagof/magic/constants.py
+++ b/src/bagof/magic/constants.py
@@ -126,6 +126,19 @@ class SHOW_ATTR:
 
 
 class HIDE_IF_NONE(SHOW_ATTR):
+    """
+    Sentinel for `Field.repr` / `Field.key`: include the field in the
+    generated `__repr__` / dict-like interface only when its value is not
+    `None` at runtime, instead of unconditionally.
+
+    ```python
+    class C(Magic):
+        x: Annotated[Optional[int], Field(repr=HIDE_IF_NONE)]
+
+    repr(C(None))  # "C()"
+    repr(C(5))     # "C(x=5)"
+    ```
+    """
 
     def __init__(self, key: tx.Optional[str] = None) -> None:
         super().__init__(key=key, hide_if_none=True)

--- a/src/bagof/magic/fields.py
+++ b/src/bagof/magic/fields.py
@@ -426,6 +426,7 @@ class Init(BoolAnnotatedField):
     NoInit()    ~> Field(init=False)
     Init[int]   ~> Annotated[T, Field(init=True)]
     NoInit[int] ~> Annotated[T, Field(init=False)]
+    ```
     """
 
     __set_slots__ = 'init'
@@ -447,6 +448,7 @@ class Kw(BoolAnnotatedField):
     Kw[int]     ~> Annotated[T, Field(kw=True)]
     NotKw[int]  ~> Annotated[T, Field(kw=False)]
     KwOnly[int] ~> Annotated[T, Field(kw=True, positional=False)]
+    ```
     """
 
     __set_slots__ = 'kw'
@@ -468,6 +470,7 @@ class Positional(BoolAnnotatedField):
     Positional[int]     ~> Annotated[T, Field(positional=True)]
     NotPositional[int]  ~> Annotated[T, Field(positional=False)]
     PositionalOnly[int] ~> Annotated[T, Field(positional=True, kw=False)]
+    ```
     """
 
     __set_slots__ = 'positional'
@@ -503,6 +506,7 @@ class Frozen(BoolAnnotatedField):
     NotFrozen()    ~> Field(frozen=False)
     Frozen[int]    ~> Annotated[T, Field(frozen=True)]
     NotFrozen[int] ~> Annotated[T, Field(frozen=False)]
+    ```
     """
 
     __set_slots__ = 'frozen'
@@ -550,6 +554,7 @@ class Repr(BoolAnnotatedField):
     NoRepr()     ~> Field(repr=False)
     Repr[int]    ~> Annotated[T, Field(repr=True)]
     NoRepr[int]  ~> Annotated[T, Field(repr=False)]
+    ```
     """
 
     __set_slots__ = ('repr',)
@@ -630,7 +635,7 @@ class NoHash(Hash, InversedBoolAnnotatedField): ...
 @slots
 class Key(BoolAnnotatedField):
     """ Specify that a field should [not] be included in the generated
-    `__hash__` method.
+    dict-like interface.
 
     ```python
     Key()       ~> Field(key=True)

--- a/src/bagof/magic/options.py
+++ b/src/bagof/magic/options.py
@@ -27,6 +27,20 @@ from .utils import SlotsBase, slots
     'doc',              # Generate class docstring from field docstrings
 )
 class Options(SlotsBase):
+    """
+    The resolved set of class-level options for a `Magic` class.
+
+    `MetaMagic` builds one `Options` instance per class from the keyword
+    arguments passed to the class statement (or to the `magic` decorator),
+    merged with the options inherited from base classes in MRO order --
+    a base class's value is used unless a derived class explicitly sets
+    its own. The result is stored on the class as `cls.__magic_options__`
+    and, together with each field's own overrides, decides which dunder
+    methods (`__init__`, `__repr__`, `__eq__`, ...) get generated and how.
+
+    See `Magic` for the full list of supported options and their
+    defaults.
+    """
 
     _DEFAULTS: tx.Dict[str, bool] = dict(
         init=True,
@@ -51,4 +65,5 @@ class Options(SlotsBase):
 
     @staticmethod
     def make_default() -> tx.Self:
+        """Return a new `Options` instance populated with default values."""
         return Options(**Options._DEFAULTS)


### PR DESCRIPTION
## Summary

Audit of the published docs (README, `docs/`, and public docstrings rendered via mkdocstrings). Highlights, roughly in order of impact:

- **The class-options table was silently missing from the published `Magic`/`MetaMagic` API pages.** Those docstrings interpolate a `{DOC_OPTIONS}` placeholder via `cls.__doc__.format(...)` executed *after* class creation. mkdocstrings/griffe only sees the static source text, so it saw the literal, unresolved `{DOC_OPTIONS}` string — meaning `init`, `repr`, `frozen`, `slots`, `kw_only`, etc. never actually appeared on the rendered `Magic` page, despite being the central explanation of how the options machinery works. Fixed by inlining the option list as literal docstring text (the `.format()` calls become harmless no-ops since there's nothing left to substitute — verified via a scratch venv install and `pytest`, 175 passed).
- Five `Field` annotation subclasses (`Init`, `Kw`, `Positional`, `Frozen`, `Repr`) had unterminated ` ```python ` fences in their docstrings, so mkdocstrings rendered the closing `"""` and surrounding text as broken raw markdown instead of a code block.
- `Key`'s docstring was copy-pasted from `Hash` and claimed to gate `__repr__`/`__hash__`; it actually gates the dict-like `__getitem__`/mapping interface.
- The module docstring said `match_args` defaults to `True`; `Options._DEFAULTS` says `False`. Also normalized `order`/`match_args` to `bool | str` (both accept a custom method name, same as `init`/`repr`/`eq`/`hash`, already documented that way) and fixed a stray line-broken period.
- The module docstring's numpydoc `Parameters` section was never closed with a following section header, so griffe kept consuming all the trailing prose and example code fences as more "parameters" — producing ~50 "could not parse line" build warnings and an empty/garbled parse. Added an `Examples` header to close the section properly.
- Fixed an example referencing `DefaultFactory`, which doesn't exist — the real name is `Factory`.
- `Options` (the class holding a `Magic` class's resolved options) and `HIDE_IF_NONE` (explicitly re-exported in `__all__`) had no docstring at all, so neither rendered on its API page. Added docstrings grounded in actual usage (checked against `tests/test_magic.py`).
- README's sibling-package links pointed at `github.com/bagofseeds/*`; repointed to `https://bagofseeds.github.io/<repo>/` per this project's convention for "read more" references.
- Removed two now-dead manual mkdocstrings cross-refs (`[MetaMagic][bagof.magic.MetaMagic]`) after finding `MetaMagic` never renders on this site (it's not in `bagof.magic.__all__`) — pointed the prose at `Magic` instead, which is visible and now carries the full option list.

## Flagged, not fixed (would need a maintainer call)

- `MetaMagic` and the module-level `fields()` helper function have full docstrings but never appear in the API reference because they're absent from `bagof.magic.__all__`. Could be intentional (implementation detail) or an oversight — didn't touch `__all__` since that changes `from bagof.magic import *` behavior, not just docs.

## Verification

- `rm -rf .cache site && zensical build -f zensical.toml -c` — "No issues found"; only the external-inventory 403s (sandbox-only) and the same small pre-existing "documented kwarg not in formal signature" warning class already present for `Field.__init__` remain (no new warning categories).
- Installed the package in a scratch venv and empirically checked the doc-example equivalences that looked non-obvious (`KwOnly`/`NotKwOnly`, `Factory`, `ConvertTo`, `Frozen`, `PositionalOnly`) against real runtime behavior before touching any of them.
- `pytest`: 175 passed, unchanged.

No code logic was changed — only docstring/comment text and README prose (the two `.format()` calls become no-ops as a side effect of the docstring text no longer containing a placeholder, not because the statements were touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FPpSMVqQuB4GSt3PbqibQX


---
_Generated by [Claude Code](https://claude.ai/code/session_01FPpSMVqQuB4GSt3PbqibQX)_