### PR TITLE
Fix the annotation inverses to flip every slot they own

### DIFF
--- a/src/bagof/magic/fields.py
+++ b/src/bagof/magic/fields.py
@@ -40,7 +40,7 @@ import typing_extensions as tx
 from ._resolve import make_converter as _make_converter
 from ._resolve import make_factory as _make_factory
 from ._resolve import make_validator as _make_validator
-from .constants import MISSING, REQUIRED, SHOW_ATTR, MaybeMissing
+from .constants import MISSING, REQUIRED, SHOW_ATTR
 from .options import Options
 from .utils import SlotsBase, _get_origin, slots
 
@@ -292,7 +292,11 @@ class AnnotatedField(Field):
     def _set_slots(cls) -> tx.Dict[str, tx.Any]:
         set_slots = {}
         for base in reversed(cls.__mro__):
-            cls_set_slots = getattr(base, '__set_slots__', {})
+            # `__dict__`, not `getattr`: the value each slot is set to
+            # comes from the class that *declares* it, so an inverse
+            # (`NotPositional`) has to restate the slot to flip it, and
+            # cannot flip a sibling's (`KwOnly` keeps `Kw`'s `True`).
+            cls_set_slots = base.__dict__.get('__set_slots__', {})
             if isinstance(cls_set_slots, str):
                 cls_set_slots = (cls_set_slots,)
             if isinstance(cls_set_slots, tuple):
@@ -343,14 +347,18 @@ class BoolAnnotatedField(AnnotatedField):
         if not isinstance(args, tuple):
             args = (args,)
         t, *args = args
-        return tx.Annotated[(t, cls(True)) + tuple(args)]
+        # No positional value: every slot takes the value its own
+        # declaring class set, so an inverse comes out `False` and a
+        # mixed pair (`KwOnly`) keeps one of each. Anything after the
+        # type stays metadata.
+        return tx.Annotated[(t, cls()) + tuple(args)]
 
 
 @slots
 class InversedBoolAnnotatedField(BoolAnnotatedField):
+    """Base for the negative half of a pair (`NoInit`, `NotKw`, ...)."""
 
-    def __init__(self, value: MaybeMissing[bool] = True, /) -> None:
-        super().__init__(not value)
+    __set_value__ = False
 
 
 @slots
@@ -433,7 +441,8 @@ class Init(BoolAnnotatedField):
 
 
 @slots
-class NoInit(Init, InversedBoolAnnotatedField): ...
+class NoInit(Init, InversedBoolAnnotatedField):
+    __set_slots__ = 'init'
 
 
 @slots
@@ -455,7 +464,8 @@ class Kw(BoolAnnotatedField):
 
 
 @slots
-class NotKw(Kw, InversedBoolAnnotatedField): ...
+class NotKw(Kw, InversedBoolAnnotatedField):
+    __set_slots__ = 'kw'
 
 
 @slots
@@ -477,7 +487,8 @@ class Positional(BoolAnnotatedField):
 
 
 @slots
-class NotPositional(Positional, InversedBoolAnnotatedField): ...
+class NotPositional(Positional, InversedBoolAnnotatedField):
+    __set_slots__ = 'positional'
 
 
 @slots
@@ -513,7 +524,8 @@ class Frozen(BoolAnnotatedField):
 
 
 @slots
-class NotFrozen(Frozen, InversedBoolAnnotatedField): ...
+class NotFrozen(Frozen, InversedBoolAnnotatedField):
+    __set_slots__ = 'frozen'
 
 
 @slots
@@ -561,7 +573,8 @@ class Repr(BoolAnnotatedField):
 
 
 @slots
-class NoRepr(Repr, InversedBoolAnnotatedField): ...
+class NoRepr(Repr, InversedBoolAnnotatedField):
+    __set_slots__ = ('repr',)
 
 
 @slots
@@ -581,7 +594,8 @@ class Eq(BoolAnnotatedField):
 
 
 @slots
-class NoEq(Eq, InversedBoolAnnotatedField): ...
+class NoEq(Eq, InversedBoolAnnotatedField):
+    __set_slots__ = ('eq',)
 
 
 @slots
@@ -601,7 +615,8 @@ class Order(BoolAnnotatedField):
 
 
 @slots
-class NoOrder(Order, InversedBoolAnnotatedField): ...
+class NoOrder(Order, InversedBoolAnnotatedField):
+    __set_slots__ = ('order',)
 
 
 @slots
@@ -609,7 +624,8 @@ class Compare(Eq, Order):  ...
 
 
 @slots
-class NoCompare(Compare, InversedBoolAnnotatedField): ...
+class NoCompare(Compare, InversedBoolAnnotatedField):
+    __set_slots__ = ('eq', 'order')
 
 
 @slots
@@ -629,7 +645,8 @@ class Hash(BoolAnnotatedField):
 
 
 @slots
-class NoHash(Hash, InversedBoolAnnotatedField): ...
+class NoHash(Hash, InversedBoolAnnotatedField):
+    __set_slots__ = ('hash',)
 
 
 @slots
@@ -649,7 +666,8 @@ class Key(BoolAnnotatedField):
 
 
 @slots
