### PR TITLE
Carry the PSF license for the code adapted from dataclasses

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,11 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+Parts of this software are copied from, or derived from, CPython's standard
+library `dataclasses` module, which is licensed under the Python Software
+Foundation License Version 2. Those parts remain under that license: see
+`LICENSES/PSF-2.0.txt` for its text and `NOTICE.md` for the list of derived
+components and the summary of changes.

--- a/LICENSES/PSF-2.0.txt
+++ b/LICENSES/PSF-2.0.txt
@@ -1,0 +1,62 @@
+Copyright (c) 2001-2026 Python Software Foundation; All Rights Reserved
+
+This license covers the portions of `bagof-magic` that are copied from, or
+derived from, CPython's standard library. Those portions are listed in
+`NOTICE.md` at the root of this repository, together with the summary of
+changes required by clause 3 below.
+
+The rest of `bagof-magic` is distributed under the MIT license, in
+`LICENSE`.
+
+================================================================================
+
+PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+--------------------------------------------
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation
+("PSF"), and the Individual or Organization ("Licensee") accessing and
+otherwise using this software ("Python") in source or binary form and
+its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF hereby
+grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+analyze, test, perform and/or display publicly, prepare derivative works,
+distribute, and otherwise use Python alone or in any derivative version,
+provided, however, that PSF's License Agreement and PSF's notice of copyright,
+i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 Python Software Foundation;
+All Rights Reserved" are retained in Python alone or in any derivative version
+prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python.
+
+4. PSF is making Python available to Licensee on an "AS IS"
+basis.  PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between PSF and
+Licensee.  This License Agreement does not grant permission to use PSF
+trademarks or trade name in a trademark sense to endorse or promote
+products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using Python, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.
+
+

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,83 @@
+# Third-party notices
+
+`bagof-magic` is distributed under the MIT license (see [`LICENSE`](LICENSE)).
+
+Parts of it are copied from, or derived from, CPython's standard library
+`dataclasses` module, which is licensed under the **Python Software Foundation
+License Version 2**. A copy of that license, together with the PSF copyright
+notice its clause 2 requires us to retain, is in
+[`LICENSES/PSF-2.0.txt`](LICENSES/PSF-2.0.txt).
+
+> Copyright (c) 2001-2026 Python Software Foundation; All Rights Reserved
+
+Clause 3 of that license requires a brief summary of the changes made. This
+file is that summary.
+
+## Where the derived code is
+
+Upstream source: [`Lib/dataclasses.py`](https://github.com/python/cpython/blob/main/Lib/dataclasses.py)
+in CPython. Where a helper changed shape across Python versions, the version we
+followed is noted.
+
+### `src/bagof/magic/__init__.py`
+
+| Ours | Upstream |
+| --- | --- |
+| `__pre_new__` | `_process_class` |
+| `_add_fields` | the inherited-field collection loop inside `_process_class` |
+| `_FuncBuilder` | `_FuncBuilder` (3.13+) |
+| `_make_init` | `_init_fn`, `_init_param`, `_field_init` |
+| `_make_repr` | `_repr_fn` (3.11) / the `__repr__` branch of `_process_class` (3.13+) |
+| `_make_eq`, `_make_lt` | `_cmp_fn` (3.11) / the `__eq__` and `__lt__` branches of `_process_class` (3.13+) |
+| `_make_assign` | `_frozen_get_del_attr` |
+| `_make_state` | `_dataclass_getstate`, `_dataclass_setstate` |
+| `_hash_set_none`, `_hash_exception`, `_hash_add`, `_hash_action` | the same names |
+| `_get_slots` | `_get_slots` |
+| `_make_slots` | the slot-computing half of `_add_slots` |
+
+### `src/bagof/magic/utils.py`
+
+| Ours | Upstream |
+| --- | --- |
+| `_update_func_cell_for__class__` | the same name (a helper of `_add_slots`, 3.12+) |
+| `rebuild_cls` | the class-rebuilding half of `_add_slots` |
+
+### `src/bagof/magic/constants.py`
+
+| Ours | Upstream |
+| --- | --- |
+| `_MissingType`, `MISSING` | `_MISSING_TYPE`, `MISSING` |
+| `_HasFactory` | `_HAS_DEFAULT_FACTORY_CLASS` |
+| `_FIELDS`, `_POST_INIT_NAME` | the same names |
+
+## Summary of changes
+
+- **A metaclass, not a decorator.** `dataclasses` processes a class after it
+  exists; `bagof-magic` builds it in `MetaMagic.__new__`, so the generated
+  methods are written into the namespace before the class object is created.
+  `_process_class` was restructured into `__pre_new__` and `__post_new__`
+  accordingly, and every `_set_new_attribute(cls, ...)` call became a
+  `namespace.setdefault(...)`.
+- **Options are inherited.** They are given as class keyword arguments and
+  merged down the MRO into an `Options` object, rather than passed to a
+  decorator per class. `_add_fields` was written for that merge; upstream has
+  no equivalent, since a decorator sees only one class at a time.
+- **Fields come from annotations, not from a `field()` call.** `Field` is
+  configured through `Annotated` metadata, resolved by `Field.from_hint`, and
+  carries options `dataclasses` has no equivalent for: `converter`,
+  `validator`, `factory`, `key`, `alias`, `doc`, `kw`, `positional`.
+- **Conversion and validation.** The generated `__init__` and `__setattr__`
+  run a per-field converter and validator, resolved from the field's type hint
+  through the sibling `bagof-converters` and `bagof-validators` packages.
+- **Names are configurable.** Options accept a string as well as a boolean, so
+  a generated method can be written under a name other than its dunder.
+- **A dict-like protocol.** The `mapping` option generates `__getitem__`,
+  `__setitem__`, `__delitem__`, `__iter__` and `__len__`, and registers the
+  class as a `Mapping` or `MutableMapping`. There is no upstream equivalent.
+- **Generated documentation.** The `doc` option appends an attribute table to
+  the class docstring, built from each field's own documentation.
+- **Version reach.** The code runs on Python 3.8 and later, so `match`
+  statements were rewritten as `if`/`elif` (`_get_slots`), and annotations are
+  read through `annotationlib` on 3.14+ and from the class namespace below it.
+- **Per-field, rather than per-class, control** of `repr`, `eq`, `order`,
+  `hash`, `frozen`, `kw_only` and `positional_only`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
+# `LICENSES/` sits outside setuptools' default license-file glob, and the
+# PSF license must ship with the distribution, not just the repository.
+license-files = ["LICENSE", "LICENSES/*.txt", "NOTICE.md"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/bagof/magic/__init__.py
+++ b/src/bagof/magic/__init__.py
@@ -161,8 +161,11 @@ __all__ += __all_options__
 # ----------------------------------------------------------------------
 # Builder
 # ----------------------------------------------------------------------
-# Adapted from Python's standard library `dataclasses` module, which is
-# licensed under the Python Software Foundation License Version 2.
+# Adapted from Python's standard library `dataclasses` module.
+# Copyright (c) 2001-2026 Python Software Foundation; All Rights Reserved.
+# Licensed under the Python Software Foundation License Version 2; see
+# LICENSES/PSF-2.0.txt for its text and NOTICE.md for the list of derived
+# components and the summary of changes.
 
 def __post_new__(cls: type) -> type:
     # These methods have to be assigned post-new, because they
@@ -511,7 +514,8 @@ def __pre_new__(
 
 
 class _FuncBuilder:
-    # Also adapted from dataclasses
+    # Also adapted from `dataclasses` (see the notice above the Builder
+    # section, and NOTICE.md).
 
     def __init__(self, globals: dict) -> None:
         self.methods = {}  # name -> function

--- a/src/bagof/magic/constants.py
+++ b/src/bagof/magic/constants.py
@@ -1,3 +1,14 @@
+"""
+Sentinels and attribute names used across the package.
+
+`MISSING`, `_HasFactory`, `_FIELDS` and `_POST_INIT_NAME` are adapted from
+Python's standard library `dataclasses` module.
+Copyright (c) 2001-2026 Python Software Foundation; All Rights Reserved.
+Licensed under the Python Software Foundation License Version 2; see
+LICENSES/PSF-2.0.txt for its text and NOTICE.md for the list of derived
+components and the summary of changes.
+"""
+
 from __future__ import annotations
 
 import typing_extensions as tx

--- a/src/bagof/magic/utils.py
+++ b/src/bagof/magic/utils.py
@@ -1,3 +1,14 @@
+"""
+Class-rebuilding helpers.
+
+`rebuild_cls` and `_update_func_cell_for__class__` are adapted from Python's
+standard library `dataclasses` module.
+Copyright (c) 2001-2026 Python Software Foundation; All Rights Reserved.
+Licensed under the Python Software Foundation License Version 2; see
+LICENSES/PSF-2.0.txt for its text and NOTICE.md for the list of derived
+components and the summary of changes.
+"""
+
 from __future__ import annotations
 
 __all__ = ["SlotsBase", "rebuild_cls", "slots"]


### PR DESCRIPTION
You're right that this was missing. Two source comments said the code was adapted from `dataclasses`, but the license itself was never carried — and the PSF License Version 2 has two obligations that an attribution comment does not satisfy:

- **clause 2** — the PSF copyright notice must be *retained* in any derivative version;
- **clause 3** — a derivative work made available to others must include *a brief summary of the changes made*.

## What this adds

**`LICENSES/PSF-2.0.txt`** — the full license text, taken verbatim from CPython's own `LICENSE.txt`, prefixed with the copyright notice and a note on which parts of the package it covers.

**`NOTICE.md`** — the required summary. It maps every derived component to its upstream name, so the scope is auditable rather than a vague "adapted from dataclasses":

| Ours | Upstream |
| --- | --- |
| `__pre_new__` | `_process_class` |
| `_FuncBuilder` | `_FuncBuilder` (3.13+) |
| `_make_init` | `_init_fn`, `_init_param`, `_field_init` |
| `_make_repr` / `_make_eq` / `_make_lt` | `_repr_fn` / `_cmp_fn` (3.11), the corresponding branches of `_process_class` (3.13+) |
| `_make_assign` | `_frozen_get_del_attr` |
| `_make_state` | `_dataclass_getstate` / `_dataclass_setstate` |
| `_hash_action` and friends | the same names |
| `_get_slots` / `_make_slots` | `_get_slots` / `_add_slots` |
| `rebuild_cls`, `_update_func_cell_for__class__` | the two halves of `_add_slots` |
| `MISSING`, `_HasFactory`, `_FIELDS`, `_POST_INIT_NAME` | `MISSING`, `_HAS_DEFAULT_FACTORY_CLASS`, and the same two names |

…followed by the change summary itself: metaclass rather than decorator, inherited options, annotation-driven fields, the converter/validator pipeline, renameable methods, the `mapping` protocol, generated docs, 3.8 reach, and per-field control of what upstream only offers per class.

**`LICENSE`** — a pointer to both, so the MIT text is not read as covering the whole package.

**Per-file headers.** `utils.py` had no attribution at all, though `_update_func_cell_for__class__` is near-verbatim CPython down to its comments; `constants.py` likewise. Both now carry one. The two existing comments in `__init__.py` name the copyright holder and point at the notice.

**Packaging.** `LICENSES/` sits outside setuptools' default license-file glob, so the license would have shipped in the repository but not in the distribution — which is where it actually needs to be. `license-files` is extended, and verified:

```
WHEEL:  dist-info/licenses/LICENSE
        dist-info/licenses/NOTICE.md
        dist-info/licenses/LICENSES/PSF-2.0.txt
SDIST:  LICENSE, NOTICE.md, LICENSES/PSF-2.0.txt
```

## Scope

I checked the other five packages — `bagof-core-magic`, `bagof-converters`, `bagof-validators`, `bagof-factories`, `bagof-hints`. Their only `stdlib` mentions are import-section headers; none carries derived code, so none needs this.

No behaviour change; the suite passes unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_