### PR TITLE
Make the package importable under `python -OO`

### DIFF
--- a/src/bagof/magic/__init__.py
+++ b/src/bagof/magic/__init__.py
@@ -498,7 +498,9 @@ def __pre_new__(
     fnbuilder.insert_fns(clsname, namespace)
 
     # Add attributes to class documentation
-    if options.doc:
+    # `python -OO` asks for docstrings to be dropped; a generated one is
+    # no different, so honour the flag rather than reintroducing them.
+    if options.doc and sys.flags.optimize < 2:
         docname = '__doc__' if options.doc is True else options.doc
         doc = namespace.get(docname, '') or ''
         doc = doc.rstrip("\n")
@@ -1268,8 +1270,11 @@ class Magic(metaclass=MetaMagic):
     __slots__ = ()
 
 
-MetaMagic.__doc__ = MetaMagic.__doc__.format(DOC_OPTIONS=_DOC_OPTIONS)
-Magic.__doc__ = Magic.__doc__.format(DOC_OPTIONS=_DOC_OPTIONS)
+# `python -OO` strips docstrings, so there may be nothing to format.
+if MetaMagic.__doc__:
+    MetaMagic.__doc__ = MetaMagic.__doc__.format(DOC_OPTIONS=_DOC_OPTIONS)
+if Magic.__doc__:
+    Magic.__doc__ = Magic.__doc__.format(DOC_OPTIONS=_DOC_OPTIONS)
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1700,3 +1700,30 @@ class TestPositionalOnly:
 
         r = R(1, 2, c=3)
         assert (r.a, r.b, r.c) == (1, 2, 3)
+
+
+class TestOptimisedInterpreter:
+    """`python -OO` strips docstrings; nothing may assume they are there."""
+
+    def test_import_and_class_creation_under_OO(self) -> None:
+        # stdlib
+        import subprocess
+        import sys
+
+        # Regression: the module ran `MetaMagic.__doc__.format(...)` at
+        # import time, which is an AttributeError once `-OO` has replaced
+        # every docstring with None.
+        source = (
+            "from bagof.magic import Magic\n"
+            "class C(Magic):\n"
+            "    x: int = 1\n"
+            "assert C(2).x == 2\n"
+            "assert C.__doc__ is None\n"
+            "print('ok')\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-OO", "-c", source],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "ok"


### PR DESCRIPTION
`-OO` replaces every docstring with `None`, so the two module-level formatting calls raised at import time:

```
AttributeError: 'NoneType' object has no attribute 'format'
```

Both are now guarded.

Class docstring generation is skipped under `-OO` too: someone passing the flag has asked for docstrings to be dropped, and a generated one is no different from a written one. Without this, `C.__doc__` came back as a synthesised attribute table on an interpreter that was meant to have none.

## Tests

New `TestOptimisedInterpreter`, which runs a subprocess with `-OO` and asserts the class builds, works, and has no docstring.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_