-class NotKey(Key, InversedBoolAnnotatedField): ...
+class NotKey(Key, InversedBoolAnnotatedField):
+    __set_slots__ = ('key',)
 
 
 @slots

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -21,6 +21,7 @@ from bagof.magic import (
     Key,
     KwOnly,
     Magic,
+    NoCompare,
     NoEq,
     NoHash,
     NoInit,
@@ -1821,3 +1822,76 @@ class TestPublicName:
             self: int
 
         assert C(1).self == 1
+
+
+class TestAnnotationPolarity:
+    """Every annotation sets its own slots to its own value."""
+
+    # (annotation, expected {slot: value})
+    CASES = [
+        ("Init", {"init": True}),
+        ("NoInit", {"init": False}),
+        ("Kw", {"kw": True}),
+        ("NotKw", {"kw": False}),
+        ("Positional", {"positional": True}),
+        ("NotPositional", {"positional": False}),
+        ("KwOnly", {"kw": True, "positional": False}),
+        ("PositionalOnly", {"kw": False, "positional": True}),
+        ("NotKwOnly", {"kw": True, "positional": True}),
+        ("NotPositionalOnly", {"kw": True, "positional": True}),
+        ("Frozen", {"frozen": True}),
+        ("NotFrozen", {"frozen": False}),
+        ("Repr", {"repr": True}),
+        ("NoRepr", {"repr": False}),
+        ("Eq", {"eq": True}),
+        ("NoEq", {"eq": False}),
+        ("Order", {"order": True}),
+        ("NoOrder", {"order": False}),
+        ("Compare", {"eq": True, "order": True}),
+        ("NoCompare", {"eq": False, "order": False}),
+        ("Hash", {"hash": True}),
+        ("NoHash", {"hash": False}),
+        ("Key", {"key": True}),
+        ("NotKey", {"key": False}),
+        ("Var", {"var": True}),
+        ("InitVar", {"init": True, "var": True}),
+        ("ClassVar", {"init": False, "var": True}),
+    ]
+
+    @pytest.mark.parametrize("name,expected", CASES, ids=[c[0] for c in CASES])
+    def test_called_form(self, name: str, expected: dict) -> None:
+        annotation = getattr(m, name)()
+        for slot, value in expected.items():
+            assert getattr(annotation, slot) is value, slot
+
+    @pytest.mark.parametrize("name,expected", CASES, ids=[c[0] for c in CASES])
+    def test_subscript_form(self, name: str, expected: dict) -> None:
+        # `X[int]` must lower to the same field options as `X()`.
+        (annotation,) = tx.get_args(getattr(m, name)[int])[1:]
+        for slot, value in expected.items():
+            assert getattr(annotation, slot) is value, slot
+
+    def test_multi_slot_inverse_clears_every_slot(self) -> None:
+        # Regression: an inverse only ever flipped its first slot, so
+        # `NoCompare` cleared `order` and left `eq` at True.
+        class C(Magic, order=True):
+            x: int
+            y: NoCompare[int]
+
+        y = {f.name: f for f in m.fields(C)}["y"]
+        assert (y.eq, y.order) == (False, False)
+        assert C(1, 2) == C(1, 99)
+
+    def test_a_mixed_pair_keeps_one_of_each(self) -> None:
+        # `KwOnly` is `Kw` + `NotPositional`: the inverse must not flip
+        # the positive half.
+        class C(Magic):
+            x: KwOnly[int]
+
+        assert C(x=1).x == 1
+        with pytest.raises(TypeError):
+            C(1)
+
+    def test_subscript_keeps_extra_metadata(self) -> None:
+        hint = NoRepr[int, "some note"]
+        assert tx.get_args(hint)[2] == "some note"


### PR DESCRIPTION
Found while writing the `pycon` lowerings for the annotation docstrings — the documented lowering for `NoCompare` was not what the code produced.

## The bug

`NoCompare` only cleared `order`. `eq` stayed `True`, so a field marked `NoCompare` was still compared:

```pycon
>>> class C(Magic, order=True):
...     x: int
...     y: NoCompare[int]
>>> C(1, 2) == C(1, 99)
False                      # y was still in __eq__
>>> NoCompare()
NoCompare(eq=True, order=False)
```

`InversedBoolAnnotatedField` inverted by passing a single positional to `AnnotatedField.__init__`, which zips values against the slot list — so only the first slot was ever reached. `NoCompare` is the only inverse of a two-slot annotation, which is why nothing else showed it.

## Why the obvious fix is wrong

Inverting *every* slot breaks the mixed pairs. `KwOnly` is `Kw` + `NotPositional`: the inverse has to flip `positional` while leaving `kw` alone. Inverting everything turned `KwOnly` into `(kw=False, positional=False)` — a field in no part of `__init__` at all. (I tried this first; eleven tests caught it.)

So polarity belongs to a **slot**, not to a call:

- `_set_slots` reads `__set_slots__` from the class that *declares* it (`__dict__` rather than `getattr`), so an inherited declaration can no longer be re-reported under a different polarity;
- `InversedBoolAnnotatedField` carries `__set_value__ = False`, and each inverse restates the slots it flips — explicit, and it reads as the specification rather than a derivation;
- `BoolAnnotatedField.__class_getitem__` builds `cls()` rather than `cls(True)`, so the subscript form takes each slot's own declared value instead of forcing `True`. Anything after the type is still kept as metadata.

## Result

All 27 annotations, in both forms:

| | called | subscript |
| --- | --- | --- |
| `NoCompare` | `(eq=False, order=False)` | same |
| `KwOnly` | `(kw=True, positional=False)` | same |
| `PositionalOnly` | `(kw=False, positional=True)` | same |
| `NoInit` | `(init=False)` | same |
| `ClassVar` | `(init=False, var=True)` | same |

## Tests

`TestAnnotationPolarity` parametrises every annotation over both forms — the table above as a test rather than a promise — plus the `NoCompare` regression, the `KwOnly` mixed-pair case, and a check that `NoRepr[int, "note"]` still keeps its metadata.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_