### PR TITLE
Hand the init hooks one object holding every argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,27 @@ Set `mutable_default="raise"` to be stopped at the class definition instead,
 as `dataclasses` and `attrs` do — or `"allow"` when one shared object really
 is what you want.
 
+**Hooks around construction.** Write `__pre_init__` or `__post_init__` and
+it runs on the way in. Give it a parameter and it receives everything the
+constructor was called with — `__pre_init__` sees the values as passed,
+`__post_init__` sees them as stored:
+
+```python
+from bagof.magic import Magic, InitVar
+
+class Circle(Magic):
+    radius: float
+    scale: InitVar[float] = 1.0      # passed in, used, not kept
+
+    def __post_init__(self, arguments):
+        self.radius = self.radius * arguments.scale
+```
+
+```pycon
+>>> Circle(2.0, scale=3.0)
+Circle(radius=6.0)
+```
+
 **Documentation that writes itself.** Describe a field and it shows up in the
 class docstring and in the generated `__init__`:
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -8,5 +8,6 @@ icon: fontawesome/brands/python
         - Magic
         - MetaMagic
         - magic
+        - Arguments
         - fields
         - HIDE_IF_NONE

--- a/src/bagof/magic/__init__.py
+++ b/src/bagof/magic/__init__.py
@@ -125,6 +125,7 @@ import sys
 from abc import ABCMeta
 from collections import abc as _abc
 from functools import partial
+from inspect import Parameter, signature
 from textwrap import dedent, indent
 
 # externals
@@ -132,10 +133,14 @@ import typing_extensions as tx
 from bagof.core.magic import UnionType as _UnionType
 
 # internals
