### PR TITLE
Fix the NameError for a field whose parameter name differs

### DIFF
--- a/src/bagof/magic/__init__.py
+++ b/src/bagof/magic/__init__.py
@@ -733,6 +733,7 @@ def _make_init(
     positional_onlys, args, kw_onlys = {}, {}, {}
 
     SELF = "self"
+    seen_params = {}
     for name, field in fields.items():
         if field.init and field.positional and not field.kw:
             positional_onlys[name] = field
@@ -742,7 +743,18 @@ def _make_init(
             kw_onlys[name] = field
         else:
             continue
-        if name == "self":
+        # The parameter is named after the field's *public* name, which
+        # differs from the field name for an aliased or underscored
+        # field. Two fields that reduce to the same parameter would
+        # generate a signature with a duplicate argument.
+        public = field.public_name
+        if public in seen_params:
+            raise TypeError(
+                f"fields {seen_params[public]!r} and {name!r} both map to "
+                f"the __init__ parameter {public!r}"
+            )
+        seen_params[public] = name
+        if public == "self":
             SELF = _SELF
 
     def _make_signature_elem(field: Field) -> tx.Tuple[str, str]:
@@ -794,19 +806,24 @@ def _make_init(
 
     def _make_prepost_call(func: str) -> str:
         prepost_args = []
-        for name, field in positional_onlys.items():
+        for field in positional_onlys.values():
             if field.var:
-                prepost_args.append(f"{name}")
-        for name, field in args.items():
+                prepost_args.append(f"{field.public_name}")
+        for field in args.values():
             if field.var:
-                prepost_args.append(f"{name}")
-        for name, field in kw_onlys.items():
+                prepost_args.append(f"{field.public_name}")
+        for field in kw_onlys.values():
             if field.var:
+                name = field.public_name
                 prepost_args.append(f"{name}={name}")
         prepost_args = ", ".join(prepost_args)
         return f"{SELF}.{func}({prepost_args})"
 
-    def _make_body_elem(name: str, field: Field) -> str:
+    def _make_body_elem(field: Field) -> str:
+        # The body reads the *parameter*, which is named after the
+        # field's public name, and writes the *field*, which keeps its
+        # own name.
+        name = field.public_name
         body = ""
         if field.factory:
             body += dedent(f"""
@@ -834,12 +851,12 @@ def _make_init(
     body = []
     if "pre" in prepost:
         body.append(_make_prepost_call(_PRE_INIT_NAME))
-    for name, field in positional_onlys.items():
-        body.append(_make_body_elem(name, field))
-    for name, field in args.items():
-        body.append(_make_body_elem(name, field))
-    for name, field in kw_onlys.items():
-        body.append(_make_body_elem(name, field))
+    for field in positional_onlys.values():
+        body.append(_make_body_elem(field))
+    for field in args.values():
+        body.append(_make_body_elem(field))
+    for field in kw_onlys.values():
+        body.append(_make_body_elem(field))
     if "post" in prepost:
         body.append(_make_prepost_call(_POST_INIT_NAME))
 

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1700,3 +1700,60 @@ class TestPositionalOnly:
 
         r = R(1, 2, c=3)
         assert (r.a, r.b, r.c) == (1, 2, 3)
+
+
+class TestPublicName:
+    """A field whose parameter name differs from its own name."""
+
+    def test_underscored_field(self) -> None:
+        # Regression: the generated body referenced the field name while
+        # the signature declared the public name, so the class raised
+        # `NameError: name '_x' is not defined` at definition time.
+        class P(Magic):
+            _x: int
+
+        assert P(1)._x == 1
+        assert P(x=2)._x == 2
+        assert repr(P(3)) == "P(x=3)"
+
+    def test_explicit_alias(self) -> None:
+        class A(Magic):
+            x: Annotated[int, Field(alias="ex")]
+
+        assert A(ex=1).x == 1
+        assert A(1).x == 1
+        assert repr(A(1)) == "A(ex=1)"
+
+    def test_alias_false_keeps_the_private_name(self) -> None:
+        class A(Magic):
+            _x: Annotated[int, Field(alias=False)]
+
+        assert A(_x=1)._x == 1
+
+    def test_underscored_field_with_a_converter(self) -> None:
+        class P(Magic, convert=True):
+            _x: int
+
+        assert P("5")._x == 5
+
+    def test_underscored_pseudo_field_reaches_post_init(self) -> None:
+        class C(Magic):
+            x: int
+            _seed: Annotated[int, Field(var=True, init=True)] = 0
+
+            def __post_init__(self, seed: int) -> None:
+                object.__setattr__(self, "x", self.x + seed)
+
+        assert C(1, seed=7).x == 8
+
+    def test_two_fields_mapping_to_one_parameter_is_rejected(self) -> None:
+        with pytest.raises(TypeError, match="both map to"):
+            class Bad(Magic):
+                _y: int
+                y: int
+
+    def test_a_field_named_self_still_works(self) -> None:
+        class C(Magic):
+            self: int
+
+        assert C(1).self == 1


### PR DESCRIPTION
`_make_init` built the signature from `field.public_name` but the body from the field's own `name`. The two differ whenever an `alias` is set and, silently, for every field whose name starts with an underscore — `public_name` strips it. Both raised at class-definition time:

```pycon
>>> class P(Magic):
...     _x: int
NameError: name '_x' is not defined

>>> class A(Magic):
...     x: Annotated[int, Field(alias="ex")]
NameError: name 'x' is not defined
```

So `alias` and underscored fields were unusable, despite both being documented.

## Change

The generated body now reads the parameter through `public_name` and writes the attribute through `name`. `_make_prepost_call` does the same, so an underscored `InitVar` reaches `__post_init__` under the name `__init__` actually declares.

Two fields can now collide on a single parameter (`_y` and `y` both reduce to `y`), which would generate a signature with a duplicate argument. That is caught with a `TypeError` naming both fields rather than producing a confusing `SyntaxError` from the generated source.

## Tests

New `TestPublicName`: underscored fields (positional and keyword), an explicit `alias`, `alias=False`, an underscored field with a converter, an underscored pseudo-field reaching `__post_init__`, the collision error, and a field literally named `self` (which shares the same code path).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_