### PR TITLE
Say the same thing for a reserved __hash__ as for every other method

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,10 @@ src/bagof/magic/
   utils.py      # SlotsBase, rebuild_cls, the `slots` decorator
   _resolve.py   # adapters to bagof-converters / -validators / -factories
 tests/
-  test_magic.py
+  test_magic.py                 # the builder, option by option
+  test_docstrings.py            # every `pycon` block in a docstring or page
+  test_options_are_documented.py  # every option is written down everywhere
+  test_licensing.py             # the license files reach the wheel
   test_import.py
 ```
 
@@ -96,14 +99,17 @@ will look "dead" on the other — that is expected, not a gap.
    source uses `__magic_<field>_type__` and friends; an error message must
    name the *field*, not the local.
 6. **A new class option has to be registered in six places.** The `@slots`
-   list and `_DEFAULTS` in `options.py`, and then the option list written out
-   three times in `__init__.py` — the module docstring, `_DOC_OPTIONS`, and
-   the `MetaMagic` and `Magic` docstrings — plus the settings table in
-   `README.md` and the comparison table in `docs/comparison.md`. Grep for an
-   existing option name to find them all. `MetaMagic.__doc__` and
-   `Magic.__doc__` are passed through `str.format`, so a `{` in one of them
-   is read as a placeholder: spell an option's accepted values in prose, not
-   in numpydoc's `{"a", "b"}` notation.
+   list and `_DEFAULTS` in `options.py`, the option list written out three
+   times — the module docstring at the top of `__init__.py`, and the
+   `MetaMagic` and `Magic` docstrings — and the settings table in
+   `README.md`. `tests/test_options_are_documented.py` checks all six, so a
+   missing one is a test failure rather than a doc page that quietly
+   disagrees with the code. The comparison table in `docs/comparison.md` is
+   not one row per option and is not checked; update it by hand when a new
+   option is worth comparing. `MetaMagic.__doc__` and `Magic.__doc__` are
+   passed through `str.format`, so a `{` in one of them is read as a
+   placeholder: spell an option's accepted values in prose, not in
+   numpydoc's `{"a", "b"}` notation.
 
 ## Documentation style (`README.md`, `docs/*.md`, public docstrings)
 

--- a/src/bagof/magic/__init__.py
+++ b/src/bagof/magic/__init__.py
@@ -40,6 +40,8 @@ eq : bool | str, default=True
     Generate `__eq__` method
 order : bool | str, default=False
     Generate `__lt__`, `__le__`, `__gt__` and `__ge__` methods
+hash : bool | str, default=None
+    Generate `__hash__` method; if `None`, decide automatically
 unsafe_hash : bool, default=False
     Always generate `__hash__` method
 frozen : bool, default=False
@@ -48,6 +50,8 @@ match_args : bool | str, default=False
     Generate `__match_args__` for pattern matching
 kw_only : bool, default=False
     Make all fields keyword-only by default
+positional_only : bool, default=False
+    Make all fields positional-only by default
 slots : bool, default=False
     Generate `__slots__` and remove `__dict__`
 weakref_slot : bool, default=False
@@ -60,6 +64,12 @@ convert : bool, default=False
     Use field type as converter if none is provided
 validate : bool, default=False
     Use field type as validator if none is provided
+mapping : bool, default=False
+    Implement the `Mapping` protocol
+reverse : bool, default=False
+    Use the reverse MRO order to determine field order
+doc : bool | str, default=True
+    Add field documentation to class docstring
 
 Examples
 --------
@@ -505,8 +515,9 @@ def _install_hash(
     private = _MAGIC("hash")
     if private in namespace:
         raise TypeError(
-            f"{private!r} is generated; define '__hash__' instead and call "
-            f"{private!r} from it"
+            f"{private} is written by Magic, so a class cannot define its "
+            f"own. Write __hash__ instead, and call {private} from it if "
+            f"you want the generated one."
         )
     namespace[private] = _hash_add(qualname, real_fields)
 

--- a/tests/test_options_are_documented.py
+++ b/tests/test_options_are_documented.py
@@ -1,0 +1,60 @@
+"""Every class option must be written down everywhere it belongs.
+
+An option lives in six places: the slot list and the defaults in
+`bagof.magic.options`, three docstrings, and the settings table in the
+README. Adding one and forgetting a couple of them is easy, and the
+result is a documented API that quietly disagrees with the code -- so
+this checks rather than trusts.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import typing_extensions as tx
+
+import bagof.magic as magic
+from bagof.magic.options import Options
+
+#: Every option, taken from the one place that decides what exists.
+OPTIONS = sorted(Options._DEFAULTS)
+
+
+def _root() -> tx.Optional[Path]:
+    """The repository root, or `None` when running from an installed copy."""
+    root = Path(magic.__file__).resolve().parents[3]
+    return root if (root / "README.md").is_file() else None
+
+
+def _documented(text: str) -> tx.Set[str]:
+    """The option names a numpydoc parameter block describes."""
+    return set(re.findall(r"^\s*(\w+) : ", text, re.MULTILINE))
+
+
+@pytest.mark.parametrize("option", OPTIONS)
+def test_option_has_a_slot(option: str) -> None:
+    assert option in Options._slots()
+
+
+@pytest.mark.parametrize("option", OPTIONS)
+def test_option_is_in_the_module_docstring(option: str) -> None:
+    assert option in _documented(magic.__doc__)
+
+
+@pytest.mark.parametrize("option", OPTIONS)
+def test_option_is_in_the_metaclass_docstring(option: str) -> None:
+    assert option in _documented(magic.MetaMagic.__doc__)
+
+
+@pytest.mark.parametrize("option", OPTIONS)
+def test_option_is_in_the_base_class_docstring(option: str) -> None:
+    assert option in _documented(magic.Magic.__doc__)
+
+
+@pytest.mark.parametrize("option", OPTIONS)
+def test_option_is_in_the_readme_table(option: str) -> None:
+    root = _root()
+    if root is None:
+        pytest.skip("running from an installed copy, with no README")
+    readme = (root / "README.md").read_text(encoding="utf-8")
+    assert f"| `{option}` |" in readme

--- a/tests/test_options_are_documented.py
+++ b/tests/test_options_are_documented.py
@@ -19,11 +19,7 @@ from bagof.magic.options import Options
 #: Every option, taken from the one place that decides what exists.
 OPTIONS = sorted(Options._DEFAULTS)
 
-
-def _root() -> tx.Optional[Path]:
-    """The repository root, or `None` when running from an installed copy."""
-    root = Path(magic.__file__).resolve().parents[3]
-    return root if (root / "README.md").is_file() else None
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def _documented(text: str) -> tx.Set[str]:
@@ -51,10 +47,11 @@ def test_option_is_in_the_base_class_docstring(option: str) -> None:
     assert option in _documented(magic.Magic.__doc__)
 
 
+@pytest.mark.skipif(
+    not (ROOT / "README.md").is_file(),
+    reason="running from an installed copy, not a checkout",
+)
 @pytest.mark.parametrize("option", OPTIONS)
 def test_option_is_in_the_readme_table(option: str) -> None:
-    root = _root()
-    if root is None:
-        pytest.skip("running from an installed copy, with no README")
-    readme = (root / "README.md").read_text(encoding="utf-8")
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
     assert f"| `{option}` |" in readme


### PR DESCRIPTION
Closes #44.

## The error

`_install` raises the polished form:

> `__magic_eq__` is written by Magic, so a class cannot define its own. Write `__eq__` instead, and call `__magic_eq__` from it if you want the generated one.

while `_install_hash` still raised:

> `'__magic_hash__'` is generated; define `'__hash__'` instead and call `'__magic_hash__'` from it

Same information, in the voice CLAUDE.md's error-message rule rules out. It now matches its sibling.

## The option list

Five of the nineteen options were missing from the list at the top of the module: `hash`, `positional_only`, `mapping`, `reverse` and `doc`. They are all in `Options._DEFAULTS` and in the `MetaMagic` and `Magic` docstrings, so the module docstring was the one place that had drifted.

Rather than write the "register a new option in six places" rule down a second time, there is now a test. Every option in `Options._DEFAULTS` must appear in its slot list, in all three docstrings, and in the README's settings table. Against `main` it fails on exactly those five:

```
FAILED test_option_is_in_the_module_docstring[doc]
FAILED test_option_is_in_the_module_docstring[hash]
FAILED test_option_is_in_the_module_docstring[mapping]
FAILED test_option_is_in_the_module_docstring[positional_only]
FAILED test_option_is_in_the_module_docstring[reverse]
```

The comparison page is deliberately not checked — it is not one row per option, and forcing it to be would make it a worse page.

## Two smaller corrections in CLAUDE.md

The registration rule named a `_DOC_OPTIONS` that no longer exists, and the layout section listed two of the five test files.

518 passed; ruff and codespell clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_