### PR TITLE
Regenerate __getstate__/__setstate__ for every class that would inherit one

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -76,6 +76,12 @@ followed is noted.
   class as a `Mapping` or `MutableMapping`. There is no upstream equivalent.
 - **Generated documentation.** The `doc` option appends an attribute table to
   the class docstring, built from each field's own documentation.
+- **Saving and restoring an object.** `_make_state` saves an object's
+  attribute dictionary together with whichever of its slots hold a value --
+  the two-part value `object.__getstate__` produces from Python 3.11 on --
+  rather than upstream's tuple of field values. Anything kept on an object
+  that was never declared as a field survives a copy, and the slot names are
+  read from the whole inheritance chain.
 - **Version reach.** The code runs on Python 3.8 and later, so `match`
   statements were rewritten as `if`/`elif` (`_get_slots`), and annotations are
   read through `annotationlib` on 3.14+ and from the class namespace below it.

--- a/src/bagof/magic/__init__.py
+++ b/src/bagof/magic/__init__.py
@@ -467,12 +467,29 @@ def _install(
     return False
 
 
+def _slot_names(
+    mro: tx.Tuple[type, ...], namespace: dict
+) -> tx.Tuple[str, ...]:
+    """Every slot an instance of the class being built can hold.
+
+    Slots are inherited, so this is the whole chain of bases and not
+    just what the class itself declares. `__dict__` and `__weakref__`
+    are left out: they are places to keep attributes, not attributes.
+    """
+    names = set()
+    for base in mro:
+        names.update(_get_slots(base))
+    own = namespace.get("__slots__")
+    names.update((own,) if isinstance(own, str) else (own or ()))
+    names -= {"__dict__", "__weakref__"}
+    return tuple(sorted(names))
+
+
 def _install_state(
     namespace: dict,
     generated: dict,
     mro: tx.Tuple[type, ...],
     qualname: str,
-    real_fields: dict,
     frozen: bool,
 ) -> None:
     """
@@ -484,21 +501,24 @@ def _install_state(
     usual attribute assignment.
 
     Every class below one of those needs a pair of its own as well. The
-    pair carries the list of fields to save, so a base's pair leaves out
-    each field the class has added, and a copy comes back without them.
+    pair carries the names of the slots to save, so a base's pair leaves
+    out each slot the class has added, and a copy comes back missing
+    them.
 
     There is no option to turn these off, and no plain-Python method to
     put in their place, so the only question is whether to write them.
-    Methods you wrote yourself are left alone.
+    Methods you wrote yourself are left alone: the two have to agree
+    with each other, so writing one of them means both are yours.
     """
     if not frozen and not _inherited_generated(mro, "state"):
         return
-    for name, fn in zip(
-        ("__getstate__", "__setstate__"), _make_state(qualname, real_fields)
-    ):
-        if name not in namespace:
-            namespace[name] = fn
-            generated[name] = "state"
+    names = ("__getstate__", "__setstate__")
+    if any(name in namespace for name in names):
+        return
+    pair = _make_state(qualname, _slot_names(mro, namespace))
+    for name, fn in zip(names, pair):
+        namespace[name] = fn
+        generated[name] = "state"
 
 
 def _install_hash(
@@ -916,11 +936,6 @@ def __pre_new__(
     # would otherwise inherit means looking at the bases it really has.
     base_mro = type(_DISCARD, bases, {}).__mro__[1:]
 
-    _install_state(
-        namespace, generated, base_mro, qualname, real_fields,
-        bool(options.frozen),
-    )
-
     repr_fields = {name: f for name, f in fields.items() if f.repr}
     _install(
         namespace, generated, base_mro, "repr",
@@ -958,6 +973,12 @@ def __pre_new__(
             raise TypeError(f'{clsname} already specifies __slots__')
         weakref_slot = options.weakref_slot
         namespace["__slots__"] = _make_slots(bases, real_fields, weakref_slot)
+
+    # Saving an object means saving its slots, so this waits until
+    # `__slots__` is settled as well as `bases`.
+    _install_state(
+        namespace, generated, base_mro, qualname, bool(options.frozen),
+    )
 
     fnbuilder.insert_fns(clsname, namespace)
 
@@ -1460,17 +1481,46 @@ def _make_assign(cls: type) -> type:
     return __delattr__, __setattr__
 
 
-def _make_state(qualname: str, fields: dict[str, Field]) -> tx.Callable:
+def _make_state(
+    qualname: str, slot_names: tx.Tuple[str, ...]
+) -> tx.Tuple[tx.Callable, tx.Callable]:
+    """
+    Build the pair `pickle` and `copy` use to save and restore an
+    object.
+
+    What is saved is everything an object is really carrying: its
+    attribute dictionary, and whichever of its slots have been given a
+    value. Fields are not singled out, so an attribute that was set on
+    the object without ever being declared survives a copy like any
+    other.
+
+    The saved value is a pair, `(attributes, slots)`, either half of
+    which is `None` when there is nothing of that kind to save. This is
+    the shape Python itself uses from 3.11 on for a class that does not
+    say otherwise -- written out here because the versions before that
+    have no method to borrow it from.
+    """
 
     def __getstate__(self: Magic) -> tx.Tuple:
-        kept = [f for f in fields.values() if not f.var]
-        return tuple(getattr(self, f.name) for f in kept)
+        attributes = getattr(self, "__dict__", None)
+        slots = {}
+        for name in slot_names:
+            try:
+                slots[name] = getattr(self, name)
+            except AttributeError:
+                # A slot that was never given a value stays empty on
+                # the copy too.
+                pass
+        return (dict(attributes) if attributes else None, slots or None)
 
     def __setstate__(self: Magic, state: tx.Tuple) -> None:
-        kept = [f for f in fields.values() if not f.var]
-        for field, value in zip(kept, state):
-            # use setattr because dataclass may be frozen
-            object.__setattr__(self, field.name, value)
+        attributes, slots = state
+        if attributes:
+            self.__dict__.update(attributes)
+        for name, value in (slots or {}).items():
+            # Straight through to the object, since assigning the usual
+            # way is what a frozen class refuses.
+            object.__setattr__(self, name, value)
 
     __getstate__.__qualname__ = f"{qualname}.__getstate__"
     __setstate__.__qualname__ = f"{qualname}.__setstate__"

--- a/src/bagof/magic/__init__.py
+++ b/src/bagof/magic/__init__.py
@@ -467,6 +467,40 @@ def _install(
     return False
 
 
+def _install_state(
+    namespace: dict,
+    generated: dict,
+    mro: tx.Tuple[type, ...],
+    qualname: str,
+    real_fields: dict,
+    frozen: bool,
+) -> None:
+    """
+    Bind the two methods `pickle` and `copy` use to save and restore an
+    object, if this class needs them.
+
+    A frozen class needs them: restoring an object means putting the
+    saved values back on it, which a frozen class refuses through the
+    usual attribute assignment.
+
+    Every class below one of those needs a pair of its own as well. The
+    pair carries the list of fields to save, so a base's pair leaves out
+    each field the class has added, and a copy comes back without them.
+
+    There is no option to turn these off, and no plain-Python method to
+    put in their place, so the only question is whether to write them.
+    Methods you wrote yourself are left alone.
+    """
+    if not frozen and not _inherited_generated(mro, "state"):
+        return
+    for name, fn in zip(
+        ("__getstate__", "__setstate__"), _make_state(qualname, real_fields)
+    ):
+        if name not in namespace:
+            namespace[name] = fn
+            generated[name] = "state"
+
+
 def _install_hash(
     namespace: dict,
     generated: dict,
@@ -869,11 +903,6 @@ def __pre_new__(
             f.public_name for f in fields.values() if f.init and f.positional
         ))
 
-    if options.frozen:
-        getstate, setstate = _make_state(qualname, real_fields)
-        namespace.setdefault("__getstate__", getstate)
-        namespace.setdefault("__setstate__", setstate)
-
     if options.mapping:
         dict_fields = {f.public_key: f for f in fields.values() if f.key}
         for name, func in _make_mapping(qualname, dict_fields).items():
@@ -886,6 +915,11 @@ def __pre_new__(
     # the `mapping` option can add one, and working out what a class
     # would otherwise inherit means looking at the bases it really has.
     base_mro = type(_DISCARD, bases, {}).__mro__[1:]
+
+    _install_state(
+        namespace, generated, base_mro, qualname, real_fields,
+        bool(options.frozen),
+    )
 
     repr_fields = {name: f for name, f in fields.items() if f.repr}
     _install(

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1,4 +1,6 @@
 """Unit tests for the bagof.magic module."""
+import copy
+import pickle
 from typing import ClassVar as TypingClassVar
 from typing import Optional, Union
 
@@ -36,6 +38,7 @@ from bagof.magic import (
 )
 from bagof.magic.constants import (
     _FIELDS,
+    _GENERATED,
     _OPTIONS,
     MISSING,
     REQUIRED,
@@ -1007,20 +1010,79 @@ class PickleFrozen(Magic, frozen=True):
     a: int
 
 
+class PickleThawed(PickleFrozen, frozen=False):
+    b: int
+
+
+class PickleFrozenChild(PickleFrozen, frozen=True):
+    b: int
+
+
+class PicklePlainChild(PicklePoint):
+    z: int
+
+
+class PickleGrandchild(PickleThawed):
+    c: int
+
+
+class PickleOwnState(PickleFrozen, frozen=False):
+    b: int
+
+    def __getstate__(self) -> dict:
+        return {"a": self.a, "b": self.b, "by_hand": True}
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+
+
 class TestPickle:
 
     def test_pickle_round_trip(self) -> None:
-        import pickle
-
         restored = pickle.loads(pickle.dumps(PicklePoint(1, 2)))
         assert restored == PicklePoint(1, 2)
         assert restored.x == 1 and restored.y == 2
 
     def test_pickle_frozen(self) -> None:
-        import pickle
-
         restored = pickle.loads(pickle.dumps(PickleFrozen(5)))
         assert restored == PickleFrozen(5)
+
+    def test_pickle_unfrozen_subclass(self) -> None:
+        restored = pickle.loads(pickle.dumps(PickleThawed(1, 2)))
+        assert (restored.a, restored.b) == (1, 2)
+
+    def test_copy_unfrozen_subclass(self) -> None:
+        copied = copy.copy(PickleThawed(1, 2))
+        assert (copied.a, copied.b) == (1, 2)
+
+    def test_deepcopy_unfrozen_subclass(self) -> None:
+        original = PickleThawed(1, [2])
+        copied = copy.deepcopy(original)
+        assert (copied.a, copied.b) == (1, [2])
+        assert copied.b is not original.b
+
+    def test_pickle_frozen_subclass(self) -> None:
+        restored = pickle.loads(pickle.dumps(PickleFrozenChild(1, 2)))
+        assert (restored.a, restored.b) == (1, 2)
+
+    def test_pickle_grandchild(self) -> None:
+        # Two steps below the frozen class the pair started with.
+        restored = pickle.loads(pickle.dumps(PickleGrandchild(1, 2, 3)))
+        assert (restored.a, restored.b, restored.c) == (1, 2, 3)
+
+    def test_plain_subclass_keeps_default_pickling(self) -> None:
+        # Nothing frozen anywhere, so there is nothing to write.
+        assert "__getstate__" not in PicklePlainChild.__dict__
+        assert "__setstate__" not in PicklePlainChild.__dict__
+        restored = pickle.loads(pickle.dumps(PicklePlainChild(1, 2, 3)))
+        assert restored == PicklePlainChild(1, 2, 3)
+
+    def test_own_state_methods_are_kept(self) -> None:
+        restored = pickle.loads(pickle.dumps(PickleOwnState(1, 2)))
+        assert (restored.a, restored.b) == (1, 2)
+        assert restored.by_hand is True
+        assert "__getstate__" not in PickleOwnState.__dict__[_GENERATED]
+        assert "__setstate__" not in PickleOwnState.__dict__[_GENERATED]
 
 
 # ======================================================================

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1344,6 +1344,12 @@ def _round_trips(obj: tx.Any) -> tx.List[tx.Any]:
     ]
 
 
+class _PickleUnsetSlot(Magic, frozen=True, slots=True, init=False):
+    """A slotted class that assigns nothing, so its slot starts empty."""
+
+    x: int = 3
+
+
 class TestPickle:
 
     def test_pickle_round_trip(self) -> None:
@@ -1448,6 +1454,15 @@ class TestPickle:
         # `b` is not a field of its own, but it is on the object.
         for restored in _round_trips(PicklePseudoField(1, 2)):
             assert (restored.a, restored.b) == (1, 4)
+
+    def test_an_empty_slot_stays_empty(self) -> None:
+        # With no `__init__` of its own, nothing assigns `x`, so the
+        # slot holds no value at all -- and the copy must not invent
+        # one.
+        obj = copy.deepcopy(_PickleUnsetSlot())
+        assert not hasattr(obj, "x")
+        obj.__magic_init__()
+        assert copy.deepcopy(obj).x == 3
 
 
 # ======================================================================

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1036,6 +1036,49 @@ class PickleOwnState(PickleFrozen, frozen=False):
         self.__dict__.update(state)
 
 
+class PickleOnlyGet(PickleFrozen, frozen=False):
+    b: int
+
+    def __getstate__(self) -> dict:
+        return {"a": self.a, "b": self.b}
+
+
+class PickleOnlySet(PickleFrozen, frozen=False):
+    b: int
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+
+
+class PickleSlots(Magic, frozen=True, slots=True):
+    a: int
+
+
+class PickleSlotsChild(PickleSlots, frozen=False, slots=True):
+    b: int
+
+
+class PickleDictAndSlots(PickleFrozen, frozen=False, slots=True):
+    b: int
+
+
+class PicklePseudoField(Magic, frozen=True):
+    a: int
+    b: InitVar[int]
+
+    def __post_init__(self, b: int) -> None:
+        object.__setattr__(self, "b", b * 2)
+
+
+def _round_trips(obj: tx.Any) -> tx.List[tx.Any]:
+    """The object back from each of the three ways of copying it."""
+    return [
+        pickle.loads(pickle.dumps(obj)),
+        copy.copy(obj),
+        copy.deepcopy(obj),
+    ]
+
+
 class TestPickle:
 
     def test_pickle_round_trip(self) -> None:
@@ -1083,6 +1126,63 @@ class TestPickle:
         assert restored.by_hand is True
         assert "__getstate__" not in PickleOwnState.__dict__[_GENERATED]
         assert "__setstate__" not in PickleOwnState.__dict__[_GENERATED]
+
+    def test_only_getstate_written_leaves_both_alone(self) -> None:
+        # The two have to agree, so half a pair of your own means the
+        # whole pair is yours.
+        assert PickleOnlyGet(1, 2).__getstate__() == {"a": 1, "b": 2}
+        assert "__setstate__" not in PickleOnlyGet.__dict__
+        assert "__getstate__" not in PickleOnlyGet.__dict__[_GENERATED]
+        assert "__setstate__" not in PickleOnlyGet.__dict__[_GENERATED]
+
+    def test_only_setstate_written_leaves_both_alone(self) -> None:
+        obj = PickleOnlySet(1, 2)
+        obj.__setstate__({"a": 3, "b": 4})
+        assert (obj.a, obj.b) == (3, 4)
+        assert "__getstate__" not in PickleOnlySet.__dict__
+        assert "__getstate__" not in PickleOnlySet.__dict__[_GENERATED]
+        assert "__setstate__" not in PickleOnlySet.__dict__[_GENERATED]
+
+    def test_extra_attribute_survives_plain(self) -> None:
+        obj = PicklePoint(1, 2)
+        obj.extra = 99
+        for restored in _round_trips(obj):
+            assert restored.extra == 99
+
+    def test_extra_attribute_survives_frozen(self) -> None:
+        obj = PickleFrozen(1)
+        object.__setattr__(obj, "extra", 99)
+        for restored in _round_trips(obj):
+            assert (restored.a, restored.extra) == (1, 99)
+
+    def test_extra_attribute_survives_unfrozen_subclass(self) -> None:
+        obj = PickleThawed(1, 2)
+        obj.extra = 99
+        for restored in _round_trips(obj):
+            assert (restored.a, restored.b, restored.extra) == (1, 2, 99)
+
+    def test_slots_survive(self) -> None:
+        # A slotted class has no attribute dictionary, so everything it
+        # holds is in its slots.
+        for restored in _round_trips(PickleSlots(1)):
+            assert restored.a == 1
+
+    def test_slots_survive_subclass(self) -> None:
+        for restored in _round_trips(PickleSlotsChild(1, 2)):
+            assert (restored.a, restored.b) == (1, 2)
+
+    def test_dict_and_slots_both_survive(self) -> None:
+        # This one has both: `a` comes from a base with an attribute
+        # dictionary, `b` is a slot.
+        obj = PickleDictAndSlots(1, 2)
+        obj.extra = 99
+        for restored in _round_trips(obj):
+            assert (restored.a, restored.b, restored.extra) == (1, 2, 99)
+
+    def test_stored_pseudo_field_survives(self) -> None:
+        # `b` is not a field of its own, but it is on the object.
+        for restored in _round_trips(PicklePseudoField(1, 2)):
+            assert (restored.a, restored.b) == (1, 4)
 
 
 # ======================================================================

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -758,11 +758,8 @@ class TestSlots:
         assert not hasattr(Point(), "__dict__")
 
     def test_slots_frozen_default_survives_pickle_and_copy(self) -> None:
-        import copy
-        import pickle
-
         point = _SlotsPoint(1)
-        assert point.__getstate__() == (1, 0)
+        assert (point.x, point.origin) == (1, 0)
         assert pickle.loads(pickle.dumps(point)) == point
         assert copy.copy(point) == point
         assert copy.deepcopy(point) == point


### PR DESCRIPTION
Part of #33 — the pickle half, on its own because it is silent data loss.

## The bug

`__getstate__`/`__setstate__` were generated only under `frozen=True`. A subclass that turns `frozen` off inherits the base's pair, and that pair is a closure over the **base's** fields. So every field the subclass adds is dropped:

```python
class FB(Magic, frozen=True):
    a: int

class FC(FB, frozen=False):
    b: int

pickle.loads(pickle.dumps(FC(1, 2)))   # AttributeError: 'FC' object has no attribute 'b'
```

`copy.copy` and `copy.deepcopy` go through the same protocol and do not even raise — they hand back a truncated object.

## The fix

A class now writes its own pair whenever it would otherwise inherit a generated one: when `frozen` is true, or when a base has a generated pair. The pair is always closed over that class's own fields, so it is always right for that class.

This rides on the machinery that landed in #32 — `_generated_methods` / `_inherited_generated` — so a hand-written `__getstate__` still wins, and a class further down the chain can tell a generated pair from one you wrote. Unlike `eq` and `hash` there is nothing to neutralise: there is no "state off" option, and `object.__getstate__` only exists from Python 3.11 while this package supports 3.8. Always regenerating is both simpler and correct.

The install moved to just after the bases are settled, since answering "would this class inherit one?" needs the finished MRO.

## Tests

Six new tests in `TestPickle`: the repro above through `pickle`, `copy` and `deepcopy`; a frozen subclass of a frozen base; a three-level chain where the pair comes from a grandparent; a plain non-frozen chain (no state methods written, default pickling still round-trips); and a subclass with a hand-written pair. The four covering new behaviour were checked to fail against `main`.

388 passed; ruff and codespell clean.

## Noticed while in there, not fixed

`_make_state` skips `var` fields entirely, so a frozen class with a pseudo-field loses it on pickle and copy. That is a separate question and predates this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_