### PR TITLE
Fix the hash option, per-field hash=None, and the match_args rename

### DIFF
--- a/src/bagof/magic/__init__.py
+++ b/src/bagof/magic/__init__.py
@@ -276,8 +276,12 @@ def __pre_new__(
         return clsname, bases, namespace
 
     # Get globals of the module where this class is defined.
-    if namespace["__module__"] in sys.modules:
-        globals = sys.modules[namespace["__module__"]].__dict__
+    # `__module__` is absent when the class is built through the
+    # functional API (`MetaMagic(name, bases, namespace)`) rather than a
+    # class statement.
+    module = namespace.get("__module__")
+    if module in sys.modules:
+        globals = sys.modules[module].__dict__
     else:
         # Theoretically this can happen if someone writes
         # a custom string to cls.__module__.  In which case
@@ -452,7 +456,13 @@ def __pre_new__(
         namespace.setdefault(fnname, _make_lt(qualname, real_fields))
 
     # Decide if/how we're going to create a hash function.
-    _make_hash = _hash_action[bool(options.unsafe_hash),
+    # A truthy `hash` means "generate one", the same force the
+    # `unsafe_hash` column applies. `False` means never, and `None`
+    # (the default) leaves the table to decide.
+    force_hash = bool(options.unsafe_hash) or bool(
+        options.hash is not None and options.hash
+    )
+    _make_hash = _hash_action[force_hash,
                               bool(options.eq),
                               bool(options.frozen),
                               has_explicit_hash]
@@ -469,7 +479,7 @@ def __pre_new__(
             if isinstance(options.match_args, str)
             else "__match_args__"
         )
-        namespace.setdefault("__match_args__", tuple(
+        namespace.setdefault(fnname, tuple(
             f.public_name for f in fields.values() if f.init and f.positional
         ))
 
@@ -618,9 +628,11 @@ def _hash_exception(qualname: str, fields: dict) -> tx.NoReturn:
 
 
 def _hash_add(qualname: str, fields: dict) -> int:
+    # `compare` is a constructor alias for `eq` + `order`, not a slot of
+    # its own -- reading it raised AttributeError for `hash=None`.
     fields = [
         f for f in fields.values()
-        if (f.compare if f.hash is None else f.hash)
+        if (f.eq if f.hash is None else f.hash)
     ]
 
     def __hash__(self: Magic) -> int:

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1700,3 +1700,73 @@ class TestPositionalOnly:
 
         r = R(1, 2, c=3)
         assert (r.a, r.b, r.c) == (1, 2, 3)
+
+
+class TestHashOption:
+    """The three states of the `hash` option, and per-field `hash=None`."""
+
+    def test_hash_true_generates_a_hash(self) -> None:
+        # Regression: the dispatch table only read `unsafe_hash`, so
+        # `hash=True` landed on the "eq and not frozen" cell and set
+        # `__hash__ = None` -- the opposite of what was asked.
+        class H(Magic, hash=True):
+            x: int
+
+        assert H.__hash__ is not None
+        assert hash(H(1)) == hash(H(1))
+        assert hash(H(1)) != hash(H(2))
+
+    def test_hash_false_disables_it(self) -> None:
+        class H(Magic, hash=False):
+            x: int
+
+        assert H.__hash__ is None
+
+    def test_hash_none_leaves_the_decision_to_eq_and_frozen(self) -> None:
+        class Mutable(Magic):
+            x: int
+
+        class Immutable(Magic, frozen=True):
+            x: int
+
+        assert Mutable.__hash__ is None
+        assert hash(Immutable(1)) == hash(Immutable(1))
+
+    def test_field_hash_none_falls_back_to_eq(self) -> None:
+        # Regression: `_hash_add` read `f.compare`, which is a constructor
+        # alias rather than a slot, so this raised AttributeError.
+        class H(Magic, unsafe_hash=True):
+            x: Annotated[int, Field(hash=None)]
+            y: Annotated[int, Field(hash=None, eq=False)]
+
+        # `y` is out of `__eq__`, so it is out of `__hash__` too.
+        assert hash(H(1, 2)) == hash(H(1, 99))
+        assert hash(H(1, 2)) != hash(H(3, 2))
+
+
+class TestMatchArgsRename:
+
+    def test_match_args_accepts_a_name(self) -> None:
+        # Regression: the name was computed and then discarded, so the
+        # tuple was always written to `__match_args__`.
+        class M(Magic, match_args="__my_args__"):
+            x: int
+            y: int
+
+        assert M.__my_args__ == ("x", "y")
+        assert "__match_args__" not in M.__dict__
+
+    def test_match_args_true_uses_the_dunder(self) -> None:
+        class M(Magic, match_args=True):
+            x: int
+
+        assert M.__match_args__ == ("x",)
+
+
+class TestFunctionalAPI:
+
+    def test_class_without_a_module_entry(self) -> None:
+        # Regression: `namespace["__module__"]` raised KeyError when the
+        # class was built through the metaclass directly.
+        C = m.MetaMagic("C", (Magic,), {"__annotations__": {"x": int}})
+        assert C(1).x == 1


### PR DESCRIPTION
Three small defects in `__pre_new__`'s method generation, plus one found while testing them.

### `hash=True` produced an *unhashable* class

The `_hash_action` lookup is keyed on `unsafe_hash`, `eq`, `frozen` and has-explicit-hash. `options.hash` was only read to disable (`is False`) or to rename — so a truthy `hash` fell through to the "eq and not frozen" cell, which sets `__hash__ = None`:

```pycon
>>> class H(Magic, hash=True): x: int
>>> H.__hash__
None                      # documented as "Generate __hash__ method"
```

A truthy `hash` now forces generation the same way `unsafe_hash` does, leaving `False` as never and `None` as the documented "decide automatically".

### `Field(hash=None)` raised `AttributeError`

`_hash_add` read `f.compare`, which is a constructor alias for `eq` + `order` rather than a slot of `Field`, so `SlotsBase.__getattr__` raised. It reads `f.eq` now — the rule `dataclasses` uses: a field out of the comparison is out of the hash.

### `match_args="<name>"` ignored the name

```python
fnname = options.match_args if isinstance(...) else "__match_args__"
namespace.setdefault("__match_args__", ...)    # fnname unused
```

Every other `bool | str` option honours the string; this one was the odd one out.

### `MetaMagic(name, bases, namespace)` raised `KeyError: '__module__'`

The functional API has no `__module__` in the namespace — exactly the case the comment two lines below anticipates ("Theoretically this can happen…"). Hit while writing the `hash=None` test.

## Tests

`TestHashOption` (all three option states plus the per-field fallback), `TestMatchArgsRename`, `TestFunctionalAPI`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_