+from ._arguments import *  # noqa: F401, F403
+from ._arguments import Arguments
+from ._arguments import __all__ as __all_arguments__
 from ._fields import *  # noqa: F401, F403
 from ._fields import Field
 from ._fields import __all__ as __all_fields__
 from .constants import (
+    _ARGUMENTS,
     _CONVERTER,
     _DEFAULT,
     _DISCARD,
@@ -159,6 +164,7 @@ from .options import Options
 from .options import __all__ as __all_options__
 from .utils import _get_origin, rebuild_cls
 
+__all__ += __all_arguments__
 __all__ += __all_fields__
 __all__ += __all_options__
 
@@ -614,6 +620,84 @@ def _handle_mutable_default(field: Field, action: str) -> bool:
     return True
 
 
+def _find_hook(
+    namespace: dict, bases: tx.Tuple[type, ...], name: str
+) -> tx.Any:
+    """The `__pre_init__` or `__post_init__` this class will call.
+
+    A hook written in the class body wins; failing that, one inherited
+    from a base counts too, so that a family of classes can share a
+    single hook rather than repeating it in every subclass.
+    """
+    if name in namespace:
+        return namespace[name]
+    for base in bases:
+        hook = getattr(base, name, None)
+        if hook is not None:
+            return hook
+    return None
+
+
+def _hook_wants_arguments(name: str, hook: tx.Any) -> bool:
+    """Whether this hook is to be handed the values `__init__` got.
+
+    A hook that declares a parameter wants them; one that declares none
+    is called with nothing. Declaring more than one is a mistake, since
+    there is only ever a single object to pass.
+    """
+    try:
+        # The hook is called as a method, so its first parameter is the
+        # instance and is not ours to fill in.
+        parameters = list(signature(hook).parameters.values())[1:]
+    except (TypeError, ValueError):
+        # Nothing readable to go on. Passing the values is the safer
+        # guess: a hook that wanted none fails loudly on the extra
+        # argument, where a hook that wanted them and got none would
+        # quietly do the wrong thing.
+        return True
+
+    positional = [
+        parameter for parameter in parameters
+        if parameter.kind in (
+            Parameter.POSITIONAL_ONLY,
+            Parameter.POSITIONAL_OR_KEYWORD,
+            Parameter.VAR_POSITIONAL,
+        )
+    ]
+    required = [
+        parameter for parameter in positional
+        if parameter.default is Parameter.empty
+        and parameter.kind is not Parameter.VAR_POSITIONAL
+    ]
+    if len(required) > 1:
+        listed = ", ".join(parameter.name for parameter in required)
+        raise TypeError(
+            f"{name} takes several arguments ({listed}), but it is called "
+            f"with one: an object holding every value passed to __init__. "
+            f"Give it a single parameter and read the values off that -- "
+            f"`def {name}(self, arguments)`, then "
+            f"`arguments.{required[0].name}`."
+        )
+    return bool(positional)
+
+
+def _prepost_hooks(
+    namespace: dict, bases: tx.Tuple[type, ...]
+) -> tx.Dict[str, bool]:
+    """Which init hooks to call, and whether each wants the values.
+
+    Maps `__pre_init__` and/or `__post_init__` -- whichever the class
+    has -- to whether the generated `__init__` should hand it an
+    `Arguments` object.
+    """
+    hooks = {}
+    for name in (_PRE_INIT_NAME, _POST_INIT_NAME):
+        hook = _find_hook(namespace, bases, name)
+        if hook is not None:
+            hooks[name] = _hook_wants_arguments(name, hook)
+    return hooks
+
+
 def __pre_new__(
 
     metacls: MetaMagic,
@@ -803,13 +887,7 @@ def __pre_new__(
         if field.order and not field.eq:
             raise ValueError('eq must be true if order is true')
 
-    # Check if pre and/or post init methods are defined in this class.
-    prepost = []
-    if _PRE_INIT_NAME in namespace:
-        prepost += ["pre"]
-    if _POST_INIT_NAME in namespace:
-        prepost += ["post"]
-    prepost = "+".join(prepost)
+    prepost = _prepost_hooks(namespace, bases)
 
     # Every generated method is also bound under a private name, whether
     # or not the class asked for the public one, so that a hand-written
@@ -1185,7 +1263,7 @@ def _make_doc_elem(field: Field, name: tx.Optional[str] = None) -> str:
 
 
 def _make_init(
-    fields: dict[str, Field], prepost: str=""
+    fields: dict[str, Field], prepost: tx.Mapping[str, bool]
 ) -> dict:
 
     locals = {"object": object, "_HasFactory": _HasFactory}
@@ -1265,20 +1343,34 @@ def _make_init(
 
     _check_signature(signature)
 
+    parameters = list(positional_onlys.values())
+    parameters += list(args.values())
+    parameters += list(kw_onlys.values())
+
     def _make_prepost_call(func: str) -> str:
-        prepost_args = []
-        for field in positional_onlys.values():
-            if field.var:
-                prepost_args.append(f"{field.public_name}")
-        for field in args.values():
-            if field.var:
-                prepost_args.append(f"{field.public_name}")
-        for field in kw_onlys.values():
-            if field.var:
-                name = field.public_name
-                prepost_args.append(f"{name}={name}")
-        prepost_args = ", ".join(prepost_args)
-        return f"{SELF}.{func}({prepost_args})"
+        # A hook that declares no parameter is called with nothing; one
+        # that declares a parameter is handed every value `__init__` was
+        # called with, keyed by the name the caller would have used.
+        if not prepost[func]:
+            return f"{SELF}.{func}()"
+        locals[_ARGUMENTS] = Arguments
+        values = ", ".join(
+            f"{field.public_name!r}: {field.public_name}"
+            for field in parameters
+        )
+        return f"{SELF}.{func}({_ARGUMENTS}({{{values}}}))"
+
+    def _make_factory_elem(field: Field) -> str:
+        # A defaulted-by-factory parameter arrives holding the factory
+        # rather than a value. Every one of them is resolved before the
+        # first hook runs, so that `__pre_init__` sees real values.
+        if not field.factory:
+            return ""
+        name = field.public_name
+        return dedent(f"""
+        if isinstance({name}, _HasFactory):
+            {name} = {name}()
+        """)
 
     def _make_body_elem(field: Field) -> str:
         # The body reads the *parameter*, which is named after the
@@ -1286,11 +1378,6 @@ def _make_init(
         # own name.
         name = field.public_name
         body = ""
-        if field.factory:
-            body += dedent(f"""
-            if isinstance({name}, _HasFactory):
-                {name} = {name}()
-            """)
         if field.converter:
             locals[_CONVERTER(name)] = field.converter
             body += dedent(f"""
@@ -1309,16 +1396,11 @@ def _make_init(
             """)
         return body
 
-    body = []
-    if "pre" in prepost:
+    body = [_make_factory_elem(field) for field in parameters]
+    if _PRE_INIT_NAME in prepost:
         body.append(_make_prepost_call(_PRE_INIT_NAME))
-    for field in positional_onlys.values():
-        body.append(_make_body_elem(field))
-    for field in args.values():
-        body.append(_make_body_elem(field))
-    for field in kw_onlys.values():
-        body.append(_make_body_elem(field))
-    if "post" in prepost:
+    body += [_make_body_elem(field) for field in parameters]
+    if _POST_INIT_NAME in prepost:
         body.append(_make_prepost_call(_POST_INIT_NAME))
 
     return {

--- a/src/bagof/magic/__init__.py
+++ b/src/bagof/magic/__init__.py
@@ -621,24 +621,63 @@ def _handle_mutable_default(field: Field, action: str) -> bool:
 
 
 def _find_hook(
-    namespace: dict, bases: tx.Tuple[type, ...], name: str
+    namespace: dict, mro: tx.Tuple[type, ...], name: str
 ) -> tx.Any:
     """The `__pre_init__` or `__post_init__` this class will call.
 
     A hook written in the class body wins; failing that, one inherited
-    from a base counts too, so that a family of classes can share a
-    single hook rather than repeating it in every subclass.
+    from a Magic base counts too, so that a family of classes can share
+    a single hook rather than repeating it in every subclass.
+
+    Only a Magic base is looked at. A class of somebody else's that
+    happens to have a method by one of these names wrote it for their
+    own library, and calling it with our arguments would do something
+    unwanted.
+
+    The search follows the real inheritance order and reads the class
+    dictionary directly, so it finds the same hook Python will call. A
+    plain attribute lookup would answer with the first base that has one
+    rather than the first in the inheritance order, and would fall
+    through to the metaclass if no base had one at all.
+
+    What comes back is what the class body held -- a plain function, or
+    a `staticmethod`, or anything else callable. `_bind_hook` turns that
+    into the thing the instance will actually call.
     """
     if name in namespace:
         return namespace[name]
-    for base in bases:
-        hook = getattr(base, name, None)
-        if hook is not None:
-            return hook
+    for base in mro:
+        if getattr(base, _FIELDS, None) is None:
+            continue
+        if name in base.__dict__:
+            return base.__dict__[name]
     return None
 
 
-def _hook_wants_arguments(name: str, hook: tx.Any) -> bool:
+#: Stand-in instance for working out what a hook's parameters will be.
+#: Binding a function to it gives the same signature binding it to a real
+#: instance would, and the class does not exist yet at this point.
+_HOOK_SELF = object()
+
+
+def _bind_hook(hook: tx.Any) -> tx.Any:
+    """The hook as the instance will call it.
+
+    The generated `__init__` calls `self.__post_init__(...)`, so what
+    matters is the parameters left *after* attribute access has done its
+    work: a plain method loses `self`, a `classmethod` loses `cls`, and
+    a `staticmethod` loses nothing. Letting the descriptor protocol
+    answer that is the only way to get all three right.
+    """
+    bind = getattr(type(hook), "__get__", None)
+    if bind is None:
+        # Not a descriptor -- a callable object, say, whose own
+        # `__call__` already hides its `self`.
+        return hook
+    return bind(hook, _HOOK_SELF, type(_HOOK_SELF))
+
+
+def _hook_wants_arguments(clsname: str, name: str, hook: tx.Any) -> bool:
     """Whether this hook is to be handed the values `__init__` got.
 
     A hook that declares a parameter wants them; one that declares none
@@ -646,9 +685,7 @@ def _hook_wants_arguments(name: str, hook: tx.Any) -> bool:
     there is only ever a single object to pass.
     """
     try:
-        # The hook is called as a method, so its first parameter is the
-        # instance and is not ours to fill in.
-        parameters = list(signature(hook).parameters.values())[1:]
+        parameters = list(signature(_bind_hook(hook)).parameters.values())
     except (TypeError, ValueError):
         # Nothing readable to go on. Passing the values is the safer
         # guess: a hook that wanted none fails loudly on the extra
@@ -672,17 +709,17 @@ def _hook_wants_arguments(name: str, hook: tx.Any) -> bool:
     if len(required) > 1:
         listed = ", ".join(parameter.name for parameter in required)
         raise TypeError(
-            f"{name} takes several arguments ({listed}), but it is called "
-            f"with one: an object holding every value passed to __init__. "
-            f"Give it a single parameter and read the values off that -- "
-            f"`def {name}(self, arguments)`, then "
-            f"`arguments.{required[0].name}`."
+            f"{clsname}.{name} takes several arguments ({listed}), but it "
+            f"is called with one: an object holding every value passed to "
+            f"__init__. Give it a single parameter and read the values off "
+            f"that -- `arguments.{required[0].name}` in place of "
+            f"`{required[0].name}`."
         )
     return bool(positional)
 
 
 def _prepost_hooks(
-    namespace: dict, bases: tx.Tuple[type, ...]
+    clsname: str, namespace: dict, mro: tx.Tuple[type, ...]
 ) -> tx.Dict[str, bool]:
     """Which init hooks to call, and whether each wants the values.
 
@@ -692,9 +729,9 @@ def _prepost_hooks(
     """
     hooks = {}
     for name in (_PRE_INIT_NAME, _POST_INIT_NAME):
-        hook = _find_hook(namespace, bases, name)
+        hook = _find_hook(namespace, mro, name)
         if hook is not None:
-            hooks[name] = _hook_wants_arguments(name, hook)
+            hooks[name] = _hook_wants_arguments(clsname, name, hook)
     return hooks
 
 
@@ -887,7 +924,7 @@ def __pre_new__(
         if field.order and not field.eq:
             raise ValueError('eq must be true if order is true')
 
-    prepost = _prepost_hooks(namespace, bases)
+    prepost = _prepost_hooks(clsname, namespace, mro)
 
     # Every generated method is also bound under a private name, whether
     # or not the class asked for the public one, so that a hand-written

--- a/src/bagof/magic/_arguments.py
+++ b/src/bagof/magic/_arguments.py
@@ -1,0 +1,122 @@
+"""The object handed to `__pre_init__` and `__post_init__`."""
+from __future__ import annotations
+
+import typing_extensions as tx
+
+__all__ = ["Arguments"]
+
+
+class Arguments:
+    """Everything that was passed to `__init__`, reachable by name.
+
+    A class whose `__pre_init__` or `__post_init__` takes a parameter is
+    handed one of these. It is the whole set of values the constructor
+    was called with -- ordinary fields and `InitVar` fields alike, with
+    any default already filled in.
+
+    ```pycon
+    >>> from bagof.magic import Magic, InitVar
+    >>> class Circle(Magic):
+    ...     radius: float
+    ...     scale: InitVar[float] = 1.0
+    ...
+    ...     def __post_init__(self, arguments):
+    ...         self.radius = self.radius * arguments.scale
+    >>> Circle(2.0, scale=3.0)
+    Circle(radius=6.0)
+    ```
+
+    `__pre_init__` sees the values as they came in; `__post_init__` sees
+    them as they were stored, after any conversion and validation.
+
+    Read a value by attribute or by key, and unpack the whole set with
+    `**arguments`:
+
+    ```pycon
+    >>> from bagof.magic import Arguments
+    >>> arguments = Arguments(radius=2.0, scale=3.0)
+    >>> arguments.scale, arguments["scale"], dict(**arguments)
+    (3.0, 3.0, {'radius': 2.0, 'scale': 3.0})
+    ```
+
+    A value named `keys` or `get` can only be read by key, since those
+    two names belong to the methods.
+    """
+
+    __slots__ = ("_values",)
+
+    def __init__(
+        self, _values: tx.Optional[tx.Mapping] = None, **values
+    ) -> None:
+        """
+        Parameters
+        ----------
+        _values : mapping, optional
+            The values, if it is easier to pass them as one mapping.
+        **values
+            The values, one keyword each.
+        """
+        merged = dict(_values or {})
+        merged.update(values)
+        object.__setattr__(self, "_values", merged)
+
+    def keys(self) -> tx.KeysView:
+        """The names, in the order `__init__` declares them."""
+        return self._values.keys()
+
+    def get(self, name: str, default: tx.Any = None) -> tx.Any:
+        """The value passed for `name`, or `default` if there is none."""
+        return self._values.get(name, default)
+
+    def __getitem__(self, name: str) -> tx.Any:
+        try:
+            return self._values[name]
+        except KeyError:
+            raise KeyError(
+                f"{name!r} was not passed to __init__; it takes "
+                f"{', '.join(map(repr, self._values)) or 'no arguments'}"
+            ) from None
+
+    def __getattr__(self, name: str) -> tx.Any:
+        # Only reached for a name that is not a slot or a method, so
+        # every lookup here is either a value or a mistake.
+        try:
+            return self._values[name]
+        except KeyError:
+            raise AttributeError(
+                f"{name!r} was not passed to __init__; it takes "
+                f"{', '.join(map(repr, self._values)) or 'no arguments'}"
+            ) from None
+
+    def __setattr__(self, name: str, value: tx.Any) -> tx.NoReturn:
+        raise AttributeError(
+            f"Cannot set {name!r}: these are the values __init__ was "
+            f"called with, and changing one here would not change what "
+            f"gets stored. Assign to the field instead."
+        )
+
+    def __delattr__(self, name: str) -> tx.NoReturn:
+        raise AttributeError(
+            f"Cannot delete {name!r}: these are the values __init__ was "
+            f"called with."
+        )
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._values
+
+    def __iter__(self) -> tx.Iterator[str]:
+        return iter(self._values)
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+    def __eq__(self, other: tx.Any) -> bool:
+        if other.__class__ is not self.__class__:
+            return NotImplemented
+        return self._values == other._values
+
+    def __repr__(self) -> str:
+        values = ", ".join(
+            f"{name}={value!r}" for name, value in self._values.items()
+        )
+        return f"{type(self).__name__}({values})"

--- a/src/bagof/magic/_arguments.py
+++ b/src/bagof/magic/_arguments.py
@@ -40,52 +40,55 @@ class Arguments:
     ```
 
     A value named `keys` or `get` can only be read by key, since those
-    two names belong to the methods.
+    two names belong to the methods. Every other name, including one
+    starting with an underscore, is reachable either way.
     """
 
-    __slots__ = ("_values",)
+    __slots__ = ("__values",)
 
     def __init__(
-        self, _values: tx.Optional[tx.Mapping] = None, **values
+        self, values: tx.Optional[tx.Mapping] = None, /, **named
     ) -> None:
         """
         Parameters
         ----------
-        _values : mapping, optional
+        values : mapping, optional
             The values, if it is easier to pass them as one mapping.
-        **values
+            Positional, so that a value of any name can be given as a
+            keyword without clashing with it.
+        **named
             The values, one keyword each.
         """
-        merged = dict(_values or {})
-        merged.update(values)
-        object.__setattr__(self, "_values", merged)
+        merged = dict(values or {})
+        merged.update(named)
+        object.__setattr__(self, "_Arguments__values", merged)
 
     def keys(self) -> tx.KeysView:
         """The names, in the order `__init__` declares them."""
-        return self._values.keys()
+        return self.__values.keys()
 
     def get(self, name: str, default: tx.Any = None) -> tx.Any:
         """The value passed for `name`, or `default` if there is none."""
-        return self._values.get(name, default)
+        return self.__values.get(name, default)
 
     def __getitem__(self, name: str) -> tx.Any:
         try:
-            return self._values[name]
+            return self.__values[name]
         except KeyError:
             raise KeyError(
                 f"{name!r} was not passed to __init__; it takes "
-                f"{', '.join(map(repr, self._values)) or 'no arguments'}"
+                f"{', '.join(map(repr, self.__values)) or 'no arguments'}"
             ) from None
 
     def __getattr__(self, name: str) -> tx.Any:
         # Only reached for a name that is not a slot or a method, so
         # every lookup here is either a value or a mistake.
         try:
-            return self._values[name]
+            return self.__values[name]
         except KeyError:
             raise AttributeError(
                 f"{name!r} was not passed to __init__; it takes "
-                f"{', '.join(map(repr, self._values)) or 'no arguments'}"
+                f"{', '.join(map(repr, self.__values)) or 'no arguments'}"
             ) from None
 
     def __setattr__(self, name: str, value: tx.Any) -> tx.NoReturn:
@@ -102,21 +105,21 @@ class Arguments:
         )
 
     def __contains__(self, name: str) -> bool:
-        return name in self._values
+        return name in self.__values
 
     def __iter__(self) -> tx.Iterator[str]:
-        return iter(self._values)
+        return iter(self.__values)
 
     def __len__(self) -> int:
-        return len(self._values)
+        return len(self.__values)
 
     def __eq__(self, other: tx.Any) -> bool:
         if other.__class__ is not self.__class__:
             return NotImplemented
-        return self._values == other._values
+        return self.__values == other.__values
 
     def __repr__(self) -> str:
         values = ", ".join(
-            f"{name}={value!r}" for name, value in self._values.items()
+            f"{name}={value!r}" for name, value in self.__values.items()
         )
         return f"{type(self).__name__}({values})"

--- a/src/bagof/magic/_fields.py
+++ b/src/bagof/magic/_fields.py
@@ -662,7 +662,8 @@ class Var(BoolAnnotatedField):
     """
     Declare something that is not stored on each instance.
 
-    `InitVar` is passed to `__init__` and handed on to `__post_init__`;
+    `InitVar` is passed to `__init__`, used, and not kept -- it reaches
+    `__pre_init__` and `__post_init__` like any other argument;
     `ClassVar` is a plain class attribute, shared by every instance and
     absent from `__init__`.
 

--- a/src/bagof/magic/constants.py
+++ b/src/bagof/magic/constants.py
@@ -61,6 +61,10 @@ def _CONVERTER(x: str) -> str: return f"__magic_{x}_converter__"
 # Name given to the local validator variable when generating __init__
 def _VALIDATOR(x: str) -> str: return f"__magic_{x}_validator__"
 
+# Name given to the local holding the Arguments class when generating
+# __init__, for the object handed to the init hooks
+_ARGUMENTS = "__magic_arguments__"
+
 # Name given to a method's return type variable when generating it
 def _RETURN_TYPE(x: str) -> str: return f"__magic_{x}_return_type__"
 

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -19,7 +19,13 @@ import typing_extensions as tx
 # locals
 import bagof.magic as magic
 
-SOURCES = ["_fields.py", "constants.py", "options.py", "__init__.py"]
+SOURCES = [
+    "_arguments.py",
+    "_fields.py",
+    "constants.py",
+    "options.py",
+    "__init__.py",
+]
 
 #: Hand-written pages, relative to the repository root.
 PAGES = ["README.md", "docs/comparison.md"]

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -3066,14 +3066,31 @@ class TestInitHooks:
             def __post_init__(self, arguments: Arguments) -> None:
                 seen.append("base")
 
-        class Child(Base):
+        class Inherits(Base):
+            x: int
+
+        class Overrides(Base):
             x: int
 
             def __post_init__(self) -> None:
                 seen.append("child")
 
-        Child(5)
-        assert seen == ["child"]
+        Inherits(5)
+        Overrides(5)
+        assert seen == ["base", "child"]
+
+    def test_an_unreadable_hook_does_not_stop_the_class_being_built(
+        self,
+    ) -> None:
+        class C(Magic):
+            x: int
+            # Nothing you would write on purpose, but it is the shortest
+            # thing whose signature cannot be read. The class is still
+            # built; the hook only fails when it is actually called.
+            __post_init__ = "not a function"
+
+        with pytest.raises(TypeError, match="not callable"):
+            C(1)
 
     def test_more_than_one_parameter_is_rejected(self) -> None:
         with pytest.raises(TypeError, match="takes several arguments"):

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -3541,8 +3541,13 @@ class TestInitHookForms:
         class C(Magic, Legacy):
             x: int
 
-        C(1)
+        instance = C(1)
         assert seen == []
+
+        # Left alone, not taken away: it is still there for whoever
+        # wrote it to call.
+        instance.__post_init__("theirs")
+        assert seen == ["theirs"]
 
     def test_the_hook_is_read_in_inheritance_order(self) -> None:
         seen = []
@@ -3565,6 +3570,10 @@ class TestInitHookForms:
         # hook is the one called -- and it takes no argument.
         Both(1)
         assert seen == [("right", None)]
+
+        # `Left` does not override it, so there the base's hook runs.
+        Left()
+        assert seen[-1] == ("base", {})
 
     def test_the_error_names_the_class(self) -> None:
         with pytest.raises(TypeError, match=r"Bad\.__post_init__"):

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -10,6 +10,7 @@ from typing_extensions import Annotated
 import bagof.magic as m
 from bagof.magic import (
     HIDE_IF_NONE,
+    Arguments,
     ClassVar,
     ConvertTo,
     Default,
@@ -708,8 +709,8 @@ class TestVarFields:
             x: int
             scale: InitVar[int]
 
-            def __post_init__(self, scale: int) -> None:
-                self.x = self.x * scale
+            def __post_init__(self, arguments: Arguments) -> None:
+                self.x = self.x * arguments.scale
 
         w = WithInitVar(5, 10)
         assert w.x == 50
@@ -1538,11 +1539,11 @@ class TestMetaclassFeatures:
             x: int
             s: InitVar[int]
 
-            def __pre_init__(self, s: int) -> None:
-                seen.append(s)
+            def __pre_init__(self, arguments: Arguments) -> None:
+                seen.append(arguments.s)
 
-            def __post_init__(self, s: int) -> None:
-                self.x += s
+            def __post_init__(self, arguments: Arguments) -> None:
+                self.x += arguments.s
 
         c = C(1, 3)
         assert c.x == 4
@@ -1636,8 +1637,8 @@ class TestMetaclassFeatures:
                 int, Field(var=True, init=True, positional=True, kw=False)
             ]
 
-            def __post_init__(self, s: int) -> None:
-                object.__setattr__(self, "doubled", s * 2)
+            def __post_init__(self, arguments: Arguments) -> None:
+                object.__setattr__(self, "doubled", arguments.s * 2)
 
         assert C(4).doubled == 8
 
@@ -1648,8 +1649,8 @@ class TestMetaclassFeatures:
                 int, Field(var=True, init=True, positional=False, kw=True)
             ]
 
-            def __post_init__(self, s: int) -> None:
-                self.x += s
+            def __post_init__(self, arguments: Arguments) -> None:
+                self.x += arguments.s
 
         assert C(1, s=5).x == 6
 
@@ -2003,8 +2004,8 @@ class TestPublicName:
             x: int
             _seed: Annotated[int, Field(var=True, init=True)] = 0
 
-            def __post_init__(self, seed: int) -> None:
-                object.__setattr__(self, "x", self.x + seed)
+            def __post_init__(self, arguments: Arguments) -> None:
+                object.__setattr__(self, "x", self.x + arguments.seed)
 
         assert C(1, seed=7).x == 8
 
@@ -2967,3 +2968,205 @@ class TestInheritableUnsetValues:
         other = Field(name="x", hash=True)
         m._inherit_attrs(field, other, ())
         assert field.hash is None
+
+
+class TestInitHooks:
+
+    def test_hook_without_a_parameter_is_called_with_nothing(self) -> None:
+        seen = []
+
+        class C(Magic):
+            x: int
+
+            def __post_init__(self, ) -> None:
+                seen.append(self.x)
+
+        C(3)
+        assert seen == [3]
+
+    def test_hook_with_a_parameter_gets_every_value(self) -> None:
+        seen = []
+
+        class C(Magic):
+            x: int
+            y: int = 2
+            s: InitVar[int] = 7
+
+            def __post_init__(self, arguments: Arguments) -> None:
+                seen.append(dict(**arguments))
+
+        C(1)
+        assert seen == [{"x": 1, "y": 2, "s": 7}]
+
+    def test_values_are_read_by_name_not_by_position(self) -> None:
+        class C(Magic):
+            first: int
+            second: int
+
+            def __post_init__(self, arguments: Arguments) -> None:
+                object.__setattr__(self, "first", arguments.second)
+                object.__setattr__(self, "second", arguments.first)
+
+        c = C(1, 2)
+        assert (c.first, c.second) == (2, 1)
+
+    def test_pre_sees_the_values_as_passed(self) -> None:
+        seen = []
+
+        class C(Magic, convert=True):
+            port: int
+
+            def __pre_init__(self, arguments: Arguments) -> None:
+                seen.append(arguments.port)
+
+        C("9000")
+        assert seen == ["9000"]
+
+    def test_post_sees_the_values_as_stored(self) -> None:
+        seen = []
+
+        class C(Magic, convert=True):
+            port: int
+
+            def __post_init__(self, arguments: Arguments) -> None:
+                seen.append(arguments.port)
+
+        C("9000")
+        assert seen == [9000]
+
+    def test_a_factory_default_is_built_before_pre_runs(self) -> None:
+        seen = []
+
+        class C(Magic):
+            tags: Factory[list]
+
+            def __pre_init__(self, arguments: Arguments) -> None:
+                seen.append(arguments.tags)
+
+        C()
+        assert seen == [[]]
+
+    def test_an_inherited_hook_still_runs(self) -> None:
+        seen = []
+
+        class Base(Magic):
+            def __post_init__(self, arguments: Arguments) -> None:
+                seen.append(dict(**arguments))
+
+        class Child(Base):
+            x: int
+
+        Child(5)
+        assert seen == [{"x": 5}]
+
+    def test_a_hook_in_the_class_body_wins_over_an_inherited_one(self) -> None:
+        seen = []
+
+        class Base(Magic):
+            def __post_init__(self, arguments: Arguments) -> None:
+                seen.append("base")
+
+        class Child(Base):
+            x: int
+
+            def __post_init__(self) -> None:
+                seen.append("child")
+
+        Child(5)
+        assert seen == ["child"]
+
+    def test_more_than_one_parameter_is_rejected(self) -> None:
+        with pytest.raises(TypeError, match="takes several arguments"):
+            class Bad(Magic):
+                x: int
+                y: int
+
+                def __post_init__(self, x: int, y: int) -> None:
+                    """Two parameters, and only one object to pass."""
+
+    def test_a_parameter_with_a_default_is_still_one_parameter(self) -> None:
+        seen = []
+
+        class C(Magic):
+            x: int
+
+            def __post_init__(self, arguments: Arguments = None) -> None:
+                seen.append(arguments.x)
+
+        C(4)
+        assert seen == [4]
+
+    def test_star_args_counts_as_wanting_the_values(self) -> None:
+        seen = []
+
+        class C(Magic):
+            x: int
+
+            def __post_init__(self, *arguments: Arguments) -> None:
+                seen.append(arguments[0].x)
+
+        C(6)
+        assert seen == [6]
+
+    def test_a_keyword_only_parameter_does_not_count(self) -> None:
+        seen = []
+
+        class C(Magic):
+            x: int
+
+            def __post_init__(self, *, tag: str = "none") -> None:
+                seen.append(tag)
+
+        C(6)
+        assert seen == ["none"]
+
+
+class TestArguments:
+
+    def test_reads_by_attribute_and_by_key(self) -> None:
+        arguments = Arguments(x=1, y=2)
+        assert arguments.x == 1
+        assert arguments["y"] == 2
+
+    def test_built_from_a_mapping(self) -> None:
+        assert Arguments({"x": 1}) == Arguments(x=1)
+
+    def test_behaves_like_a_read_only_mapping(self) -> None:
+        arguments = Arguments(x=1, y=2)
+        assert list(arguments) == ["x", "y"]
+        assert list(arguments.keys()) == ["x", "y"]
+        assert len(arguments) == 2
+        assert "x" in arguments and "z" not in arguments
+        assert arguments.get("z", 3) == 3
+        assert dict(**arguments) == {"x": 1, "y": 2}
+
+    def test_repr_lists_the_values(self) -> None:
+        assert repr(Arguments(x=1)) == "Arguments(x=1)"
+
+    def test_compares_by_value(self) -> None:
+        assert Arguments(x=1) == Arguments(x=1)
+        assert Arguments(x=1) != Arguments(x=2)
+        assert Arguments(x=1).__eq__(1) is NotImplemented
+
+    def test_an_unknown_name_says_what_was_passed(self) -> None:
+        arguments = Arguments(x=1)
+        with pytest.raises(AttributeError, match="'x'"):
+            assert arguments.nope
+        with pytest.raises(KeyError, match="'x'"):
+            arguments["nope"]
+
+    def test_an_empty_set_says_so(self) -> None:
+        with pytest.raises(AttributeError, match="no arguments"):
+            assert Arguments().nope
+
+    def test_the_values_cannot_be_changed(self) -> None:
+        arguments = Arguments(x=1)
+        with pytest.raises(AttributeError, match="Cannot set"):
+            arguments.x = 2
+        with pytest.raises(AttributeError, match="Cannot delete"):
+            del arguments.x
+
+    def test_a_value_named_after_a_method_is_read_by_key(self) -> None:
+        arguments = Arguments(keys=1, get=2)
+        assert arguments["keys"] == 1
+        assert arguments["get"] == 2

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1332,8 +1332,8 @@ class PicklePseudoField(Magic, frozen=True):
     a: int
     b: InitVar[int]
 
-    def __post_init__(self, b: int) -> None:
-        object.__setattr__(self, "b", b * 2)
+    def __post_init__(self, arguments: Arguments) -> None:
+        object.__setattr__(self, "b", arguments.b * 2)
 
 
 def _round_trips(obj: tx.Any) -> tx.List[tx.Any]:

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -3187,3 +3187,123 @@ class TestArguments:
         arguments = Arguments(keys=1, get=2)
         assert arguments["keys"] == 1
         assert arguments["get"] == 2
+
+
+class TestInitHookForms:
+    """The shapes a hook can take, and where one is looked for."""
+
+    def test_a_static_method_hook_gets_the_values(self) -> None:
+        seen = []
+
+        class C(Magic):
+            x: int
+
+            @staticmethod
+            def __post_init__(arguments: Arguments) -> None:
+                seen.append(arguments.x)
+
+        C(1)
+        assert seen == [1]
+
+    def test_a_static_method_hook_can_take_nothing(self) -> None:
+        seen = []
+
+        class C(Magic):
+            x: int
+
+            @staticmethod
+            def __post_init__() -> None:
+                seen.append("ran")
+
+        C(1)
+        assert seen == ["ran"]
+
+    def test_a_class_method_hook_gets_the_values(self) -> None:
+        seen = []
+
+        class C(Magic):
+            x: int
+
+            @classmethod
+            def __post_init__(cls, arguments: Arguments) -> None:
+                seen.append((cls.__name__, arguments.x))
+
+        C(1)
+        assert seen == [("C", 1)]
+
+    def test_a_callable_object_hook_gets_the_values(self) -> None:
+        seen = []
+
+        class Recorder:
+            def __call__(self, arguments: Arguments) -> None:
+                seen.append(arguments.x)
+
+        class C(Magic):
+            x: int
+            __post_init__ = Recorder()
+
+        C(1)
+        assert seen == [1]
+
+    def test_a_hook_on_somebody_elses_base_is_left_alone(self) -> None:
+        seen = []
+
+        class Legacy:
+            """Not a Magic class: its hook was written for someone else."""
+
+            def __post_init__(self, tag: tx.Any) -> None:
+                seen.append(tag)
+
+        class C(Magic, Legacy):
+            x: int
+
+        C(1)
+        assert seen == []
+
+    def test_the_hook_is_read_in_inheritance_order(self) -> None:
+        seen = []
+
+        class Base(Magic):
+            def __post_init__(self, arguments: Arguments) -> None:
+                seen.append(("base", dict(**arguments)))
+
+        class Left(Base):
+            pass
+
+        class Right(Base):
+            def __post_init__(self) -> None:
+                seen.append(("right", None))
+
+        class Both(Left, Right):
+            x: int
+
+        # `Right` comes before `Base` in the inheritance order, so its
+        # hook is the one called -- and it takes no argument.
+        Both(1)
+        assert seen == [("right", None)]
+
+    def test_the_error_names_the_class(self) -> None:
+        with pytest.raises(TypeError, match=r"Bad\.__post_init__"):
+            class Bad(Magic):
+                x: int
+                y: int
+
+                def __post_init__(self, x: int, y: int) -> None:
+                    """Two parameters, and only one object to pass."""
+
+    def test_a_value_named_like_the_slot_is_still_reachable(self) -> None:
+        seen = []
+
+        class C(Magic):
+            v: Annotated[int, Field(alias="_values")]
+
+            def __post_init__(self, arguments: Arguments) -> None:
+                seen.append(arguments._values)
+
+        C(3)
+        assert seen == [3]
+
+    def test_a_mapping_is_passed_positionally(self) -> None:
+        # So that a value of any name can be given as a keyword.
+        arguments = Arguments(values=1, named=2)
+        assert (arguments.values, arguments.named) == (1, 2)


### PR DESCRIPTION
Part of #16 — the `__pre_init__` / `__post_init__` half.

## Why

`__post_init__` received the `InitVar` fields as positional arguments, the way `dataclasses` does it. That binds by position, so a hook whose parameters are named in a different order than the class declares its fields silently gets the wrong values:

```python
class D(Magic):
    a: InitVar[str] = "first"
    b: InitVar[str] = "second"

    def __post_init__(self, b, a):    # names swapped
        ...                           # b is "first"
```

`attrs` avoids the trap by passing nothing at all, which is safe but leaves you unable to see an `InitVar` you asked for.

## What it does now

A hook that declares a parameter receives one `Arguments` object holding **everything** the constructor was called with — ordinary fields as well as `InitVar` ones — and every value is reached by name:

```python
class Circle(Magic):
    radius: float
    scale: InitVar[float] = 1.0

    def __post_init__(self, arguments):
        self.radius = self.radius * arguments.scale
```

```pycon
>>> Circle(2.0, scale=3.0)
Circle(radius=6.0)
```

A hook that declares no parameter is called with nothing, so there is no cost to one that does not want the values. Declaring more than one parameter is an error at class definition, since there is only ever one object to pass.

`Arguments` reads by attribute or by key, iterates its names, and unpacks with `**arguments`. It is read-only: assigning to it would not change what gets stored, so it says so instead.

## Raw in, converted out

`__pre_init__` sees the values as they came in; `__post_init__` sees them as they were stored, after conversion and validation. Both read the locals the generated `__init__` already holds, so **no converter runs twice**. Factory defaults are now resolved for every parameter before the first hook rather than field by field, so `__pre_init__` sees a real value rather than the object that stands in for a factory.

## An inherited hook runs now

The check only looked at the class being built, so a family of classes could not share one hook:

```python
class Base(Magic):
    def __post_init__(self): ...

class Child(Base):
    x: int

Child(1)      # the hook never ran
```

## Breaking

A hook that took its `InitVar`s as separate parameters now gets one `Arguments` instead. The five tests that used the old shape were rewritten; the fix in user code is `arguments.scale` in place of `scale`.

## Tests

Twelve tests for the hooks (no-parameter, one-parameter, by-name rather than by-position, raw-vs-converted, factory-before-pre, inherited, overridden, too many parameters, defaulted parameter, `*args`, keyword-only) and nine for `Arguments` itself. The two `pycon` blocks in its docstring run in the docstring suite, so the examples are checked to be true.

404 passed; ruff and codespell clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_