### PR TITLE
chore: install test requirements in the release test job

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -67,6 +67,7 @@ jobs:
       test: ${{ inputs.test }}
       publish: ${{ inputs.publish }}
       python-version: ${{ inputs.python-version }}
+      requirements-file: tests/requirements.txt
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
       TEST_PYPI_TOKEN: ${{ secrets.TEST_PYPI_TOKEN }}


### PR DESCRIPTION
## What changed

Pass `requirements-file: tests/requirements.txt` in the local `test-and-publish.yaml` wrapper, which is where this repo calls the shared `bagofseeds/actions/.github/workflows/test-and-publish.yaml@main`. `publish-on-release.yaml` delegates to that wrapper, so the one line fixes both the release path and the manual `workflow_dispatch` path.

## Why

The release path never installed the test requirements, so the tests that gate publishing ran against a bare `pytest` + `pip install -e .` environment. The shared workflow only runs its install step when the input is non-empty:

```yaml
- name: Install from requirements file
  if: ${{ inputs.requirements-file != '' }}
```

Every repo passes that input on the push/PR path (`test-matrix.yaml` / `test.yaml`) but none passed it on the release path, so the step was silently skipped.

This was found via `bagof-hints`, where it broke the `0.1.0a` release: [run 32147168914](https://github.com/bagofseeds/bagof-hints/actions/runs/32147168914) failed with 46 errors, all `No module named mypy`, and every publish job was then skipped (`needs: tests`). The same latent gap exists in every repo that calls the shared workflow; this PR is the org-wide fix applied here.

The requirements file here currently pins only `pytest`, which the shared workflow installs anyway — so this repo is not broken today. It is fixed for consistency, and so that the first dependency added to `tests/requirements.txt` doesn't quietly go missing at release time.

Hardcoding the path matches how `test-matrix.yaml` already spells it, so no new input needed plumbing through.

## How it was verified

All workflow YAML in the repo still parses, and the diff is exactly one added line.

The behaviour was verified end-to-end in `bagof-hints`, whose suite goes from `46 failed, 530 passed, 1 skipped` (no requirements file) to `600 passed` in a clean venv built the way the shared workflow builds one. The last green `Test on push` run there confirms the same `ubuntu-latest` runner installs a requirements file successfully, so the fix does not just move the failure to install time.

No `src/` or `tests/` files are touched, so `ruff` / `codespell` are unaffected by this diff.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UeowQRDBZT8156Ja9A4rA9

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeowQRDBZT8156Ja9A4rA9)_