### PR TITLE
Generate all four comparisons, not just __lt__

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,9 +216,8 @@ codespell src tests
 
 - **Correctness**: unresolved string/forward annotations breaking
   `convert`/`validate`/`factory` (#13); fields shared and mutated across
-  classes (#14); `slots=True` with defaults (#15); `order` missing three
-  dunders (#17); generic classes (#18); a disabled option falling through to
-  `Magic`'s own generated method (#23).
+  classes (#14); `slots=True` with defaults (#15); generic classes (#18); a
+  disabled option falling through to `Magic`'s own generated method (#23).
 - **Model**: naming the field kind instead of inferring it from `init` (#16),
   which also carries the declared/resolved split that makes option inheritance
   work (#20).

--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ class Thing(Magic, frozen=True, kw_only=True, slots=True):
 
 Most of them also take a string instead of `True`, which writes the method
 under that name — handy when you want to call the generated one from your own.
+`order` names its `<` comparison, and leaves all four operators unbound.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,9 @@ class Thing(Magic, frozen=True, kw_only=True, slots=True):
 
 Most of them also take a string instead of `True`, which writes the method
 under that name — handy when you want to call the generated one from your own.
-`order` names its `<` comparison, and leaves all four operators unbound.
+`order` gives the name to its `<` comparison; the class is then left with no
+comparison operators at all, so the method is there for you to call rather
+than to answer `<`.
 
 ---
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -36,7 +36,7 @@ question of what you want the type hints to *do*.
 | | | | | |
 | **Generated methods** | | | | |
 | `__init__` / `__repr__` / `__eq__` | yes | yes | yes | **yes** |
-| Full set of ordering methods | yes | yes | no | *[partial][order]* |
+| Full set of ordering methods | yes | yes | no | **yes** |
 | `__slots__` | yes | yes | no | **yes** |
 | Keyword-only and positional-only fields | keyword only | keyword only | keyword only | **both** |
 | Rename a generated method | no | no | no | **yes** |
@@ -232,8 +232,6 @@ Being honest about the gaps, with links to where they are being worked on:
 - **Copy-with-changes and `asdict`.** [In progress][parity].
 - **Generic classes.** `class Box(Magic, Generic[T])` does not work yet
   — [tracked here][generics].
-- **The full set of ordering methods.** `order=True` gives you `<` and `>`
-  today, not `<=` and `>=` — [tracked here][order].
 - **Editor and type-checker support.** The others are understood by mypy and
   pyright today, so your editor completes the constructor and catches a wrong
   argument type. `magic` is not, yet — [tracked here][typing]. The route is
@@ -246,5 +244,4 @@ Being honest about the gaps, with links to where they are being worked on:
 [pydantic]: https://docs.pydantic.dev
 [parity]: https://github.com/bagofseeds/bagof-magic/issues/22
 [generics]: https://github.com/bagofseeds/bagof-magic/issues/18
-[order]: https://github.com/bagofseeds/bagof-magic/issues/17
 [typing]: https://github.com/bagofseeds/bagof-magic/issues/30

--- a/src/bagof/magic/__init__.py
+++ b/src/bagof/magic/__init__.py
@@ -915,20 +915,25 @@ def __pre_new__(
         _make_eq(qualname, real_fields), bool(options.eq),
     )
 
-    # `order=True` binds all four comparisons to their operators.
+    # The four comparisons are generated as a set, so that they always
+    # agree with each other. `order=True` binds each to its operator;
     # `order="<name>"` binds the `<` comparison under that name and
-    # binds nothing to any of the four operators: a comparison asked for
-    # under a name of your own is one you mean to call yourself, and
-    # `<=` answering while `<` deliberately does not would make no
-    # sense. The other three are still written under their private
-    # names, and any inherited generated one is replaced.
+    # binds none of the operators. A comparison written in the class
+    # body wins, and then none of the other three is bound either --
+    # they would answer beside it with a different answer. All four are
+    # written under their private names whatever happens.
     named_order = isinstance(options.order, str)
+    order_names = [dunder for dunder, _ in _ORDER_METHODS.values()]
+    if named_order:
+        order_names.append(options.order)
+    hand_written_order = any(name in namespace for name in order_names)
     for slot, (dunder, _) in _ORDER_METHODS.items():
         _install(
             namespace, generated, base_mro, slot,
             options.order if named_order and slot == "lt" else dunder,
             _make_order(qualname, real_fields, slot),
-            bool(options.order) and (slot == "lt" or not named_order),
+            bool(options.order) and not hand_written_order
+            and (slot == "lt" or not named_order),
         )
 
     # Whether this class compares by identity is read back out of the
@@ -1623,8 +1628,9 @@ class MetaMagic(ABCMeta):
         Generate `__eq__` method.
     order : bool | str, default=False
         Generate `__lt__`, `__le__`, `__gt__` and `__ge__` methods.
-        Given a name, generate the `<` comparison under that name and
-        leave all four operators alone.
+        Given a name, generate the `<` comparison under that name; the
+        class is then left with none of the four comparison operators,
+        including any it would otherwise inherit.
     hash : bool | str, default=None
         Generate `__hash__` method.
         If `None`, decide automatically.
@@ -1704,8 +1710,9 @@ class Magic(metaclass=MetaMagic):
         Generate `__eq__` method.
     order : bool | str, default=False
         Generate `__lt__`, `__le__`, `__gt__` and `__ge__` methods.
-        Given a name, generate the `<` comparison under that name and
-        leave all four operators alone.
+        Given a name, generate the `<` comparison under that name; the
+        class is then left with none of the four comparison operators,
+        including any it would otherwise inherit.
     hash : bool | str, default=None
         Generate `__hash__` method.
         If `None`, decide automatically.

--- a/src/bagof/magic/__init__.py
+++ b/src/bagof/magic/__init__.py
@@ -39,7 +39,7 @@ repr : bool | str, default=True
 eq : bool | str, default=True
     Generate `__eq__` method
 order : bool | str, default=False
-    Generate `__lt__` method
+    Generate `__lt__`, `__le__`, `__gt__` and `__ge__` methods
 unsafe_hash : bool, default=False
     Always generate `__hash__` method
 frozen : bool, default=False
@@ -121,6 +121,7 @@ from __future__ import annotations
 __all__ = ["Magic", "magic", "HIDE_IF_NONE"]
 # stdlib
 import copy
+import operator
 import sys
 from abc import ABCMeta
 from collections import abc as _abc
@@ -341,6 +342,17 @@ def _no_order(self: Magic, other: tx.Any) -> tx.Any:
     return NotImplemented
 
 
+#: The four comparison methods the `order` option generates: the name
+#: each is normally bound under, and the operator it applies to the
+#: tuple of values of the fields that take part in the ordering.
+_ORDER_METHODS = {
+    "lt": ("__lt__", operator.lt),
+    "le": ("__le__", operator.le),
+    "gt": ("__gt__", operator.gt),
+    "ge": ("__ge__", operator.ge),
+}
+
+
 #: What is put in place of a generated method when an option is turned
 #: off. These are the behaviours a plain Python class has: comparison by
 #: identity, the `<Thing object at 0x...>` repr, and no ordering.
@@ -348,6 +360,9 @@ _NEUTRAL = {
     "repr": object.__repr__,
     "eq": object.__eq__,
     "lt": _no_order,
+    "le": _no_order,
+    "gt": _no_order,
+    "ge": _no_order,
     "hash": None,
 }
 
@@ -900,11 +915,21 @@ def __pre_new__(
         _make_eq(qualname, real_fields), bool(options.eq),
     )
 
-    _install(
-        namespace, generated, base_mro, "lt",
-        options.order if isinstance(options.order, str) else "__lt__",
-        _make_lt(qualname, real_fields), bool(options.order),
-    )
+    # `order=True` binds all four comparisons to their operators.
+    # `order="<name>"` binds the `<` comparison under that name and
+    # binds nothing to any of the four operators: a comparison asked for
+    # under a name of your own is one you mean to call yourself, and
+    # `<=` answering while `<` deliberately does not would make no
+    # sense. The other three are still written under their private
+    # names, and any inherited generated one is replaced.
+    named_order = isinstance(options.order, str)
+    for slot, (dunder, _) in _ORDER_METHODS.items():
+        _install(
+            namespace, generated, base_mro, slot,
+            options.order if named_order and slot == "lt" else dunder,
+            _make_order(qualname, real_fields, slot),
+            bool(options.order) and (slot == "lt" or not named_order),
+        )
 
     # Whether this class compares by identity is read back out of the
     # namespace: what matters is where `__eq__` ended up, not how it got
@@ -1362,25 +1387,32 @@ def _make_eq(qualname: str, fields: dict[str, Field]) -> tx.Callable:
     return __eq__
 
 
-def _make_lt(qualname: str, fields: dict[str, Field]) -> tx.Callable:
+def _make_order(
+    qualname: str, fields: dict[str, Field], slot: str
+) -> tx.Callable:
+    # Build one of the four comparisons -- `slot` is "lt", "le", "gt" or
+    # "ge". All four compare the same thing: the values of the fields
+    # that take part in the ordering, as a tuple.
+    name, compare = _ORDER_METHODS[slot]
 
-    def __lt__(self: Magic, other: tx.Any) -> bool:
-        if other.__class__ is self.__class__:
-            this_value = tuple(
-                getattr(self, field.name)
-                for field in fields.values()
-                if field.order
-            )
-            other_value = tuple(
-                getattr(other, field.name)
-                for field in fields.values()
-                if field.order
-            )
-            return this_value < other_value
-        return NotImplemented
+    def method(self: Magic, other: tx.Any) -> tx.Any:
+        if other.__class__ is not self.__class__:
+            return NotImplemented
+        this_value = tuple(
+            getattr(self, field.name)
+            for field in fields.values()
+            if field.order
+        )
+        other_value = tuple(
+            getattr(other, field.name)
+            for field in fields.values()
+            if field.order
+        )
+        return compare(this_value, other_value)
 
-    __lt__.__qualname__ = f"{qualname}.__lt__"
-    return __lt__
+    method.__name__ = name
+    method.__qualname__ = f"{qualname}.{name}"
+    return method
 
 
 def _make_assign(cls: type) -> type:
@@ -1590,7 +1622,9 @@ class MetaMagic(ABCMeta):
     eq : bool | str, default=True
         Generate `__eq__` method.
     order : bool | str, default=False
-        Generate `__lt__` method.
+        Generate `__lt__`, `__le__`, `__gt__` and `__ge__` methods.
+        Given a name, generate the `<` comparison under that name and
+        leave all four operators alone.
     hash : bool | str, default=None
         Generate `__hash__` method.
         If `None`, decide automatically.
@@ -1669,7 +1703,9 @@ class Magic(metaclass=MetaMagic):
     eq : bool | str, default=True
         Generate `__eq__` method.
     order : bool | str, default=False
-        Generate `__lt__` method.
+        Generate `__lt__`, `__le__`, `__gt__` and `__ge__` methods.
+        Given a name, generate the `<` comparison under that name and
+        leave all four operators alone.
     hash : bool | str, default=None
         Generate `__hash__` method.
         If `None`, decide automatically.

--- a/src/bagof/magic/options.py
+++ b/src/bagof/magic/options.py
@@ -10,7 +10,7 @@ from .utils import SlotsBase, slots
     'init',             # Generate __init__ method (or its name)
     'repr',             # Generate __repr__ method (or its name)
     'eq',               # Generate __eq__ method (or its name)
-    'order',            # Generate __lt__ method (or its name)
+    'order',            # Generate comparison methods (or the name of __lt__)
     'hash',             # Generate __hash__ method (or its name)
     'unsafe_hash',      # Always generate __hash__ method
     'frozen',           # Disable __setattr__ and __delattr__

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1,4 +1,5 @@
 """Unit tests for the bagof.magic module."""
+import operator
 from typing import ClassVar as TypingClassVar
 from typing import Optional, Union
 
@@ -457,6 +458,29 @@ class TestEqOrder:
         assert Point(1, 2) < Point(1, 3)
         assert not Point(1, 3) < Point(1, 2)
 
+    def test_order_gives_all_four_comparisons(self) -> None:
+        class Point(Magic, order=True):
+            x: int
+            y: int
+
+        assert Point(1, 2) < Point(1, 3)
+        assert Point(1, 2) <= Point(1, 3)
+        assert Point(1, 2) <= Point(1, 2)
+        assert Point(1, 3) > Point(1, 2)
+        assert Point(1, 3) >= Point(1, 2)
+        assert Point(1, 3) >= Point(1, 3)
+        assert not Point(1, 2) >= Point(1, 3)
+        assert not Point(1, 3) <= Point(1, 2)
+
+    def test_order_sorts(self) -> None:
+        class Point(Magic, order=True):
+            x: int
+            y: int
+
+        points = [Point(2, 0), Point(1, 5), Point(1, 2)]
+        assert sorted(points) == [Point(1, 2), Point(1, 5), Point(2, 0)]
+        assert max(points) == Point(2, 0)
+
     def test_order_different_class(self) -> None:
         class A(Magic, order=True):
             x: int
@@ -465,6 +489,14 @@ class TestEqOrder:
             x: int
 
         assert A(1).__lt__(B(2)) is NotImplemented
+        assert A(1).__le__(B(2)) is NotImplemented
+        assert A(1).__gt__(B(2)) is NotImplemented
+        assert A(1).__ge__(B(2)) is NotImplemented
+        # With both sides answering `NotImplemented`, Python falls back
+        # to identity for `==` and refuses the ordering operators.
+        assert A(1) != B(1)
+        with pytest.raises(TypeError, match="not supported between"):
+            operator.le(A(1), B(1))
 
     def test_no_order_field(self) -> None:
         class Point(Magic, order=True):
@@ -474,6 +506,28 @@ class TestEqOrder:
         # y excluded from ordering
         assert not Point(1, 2) < Point(1, 1)
         assert not Point(1, 1) < Point(1, 2)
+        assert Point(1, 2) <= Point(1, 1)
+        assert Point(1, 2) >= Point(1, 1)
+        assert not Point(1, 2) > Point(1, 1)
+
+    def test_a_renamed_order_binds_no_operator(self) -> None:
+        class R(Magic, order="__before__"):
+            x: int
+
+        assert R(1).__before__(R(2)) is True
+        assert R(2).__before__(R(1)) is False
+        assert R.__before__ is R.__magic_lt__
+        for compare in (operator.lt, operator.le, operator.gt, operator.ge):
+            with pytest.raises(TypeError, match="not supported between"):
+                compare(R(1), R(2))
+
+    def test_a_renamed_order_still_writes_the_private_methods(self) -> None:
+        class R(Magic, order="__before__"):
+            x: int
+
+        assert R(1).__magic_le__(R(1)) is True
+        assert R(1).__magic_gt__(R(2)) is False
+        assert R(2).__magic_ge__(R(1)) is True
 
     def test_order_requires_eq(self) -> None:
         with pytest.raises(ValueError, match="eq must be true"):
@@ -2128,7 +2182,9 @@ class TestAlwaysGenerated:
     @pytest.mark.parametrize(
         "option,private",
         [("repr", "__magic_repr__"), ("eq", "__magic_eq__"),
-         ("order", "__magic_lt__"), ("hash", "__magic_hash__")],
+         ("order", "__magic_lt__"), ("order", "__magic_le__"),
+         ("order", "__magic_gt__"), ("order", "__magic_ge__"),
+         ("hash", "__magic_hash__")],
     )
     def test_the_private_name_exists_even_when_turned_off(
         self, option: str, private: str
@@ -2188,8 +2244,12 @@ class TestDisabledOptionsDoNotFallThrough:
             y: int
 
         assert Ordered(1) < Ordered(2)
-        with pytest.raises(TypeError, match="not supported between"):
-            assert Unordered(1, 2) < Unordered(3, 4)
+        assert Ordered(1) <= Ordered(2)
+        assert Ordered(2) > Ordered(1)
+        assert Ordered(2) >= Ordered(1)
+        for compare in (operator.lt, operator.le, operator.gt, operator.ge):
+            with pytest.raises(TypeError, match="not supported between"):
+                compare(Unordered(1, 2), Unordered(3, 4))
 
     def test_hash_false_on_a_frozen_base(self) -> None:
         class F(Magic, frozen=True):

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -529,6 +529,61 @@ class TestEqOrder:
         assert R(1).__magic_gt__(R(2)) is False
         assert R(2).__magic_ge__(R(1)) is True
 
+    def test_a_hand_written_lt_stands_alone(self) -> None:
+        # A comparison in the class body wins, so the other three are
+        # not generated around it: they would compare the fields and
+        # disagree with it.
+        class P(Magic, order=True):
+            x: int
+
+            def __lt__(self, other: tx.Any) -> bool:
+                return self.x > other.x
+
+        assert (P(1) < P(2)) is False
+        assert (P(2) < P(1)) is True
+        for compare in (operator.le, operator.ge):
+            with pytest.raises(TypeError, match="not supported between"):
+                compare(P(1), P(2))
+        assert [name for name in ("__le__", "__gt__", "__ge__")
+                if name in P.__dict__] == []
+        # `>` is answered by Python itself, by turning it round and
+        # asking the hand-written `<`.
+        assert (P(1) > P(2)) is True
+        # All four are still there to call.
+        assert P(1).__magic_lt__(P(2)) is True
+        assert P(1).__magic_le__(P(2)) is True
+        assert P(1).__magic_gt__(P(2)) is False
+        assert P(1).__magic_ge__(P(2)) is False
+
+    def test_a_hand_written_ge_stands_alone(self) -> None:
+        class P(Magic, order=True):
+            x: int
+
+            def __ge__(self, other: tx.Any) -> bool:
+                return "mine"
+
+        assert (P(1) >= P(2)) == "mine"
+        for compare in (operator.lt, operator.gt):
+            with pytest.raises(TypeError, match="not supported between"):
+                compare(P(1), P(2))
+        assert [name for name in ("__lt__", "__le__", "__gt__")
+                if name in P.__dict__] == []
+
+    def test_a_hand_written_lt_silences_an_ordered_base(self) -> None:
+        class Base(Magic, order=True):
+            x: int
+
+        class Child(Base):
+            y: int
+
+            def __lt__(self, other: tx.Any) -> bool:
+                return self.x > other.x
+
+        assert (Child(1, 0) < Child(2, 0)) is False
+        for compare in (operator.le, operator.ge):
+            with pytest.raises(TypeError, match="not supported between"):
+                compare(Child(1, 0), Child(2, 0))
+
     def test_order_requires_eq(self) -> None:
         with pytest.raises(ValueError, match="eq must be true"):
             class Bad(Magic):


### PR DESCRIPTION
Closes #17.

## The bug

`order=True` generated only `__lt__`, so three of the four comparisons raised:

```pycon
>>> class O(Magic, order=True):
...     x: int
>>> O(1) < O(2)
True
>>> O(1) <= O(2)
TypeError: '<=' not supported between instances of 'O' and 'O'
```

## The change

Each comparison is now its own slot — `lt`, `le`, `gt`, `ge` — with its own private name, its own neutral fallback and its own record in the generated-methods table, exactly like `lt` had. `_make_lt` became `_make_order(qualname, fields, slot)`, one factory that applies the slot's operator to the tuple of ordered field values and returns `NotImplemented` against a different class, as before.

The one thing that needed deciding is what a **renamed** `order` should mean, since `order="__before__"` cannot name four methods:

- `order=True` — all four bound to their operators.
- `order="<name>"` — the `<` comparison is available under `<name>`, and **none** of the four operators are bound. Asking for the comparison under a name of your own is a way of saying you do not want it wired to `<`; it would be incoherent for `<=` to keep working when `<` deliberately does not.

`functools.total_ordering` was not used: it works by adding methods to a finished class, which is not how anything else here is built, and it could not respect the renaming rule.

Docs updated in the README, the comparison page (the ordering row is now a plain **yes**, and the bullet claiming it was partial is gone — it was also wrong, saying `<` and `>` where only `<` existed), the option comment, and the three option lists in docstrings.

## Tests

All four operators on a two-field class; sorting and `max`; per-field `NoOrder` across all four; `NotImplemented` against a different class plus the `!=` fallback; the renamed form binding only the given name and leaving all four operators unbound; the renamed form still writing all four private names; a subclass that turns `order` off answering none of the four even though its base had them.

388 passed; ruff and codespell clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_