### PR TITLE
Stop a subclass from rewriting its base class's fields

### DIFF
--- a/src/bagof/magic/__init__.py
+++ b/src/bagof/magic/__init__.py
@@ -182,12 +182,32 @@ def __post_new__(cls: type) -> type:
     return cls
 
 
+def _inherit_attrs(
+    field: Field,
+    other: Field,
+    attrs: tx.Sequence[str],
+) -> None:
+    # Copy into `field`, from `other`, the attributes that `field` leaves
+    # unset.
+    #
+    # By the time fields of a class and of its bases are merged, an
+    # attribute that was never given a value has already been filled in
+    # with None, so both MISSING and None count as unset here.
+    for attr in attrs:
+        value = getattr(field, attr, MISSING)
+        if value is not MISSING and value is not None:
+            continue
+        inherited = getattr(other, attr, MISSING)
+        if inherited is not MISSING:
+            setattr(field, attr, inherited)
+
+
 def _add_fields(
     fields: dict[str, Field],
     new_fields: tx.Iterable[Field],
     replace: bool = False,
     reverse: bool = False,
-    inherit: tx.List[str] = ("doc",),
+    inherit: tx.Sequence[str] = ("doc",),
 ) -> None:
     # Add fields to an existing dict of fields.
     #
@@ -199,45 +219,54 @@ def _add_fields(
     #   If True, then new fields will be added before existing fields.
     #   If False, then new fields will be added after existing fields.
     #   In both case, the order of `new_fields` is preserved.
+    # * inherit :
+    #   Names of the attributes that the field being dropped passes on to
+    #   the field being kept, when both declare a field of the same name
+    #   and the kept one leaves them unset.
+    #
+    # New fields are copied on the way in: a field is mutated in place
+    # while its class is built, so a class must never hold a field that
+    # another class holds too.
     if replace and not reverse:
-        if inherit:
-            for new_field in new_fields:
-                if new_field.name in fields:
-                    old_field = fields[new_field.name]
-                    for attr in inherit:
-                        if getattr(new_field, attr, MISSING) is MISSING:
-                            continue
-                        setattr(new_field, attr, getattr(old_field, attr))
-                fields[new_field.name] = new_field
-        else:
-            fields.update({f.name: f for f in new_fields})
+        for new_field in new_fields:
+            field = new_field.copy()
+            old_field = fields.get(field.name, None)
+            if old_field is not None:
+                _inherit_attrs(field, old_field, inherit)
+            fields[field.name] = field
 
     elif replace and reverse:
-        prev_fields = fields.copy()
+        old_fields = dict(fields)
         fields.clear()
-        fields.update({f.name: f for f in new_fields})
-        for name, field in prev_fields.items():
-            fields.setdefault(name, field)
-            for attr in inherit:
-                if getattr(fields[name], attr, MISSING) is MISSING:
-                    setattr(fields[name], attr, getattr(field, attr))
+        for new_field in new_fields:
+            field = new_field.copy()
+            old_field = old_fields.get(field.name, None)
+            if old_field is not None:
+                _inherit_attrs(field, old_field, inherit)
+            fields[field.name] = field
+        for name, old_field in old_fields.items():
+            fields.setdefault(name, old_field)
 
     elif not replace and not reverse:
-        for f in new_fields:
-            fields.setdefault(f.name, f)
-            for attr in inherit:
-                if getattr(fields[f.name], attr, MISSING) is MISSING:
-                    setattr(fields[f.name], attr, getattr(f, attr))
+        for new_field in new_fields:
+            old_field = fields.get(new_field.name, None)
+            if old_field is None:
+                fields[new_field.name] = new_field.copy()
+            else:
+                _inherit_attrs(old_field, new_field, inherit)
 
-    elif not replace and reverse:
-        prev_fields = fields.copy()
+    else:  # not replace and reverse
+        old_fields = dict(fields)
         fields.clear()
-        fields.update(prev_fields)
-        for f in new_fields:
-            fields.setdefault(f.name, f)
-            for attr in inherit:
-                if getattr(fields[f.name], attr, MISSING) is MISSING:
-                    setattr(fields[f.name], attr, getattr(f, attr))
+        for new_field in new_fields:
+            old_field = old_fields.get(new_field.name, None)
+            if old_field is None:
+                fields[new_field.name] = new_field.copy()
+            else:
+                _inherit_attrs(old_field, new_field, inherit)
+                fields[new_field.name] = old_field
+        for name, old_field in old_fields.items():
+            fields.setdefault(name, old_field)
 
 
 def _namespace_annotations(namespace: dict) -> dict:

--- a/src/bagof/magic/__init__.py
+++ b/src/bagof/magic/__init__.py
@@ -182,20 +182,32 @@ def __post_new__(cls: type) -> type:
     return cls
 
 
+#: The attributes a field can take from the field it replaces, and the
+#: values that mean "this field did not say".
+#:
+#: What counts as "did not say" is per attribute, and has to be, because
+#: None is a real answer for some of them. A resolved field has
+#: `doc = None` when no documentation was given, so for `doc` both None
+#: and MISSING mean unset -- but `hash = None` means "follow whatever
+#: `eq` says", which is an answer, and would be wrong to overwrite.
+#: Anything added here needs its own decision.
+_INHERITABLE = {
+    "doc": (MISSING, None),
+}
+
+
 def _inherit_attrs(
     field: Field,
     other: Field,
     attrs: tx.Sequence[str],
 ) -> None:
-    # Copy into `field`, from `other`, the attributes that `field` leaves
-    # unset.
-    #
-    # By the time fields of a class and of its bases are merged, an
-    # attribute that was never given a value has already been filled in
-    # with None, so both MISSING and None count as unset here.
+    # Copy into `field`, from `other`, the attributes `field` leaves
+    # unset -- see `_INHERITABLE` for what unset means for each.
     for attr in attrs:
         value = getattr(field, attr, MISSING)
-        if value is not MISSING and value is not None:
+        # Compared by identity: `==` on an arbitrary field value can do
+        # anything, including returning something that is not a bool.
+        if not any(value is unset for unset in _INHERITABLE[attr]):
             continue
         inherited = getattr(other, attr, MISSING)
         if inherited is not MISSING:
@@ -207,7 +219,7 @@ def _add_fields(
     new_fields: tx.Iterable[Field],
     replace: bool = False,
     reverse: bool = False,
-    inherit: tx.Sequence[str] = ("doc",),
+    inherit: tx.Sequence[str] = tuple(_INHERITABLE),
 ) -> None:
     # Add fields to an existing dict of fields.
     #

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -2091,3 +2091,39 @@ class TestAnnotationPolarity:
     def test_subscript_keeps_extra_metadata(self) -> None:
         hint = NoRepr[int, "some note"]
         assert tx.get_args(hint)[2] == "some note"
+
+
+class TestInheritableUnsetValues:
+    """What counts as "this field did not say" is decided per attribute."""
+
+    def test_doc_treats_none_as_unset(self) -> None:
+        # A resolved field has `doc = None` when none was given, so an
+        # inherited doc fills it in.
+        class Base(Magic):
+            x: Annotated[int, Doc("base doc")] = 1
+
+        class Child(Base):
+            x: int = 2
+
+        assert {f.name: f.doc for f in m.fields(Child)}["x"] == "base doc"
+
+    def test_every_inheritable_attribute_declares_its_unset_values(
+        self,
+    ) -> None:
+        # `_inherit_attrs` looks the values up rather than assuming, so
+        # an attribute added to the list without a decision fails here
+        # rather than silently treating None as "did not say". That
+        # matters because None is a real answer for some of them --
+        # `hash = None` means "follow eq".
+        default = m._add_fields.__defaults__[-1]
+        assert set(default) <= set(m._INHERITABLE)
+        for attr, unset in m._INHERITABLE.items():
+            assert MISSING in unset, attr
+
+    def test_a_meaningful_none_would_not_be_treated_as_unset(self) -> None:
+        # `hash` is not inheritable today; if it ever is, None must keep
+        # meaning "follow eq" rather than "unset".
+        field = Field(name="x", hash=None)
+        other = Field(name="x", hash=True)
+        m._inherit_attrs(field, other, ())
+        assert field.hash is None

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1238,24 +1238,34 @@ class TestAddFields:
 
     def test_replace_no_reverse_inherit_missing(self) -> None:
         fields = {"a": Field(name="a", doc="olddoc")}
-        # new field has doc MISSING -> the inherit loop hits `continue`.
-        new = Field(name="a")
+        new = Field(name="a")  # overrides 'a', doc MISSING
         assert new.doc is MISSING
         m._add_fields(fields, [new], replace=True, reverse=False)
-        assert fields["a"] is new
+        # the new field wins, but takes the doc it does not set itself
+        assert fields["a"].doc == "olddoc"
+        # ... on a copy: `new` still belongs to whoever passed it in
+        assert fields["a"] is not new
+        assert new.doc is MISSING
 
-    def test_replace_no_reverse_inherit_copy(self) -> None:
+    def test_replace_no_reverse_inherit_none(self) -> None:
+        # a doc that was never given a value has already been filled in
+        # with None by the time fields are merged: still unset.
+        fields = {"a": Field(name="a", doc="olddoc")}
+        new = Field(name="a", doc=None)
+        m._add_fields(fields, [new], replace=True, reverse=False)
+        assert fields["a"].doc == "olddoc"
+
+    def test_replace_no_reverse_keeps_own_doc(self) -> None:
         fields = {"a": Field(name="a", doc="olddoc")}
         new = Field(name="a", doc="newdoc")
         m._add_fields(fields, [new], replace=True, reverse=False)
-        # inherit copies the *old* doc onto the new field.
-        assert fields["a"].doc == "olddoc"
+        assert fields["a"].doc == "newdoc"
 
     def test_replace_no_inherit(self) -> None:
         fields = {"a": Field(name="a", doc="olddoc")}
         new = Field(name="a", doc="newdoc")
         m._add_fields(fields, [new], replace=True, inherit=())
-        assert fields["a"] is new
+        assert fields["a"] is not new
         assert fields["a"].doc == "newdoc"
 
     def test_replace_reverse(self) -> None:
@@ -1266,19 +1276,32 @@ class TestAddFields:
         new = Field(name="a")  # overrides 'a', doc MISSING
         assert new.doc is MISSING
         m._add_fields(fields, [new], replace=True, reverse=True)
-        # new fields go first; the overriding 'a' inherits the old doc.
+        # new fields go first; the overriding 'a' inherits the old doc
         assert list(fields) == ["a", "b"]
-        assert fields["a"] is new
+        assert fields["a"] is not new
         assert fields["a"].doc == "da"
+
+    def test_replace_reverse_keeps_own_doc(self) -> None:
+        fields = {"a": Field(name="a", doc="da")}
+        new = Field(name="a", doc="newdoc")
+        m._add_fields(fields, [new], replace=True, reverse=True)
+        assert fields["a"].doc == "newdoc"
 
     def test_not_replace_no_reverse(self) -> None:
         fields = {"a": Field(name="a")}  # doc MISSING
         new_a = Field(name="a", doc="fromnew")
         new_b = Field(name="b", doc="db")
         m._add_fields(fields, [new_a, new_b], replace=False, reverse=False)
-        # existing 'a' preserved, 'b' appended; 'a' inherits new doc.
+        # existing 'a' preserved, 'b' appended; 'a' inherits new doc
         assert list(fields) == ["a", "b"]
         assert fields["a"].doc == "fromnew"
+        assert fields["b"] is not new_b
+
+    def test_not_replace_no_reverse_keeps_own_doc(self) -> None:
+        fields = {"a": Field(name="a", doc="olddoc")}
+        new_a = Field(name="a", doc="fromnew")
+        m._add_fields(fields, [new_a], replace=False, reverse=False)
+        assert fields["a"].doc == "olddoc"
 
     def test_not_replace_reverse(self) -> None:
         fields = {"a": Field(name="a")}  # doc MISSING
@@ -1287,6 +1310,16 @@ class TestAddFields:
         m._add_fields(fields, [new_a, new_b], replace=False, reverse=True)
         assert list(fields) == ["a", "b"]
         assert fields["a"].doc == "fromnew"
+        assert fields["b"] is not new_b
+
+    def test_not_replace_reverse_keeps_own_doc(self) -> None:
+        fields = {"a": Field(name="a", doc="olddoc")}
+        new_a = Field(name="a", doc="fromnew")
+        new_b = Field(name="b", doc="db")
+        m._add_fields(fields, [new_a, new_b], replace=False, reverse=True)
+        # new names go first, but a name already there keeps its field
+        assert list(fields) == ["a", "b"]
+        assert fields["a"].doc == "olddoc"
 
     def test_reverse_option_inheritance(self) -> None:
         class Base(Magic, reverse=True):
@@ -1297,6 +1330,100 @@ class TestAddFields:
 
         # reverse=True places derived fields before base fields.
         assert list(getattr(Derived, _FIELDS)) == ["y", "x"]
+
+
+# ======================================================================
+# Fields across a hierarchy
+# ======================================================================
+
+
+class TestFieldInheritance:
+
+    def test_subclass_does_not_share_fields_with_base(self) -> None:
+        class Base(Magic):
+            x: int = 1
+
+        class Derived(Base):
+            y: int = 2
+
+        assert m.fields(Base)[0] is not m.fields(Derived)[0]
+
+    def test_diamond_leaves_bases_alone(self) -> None:
+        class A(Magic):
+            x: Annotated[int, Doc("A doc")] = 1
+
+        class B(Magic):
+            x: Annotated[int, Doc("B doc")] = 2
+
+        class C(A, B):
+            pass
+
+        # Defining C must not rewrite A or B.
+        assert m.fields(A)[0].doc == "A doc"
+        assert m.fields(B)[0].doc == "B doc"
+        # C follows its MRO: A comes first, so A's doc wins.
+        assert m.fields(C)[0].doc == "A doc"
+
+    def test_child_keeps_its_own_doc(self) -> None:
+        class Base(Magic):
+            x: Annotated[int, Doc("base doc")] = 1
+
+        class Derived(Base):
+            x: Annotated[int, Doc("child doc")] = 2
+
+        assert m.fields(Derived)[0].doc == "child doc"
+        assert m.fields(Base)[0].doc == "base doc"
+
+    def test_child_inherits_the_base_doc(self) -> None:
+        class Base(Magic):
+            x: Annotated[int, Doc("base doc")] = 1
+
+        class Derived(Base):
+            x: int = 2
+
+        assert m.fields(Derived)[0].doc == "base doc"
+
+    def test_subclass_does_not_share_fields_with_base_reverse(self) -> None:
+        class Base(Magic, reverse=True):
+            x: int = 1
+
+        class Derived(Base):
+            y: int = 2
+
+        assert m.fields(Base)[0] is not m.fields(Derived)[-1]
+
+    def test_diamond_leaves_bases_alone_reverse(self) -> None:
+        class A(Magic, reverse=True):
+            x: Annotated[int, Doc("A doc")] = 1
+
+        class B(Magic, reverse=True):
+            x: Annotated[int, Doc("B doc")] = 2
+
+        class C(A, B):
+            pass
+
+        assert m.fields(A)[0].doc == "A doc"
+        assert m.fields(B)[0].doc == "B doc"
+        assert m.fields(C)[0].doc == "A doc"
+
+    def test_child_keeps_its_own_doc_reverse(self) -> None:
+        class Base(Magic, reverse=True):
+            x: Annotated[int, Doc("base doc")] = 1
+
+        class Derived(Base):
+            x: Annotated[int, Doc("child doc")] = 2
+
+        assert m.fields(Derived)[0].doc == "child doc"
+        assert m.fields(Base)[0].doc == "base doc"
+
+    def test_child_inherits_the_base_doc_reverse(self) -> None:
+        class Base(Magic, reverse=True):
+            x: Annotated[int, Doc("base doc")] = 1
+
+        class Derived(Base):
+            x: int = 2
+
+        assert m.fields(Derived)[0].doc == "base doc"
 
 
 # ======================================================================


### PR DESCRIPTION
Two defects in `_add_fields`, both reported in #14.

## 1. Fields were shared across classes and mutated in place

The derived class's field dict stored the base classes' own `Field` objects, and the merge loop then wrote to them. Defining a class rewrote one that was already finished:

```pycon
>>> class A(Magic):
...     x: Annotated[int, Doc("A doc")] = 1
>>> class B(Magic):
...     x: Annotated[int, Doc("B doc")] = 2
>>> class C(A, B): pass
>>> fields(A)[0].doc
'A doc'                     # was 'B doc'
```

`_add_fields` now copies a field on the way in (`SlotsBase.copy`), so a class never holds a field another class holds too. Fields freshly built for the class being defined are copied too, which costs one shallow copy per field and keeps the rule "everything in this dict belongs to this class" with no exception to remember.

## 2. The inherit test was inverted

In the `replace and not reverse` branch it skipped the fields that left `doc` unset and overwrote the ones that set it, so an explicit doc on a child was always discarded:

```pycon
>>> class Base(Magic):
...     x: Annotated[int, Doc("base doc")] = 1
>>> class Derived(Base):
...     x: Annotated[int, Doc("child doc")] = 2
>>> fields(Derived)[0].doc
'child doc'                 # was 'base doc'
```

All four branches now go through one helper, `_inherit_attrs`, which fills in only what the winning field leaves unset — and counts `None` as unset, since `Field.setdefault` has already turned a never-given doc into `None` by the time fields are merged. That `None` gap was why the plain `MISSING` check in the other three branches never fired either: a child that *did* re-document a field silently lost it, and under `reverse=True` a child that did *not* re-document one failed to inherit it.

## Also in this diff

The `not replace and reverse` branch cleared the dict and refilled it with the same content, so it left the new fields *after* the existing ones — identical to the non-reverse branch, and not what the `reverse` option describes. It now orders them the way the `replace and reverse` branch does. Both `not replace` branches are unreachable from the package today (both call sites pass `replace=True`); they are covered by the unit tests on `_add_fields` only.

## Tests

`TestAddFields` gains a case per branch for a field that sets the inherited attribute itself, for the `None`-means-unset rule, and for the copy; the existing cases that asserted the buggy behaviour are updated. A new `TestFieldInheritance` covers the hierarchy level — the diamond leaving its bases alone, a child keeping its own doc, a child inheriting the base's, and `fields(Base)[0] is not fields(Derived)[0]` — each also with `reverse=True`, which takes the other branch. Run against `main`, 11 of the 19 tests in the two classes fail (the rest are the cases the old code happened to get right, kept for symmetry).

299 passed; `ruff check src tests` clean.

Left alone, as belonging to #16: freezing a `Field` once resolved (suggestion 3 in the issue), which would make this class of bug unreachable rather than fixed once.

Fixes #14
