### PR TITLE
Stop overwriting a user-defined __setattr__ / __delattr__

### DIFF
--- a/src/bagof/magic/__init__.py
+++ b/src/bagof/magic/__init__.py
@@ -171,9 +171,9 @@ def __post_new__(cls: type) -> type:
     fields = getattr(cls, _FIELDS, {})
     fields = {name: field for name, field in fields.items() if not field.var}
     __delattr__, __setattr__ = _make_assign(cls)
-    if "__setattr___" not in cls.__dict__:
+    if "__setattr__" not in cls.__dict__:
         cls.__setattr__ = __setattr__
-    if "__delattr___" not in cls.__dict__:
+    if "__delattr__" not in cls.__dict__:
         cls.__delattr__ = __delattr__
 
     return cls

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1700,3 +1700,42 @@ class TestPositionalOnly:
 
         r = R(1, 2, c=3)
         assert (r.a, r.b, r.c) == (1, 2, 3)
+
+
+class TestUserDefinedAssignment:
+    """A hand-written `__setattr__` / `__delattr__` must survive."""
+
+    def test_user_setattr_is_kept(self) -> None:
+        # Regression: the guard tested for "__setattr___" (three trailing
+        # underscores), so it never matched and the user's method was
+        # always overwritten.
+        class S(Magic):
+            x: int
+
+            def __setattr__(self, name: str, value: int) -> None:
+                object.__setattr__(self, name, value * 2)
+
+        s = S(1)
+        # `__init__` assigns through `object.__setattr__`, so it is not
+        # doubled at construction...
+        assert s.x == 1
+        # ...but a later assignment goes through the user's method.
+        s.x = 3
+        assert s.x == 6
+
+    def test_user_delattr_is_kept(self) -> None:
+        class D(Magic):
+            x: int = 0
+
+            def __delattr__(self, name: str) -> None:
+                raise RuntimeError("no deleting")
+
+        with pytest.raises(RuntimeError, match="no deleting"):
+            del D(1).x
+
+    def test_frozen_still_applies_without_a_user_method(self) -> None:
+        class F(Magic, frozen=True):
+            x: int
+
+        with pytest.raises(AttributeError, match="frozen"):
+            F(1).x = 2


### PR DESCRIPTION
The guard in `__post_new__` tested for `"__setattr___"` and `"__delattr___"` — three trailing underscores — so it never matched anything in `cls.__dict__` and a hand-written method was always replaced, silently.

```python
if "__setattr___" not in cls.__dict__:   # never matches
    cls.__setattr__ = __setattr__
```

`__init__` still assigns through `object.__setattr__`, so a user method is not run at construction — conversion and validation would run twice. It takes over for every later assignment, which is what defining one means.

## Tests

New `TestUserDefinedAssignment`: a user `__setattr__` is bypassed at construction and applied afterwards, a user `__delattr__` is kept, and `frozen` still applies on a class that defines neither.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_