### PR TITLE
Ignore the .claude directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ src/bagof/*/_version.py
 # vscode
 .vscode
 
+# claude code (agent worktrees and local settings)
+.claude/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]


### PR DESCRIPTION
Claude Code puts agent worktrees and local settings under `.claude/` in the repository root, so it shows up as untracked for anyone using it here. Ignored alongside `.vscode`, which is in the file for the same reason.

One line, no code change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_