### PR TITLE
Stop match_args and mapping falling through to a base

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ class Thing(Magic, frozen=True, kw_only=True, slots=True):
 | `validate` | `False` | check every field against its type |
 | `factory` | `False` | build every missing default from its type |
 | `mutable_default` | `"factory"` | give each instance its own copy of `x: list = []`; or `"raise"`, or `"allow"` |
-| `mapping` | `False` | behave like a dictionary |
+| `mapping` | `False` | behave like a dictionary; a subclass cannot turn it off again |
 | `reverse` | `False` | list a subclass's own fields before inherited ones |
 | `doc` | `True` | add the field table to the class docstring |
 

--- a/src/bagof/magic/__init__.py
+++ b/src/bagof/magic/__init__.py
@@ -60,6 +60,8 @@ convert : bool, default=False
     Use field type as converter if none is provided
 validate : bool, default=False
     Use field type as validator if none is provided
+mapping : bool, default=False
+    Implement the `Mapping` protocol; a subclass cannot turn it off
 
 Examples
 --------
@@ -353,9 +355,11 @@ _ORDER_METHODS = {
 }
 
 
-#: What is put in place of a generated method when an option is turned
-#: off. These are the behaviours a plain Python class has: comparison by
-#: identity, the `<Thing object at 0x...>` repr, and no ordering.
+#: What is put in place of a generated method or value when an option
+#: is turned off. These are the answers a plain Python class gives:
+#: the `<Thing object at 0x...>` repr, comparison by identity, no
+#: ordering, no hash once `__eq__` is written, and nothing for a `case`
+#: pattern to bind.
 _NEUTRAL = {
     "repr": object.__repr__,
     "eq": object.__eq__,
@@ -371,11 +375,12 @@ _NEUTRAL = {
 
 
 def _generated_methods(cls: type) -> dict:
-    """Which methods on this class were written by Magic, and for what.
+    """Which of this class's attributes Magic wrote, and for what.
 
-    Maps the name a method was bound under to the option that produced
-    it -- `{"__eq__": "eq"}` normally, `{"__same__": "eq"}` if the class
-    asked for `eq="__same__"`.
+    Covers the generated methods and the `__match_args__` tuple. Maps
+    the name each was bound under to the option that produced it --
+    `{"__eq__": "eq"}` normally, `{"__same__": "eq"}` if the class asked
+    for `eq="__same__"`.
 
     Only the names a subclass might have to replace are listed, so the
     private `__magic_*__` names are left out: every class writes its own,
@@ -387,10 +392,11 @@ def _generated_methods(cls: type) -> dict:
     this record can tell the two apart, and telling them apart is what
     decides whether a subclass may replace the method.
 
-    It is a record on the class rather than a mark on the method itself
-    because some of what gets bound cannot carry a mark: a generated
-    `__hash__` is sometimes `None`, and a turned-off option leaves
-    behind `object.__eq__`, which is a built-in.
+    It is a record on the class rather than a mark on what was bound,
+    because most of what gets bound cannot carry a mark: a generated
+    `__hash__` is sometimes `None`, a turned-off option leaves behind
+    `object.__eq__`, which is a built-in, and `__match_args__` is a
+    tuple.
     """
     return cls.__dict__.get(_GENERATED) or {}
 
@@ -438,28 +444,30 @@ def _install(
     enabled: bool,
 ) -> bool:
     """
-    Put one generated method on the class being built.
+    Put one generated method or value on the class being built.
+
+    Everything here is a method apart from `__match_args__`, which is a
+    tuple of field names.
 
     It is always bound under its private name (`__magic_eq__` and
-    friends), so that a hand-written method can call the generated one.
-    It is bound under its public name (`__eq__`) only if the class asked
-    for that method.
+    friends), so that a hand-written method can reach the generated
+    one. It is bound under its public name (`__eq__`) only if the class
+    asked for it.
 
-    If the class did *not* ask for it, any generated method it would
-    otherwise inherit is replaced by the plain-Python behaviour. A
-    generated method belongs to the class it was made for: it only
-    knows that class's fields, so letting it answer for a different
-    class gives wrong answers. Methods you wrote yourself are never
-    replaced.
+    If the class did *not* ask for it, anything generated it would
+    otherwise inherit is replaced by the plain-Python behaviour. What
+    is generated belongs to the class it was made for: it only knows
+    that class's fields, so letting it answer for a different class
+    gives wrong answers. Whatever you wrote yourself is never replaced.
 
-    Returns whether the public name ended up holding our method.
+    Returns whether the public name ended up holding ours.
     """
     private = _MAGIC(slot)
     if private in namespace:
         raise TypeError(
             f"{private} is written by Magic, so a class cannot define its "
-            f"own. Write {public} instead, and call {private} from it if "
-            f"you want the generated one."
+            f"own. Write {public} instead, and use {private} from there if "
+            f"you want what Magic generated."
         )
     namespace[private] = fn
 
@@ -767,21 +775,21 @@ def __pre_new__(
     namespace[_OPTIONS] = options
 
     # Once a class is dict-like, none of its subclasses can stop being
-    # one, so a subclass that says `mapping=False` is asking for
-    # something that cannot be delivered. `mro[0]` is the throwaway
-    # class built above to work out the inheritance order; it is not a
-    # base of anything.
-    mapping_base = next(
-        (
-            b for b in mro[1:]
-            if getattr(getattr(b, _OPTIONS, None), "mapping", False)
-        ),
-        None,
-    )
+    # one, so a subclass that turns `mapping` off is asking for
+    # something that cannot be delivered. The class to name is the
+    # furthest one along the chain that is dict-like: `mapping` is
+    # inherited, so every class below the one that asked for it has the
+    # option set too, and turning it off on any of those would only
+    # raise this again. `mro[0]` is the throwaway class built above to
+    # work out the inheritance order; it is not a base of anything.
+    mapping_base = None
+    for b in mro[1:]:
+        if getattr(getattr(b, _OPTIONS, None), "mapping", False):
+            mapping_base = b
     if mapping_base is not None and not options.mapping:
         raise TypeError(
             f"{clsname} gets its dict-like behaviour from "
-            f"{mapping_base.__name__}, and mapping=False cannot take it "
+            f"{mapping_base.__name__}, and a subclass cannot take it "
             f"away: {clsname} would still answer yes to an isinstance "
             f"check against Mapping, while the dict-like methods it "
             f"inherited would report {mapping_base.__name__}'s fields "
@@ -1817,7 +1825,8 @@ class MetaMagic(ABCMeta):
     validate : bool, default=False
         Use field type as validator if none is provided.
     mapping : bool, default=False
-        Implement the `Mapping` protocol.
+        Implement the `Mapping` protocol. A subclass cannot turn it off
+        again.
     reverse : bool, default=False
         Use the reverse MRO order to determine field order.
         This only affects the relative order of the fields of one class
@@ -1899,7 +1908,8 @@ class Magic(metaclass=MetaMagic):
     validate : bool, default=False
         Use field type as validator if none is provided.
     mapping : bool, default=False
-        Implement the `Mapping` protocol.
+        Implement the `Mapping` protocol. A subclass cannot turn it off
+        again.
     reverse : bool, default=False
         Use the reverse MRO order to determine field order.
         This only affects the relative order of the fields of one class

--- a/src/bagof/magic/__init__.py
+++ b/src/bagof/magic/__init__.py
@@ -349,6 +349,9 @@ _NEUTRAL = {
     "eq": object.__eq__,
     "lt": _no_order,
     "hash": None,
+    # An empty tuple is what a class with no pattern-matching support
+    # has: `case C(x)` refuses to bind anything positionally.
+    "match_args": (),
 }
 
 
@@ -726,6 +729,30 @@ def __pre_new__(
     options.update(Options(**kwargs))
     namespace[_OPTIONS] = options
 
+    # Once a class is dict-like, none of its subclasses can stop being
+    # one, so a subclass that says `mapping=False` is asking for
+    # something that cannot be delivered. `mro[0]` is the throwaway
+    # class built above to work out the inheritance order; it is not a
+    # base of anything.
+    mapping_base = next(
+        (
+            b for b in mro[1:]
+            if getattr(getattr(b, _OPTIONS, None), "mapping", False)
+        ),
+        None,
+    )
+    if mapping_base is not None and not options.mapping:
+        raise TypeError(
+            f"{clsname} gets its dict-like behaviour from "
+            f"{mapping_base.__name__}, and mapping=False cannot take it "
+            f"away: {clsname} would still answer yes to an isinstance "
+            f"check against Mapping, while the dict-like methods it "
+            f"inherited would report {mapping_base.__name__}'s fields "
+            f"instead of its own. Either leave mapping alone here, or "
+            f"turn it off on {mapping_base.__name__} and ask for it only "
+            f"on the subclasses that want it."
+        )
+
     if options.mutable_default not in _MUTABLE_DEFAULT_ACTIONS:
         raise ValueError(
             f"mutable_default must be 'factory', 'raise' or 'allow', "
@@ -893,16 +920,6 @@ def __pre_new__(
     # Include only real fields.  This is used in all of the following methods.
     real_fields = {name: f for name, f in fields.items() if not f.var}
 
-    if options.match_args:
-        fnname = (
-            options.match_args
-            if isinstance(options.match_args, str)
-            else "__match_args__"
-        )
-        namespace.setdefault(fnname, tuple(
-            f.public_name for f in fields.values() if f.init and f.positional
-        ))
-
     if options.mapping:
         dict_fields = {f.public_key: f for f in fields.values() if f.key}
         for name, func in _make_mapping(qualname, dict_fields).items():
@@ -919,6 +936,19 @@ def __pre_new__(
     _install_state(
         namespace, generated, base_mro, qualname, real_fields,
         bool(options.frozen),
+    )
+
+    _install(
+        namespace, generated, base_mro, "match_args",
+        (
+            options.match_args
+            if isinstance(options.match_args, str)
+            else "__match_args__"
+        ),
+        tuple(
+            f.public_name for f in fields.values() if f.init and f.positional
+        ),
+        bool(options.match_args),
     )
 
     repr_fields = {name: f for name, f in fields.items() if f.repr}

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1042,6 +1042,18 @@ class TestMatchArgs:
 
         assert Child.__match_args__ == ("b",)
 
+    def test_writing_the_private_name_is_refused(self) -> None:
+        with pytest.raises(TypeError) as caught:
+            class Point(Magic, match_args=True):
+                x: int
+                __magic_match_args__ = ("x",)
+
+        message = str(caught.value)
+        assert "__magic_match_args__" in message
+        assert "__match_args__" in message
+        # A tuple is not something the reader can call.
+        assert "call" not in message
+
 
 # ======================================================================
 # Field (direct)
@@ -1193,16 +1205,34 @@ class TestMapping:
             class Child(Base, mapping=False):
                 b: int
 
-    def test_the_ban_reaches_a_distant_base(self) -> None:
+    def test_the_ban_names_the_class_that_asked_for_it(self) -> None:
         class Base(Magic, mapping=True):
             a: int
 
         class Middle(Base):
             b: int
 
-        with pytest.raises(TypeError, match="Middle"):
+        with pytest.raises(TypeError) as caught:
             class Child(Middle, mapping=False):
                 c: int
+
+        # `Middle` is dict-like only because it inherited the option,
+        # so pointing at it would send the reader somewhere that raises
+        # this same error again.
+        assert "Base" in str(caught.value)
+        assert "Middle" not in str(caught.value)
+
+    def test_the_ban_does_not_quote_a_value_back(self) -> None:
+        class Base(Magic, mapping=True):
+            a: int
+
+        with pytest.raises(TypeError) as caught:
+            class Child(Base, mapping=None):
+                b: int
+
+        # Any falsy value turns the option off, so the message must not
+        # name one the reader did not write.
+        assert "mapping=False" not in str(caught.value)
 
     def test_a_subclass_that_keeps_it_reports_its_own_fields(self) -> None:
         class Base(Magic, mapping=True):

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -740,6 +740,43 @@ class TestMatchArgs:
 
         assert Point.__match_args__ == ("x",)
 
+    def test_turning_it_off_does_not_leave_the_base_tuple(self) -> None:
+        class Base(Magic, match_args=True):
+            a: int
+
+        class Child(Base, match_args=False):
+            b: int
+
+        # Without this, `case Child(x)` would bind `x` to `a` -- the
+        # base's field list, answering for a class that asked for no
+        # pattern matching at all.
+        assert Child.__match_args__ == ()
+
+    def test_a_subclass_that_keeps_it_lists_its_own_fields(self) -> None:
+        class Base(Magic, match_args=True):
+            a: int
+
+        class Child(Base):
+            b: int
+
+        assert Child.__match_args__ == ("a", "b")
+
+    def test_the_tuple_is_always_available_privately(self) -> None:
+        class Child(Magic, match_args=False):
+            a: int
+
+        assert Child.__magic_match_args__ == ("a",)
+
+    def test_a_hand_written_tuple_is_left_alone(self) -> None:
+        class Base(Magic, match_args=True):
+            a: int
+
+        class Child(Base, match_args=False):
+            b: int
+            __match_args__ = ("b",)
+
+        assert Child.__match_args__ == ("b",)
+
 
 # ======================================================================
 # Field (direct)
@@ -882,6 +919,45 @@ class TestMapping:
 
         p = Point(1, 2)
         assert dict(p) == {"x": 1, "y": 2}
+
+    def test_a_subclass_cannot_stop_being_dict_like(self) -> None:
+        class Base(Magic, mapping=True):
+            a: int
+
+        with pytest.raises(TypeError, match="cannot take it away"):
+            class Child(Base, mapping=False):
+                b: int
+
+    def test_the_ban_reaches_a_distant_base(self) -> None:
+        class Base(Magic, mapping=True):
+            a: int
+
+        class Middle(Base):
+            b: int
+
+        with pytest.raises(TypeError, match="Middle"):
+            class Child(Middle, mapping=False):
+                c: int
+
+    def test_a_subclass_that_keeps_it_reports_its_own_fields(self) -> None:
+        class Base(Magic, mapping=True):
+            a: int
+
+        class Child(Base):
+            b: int
+
+        assert dict(Child(1, 2)) == {"a": 1, "b": 2}
+
+    def test_mapping_false_is_fine_without_a_dict_like_base(self) -> None:
+        class Base(Magic):
+            a: int
+
+        class Child(Base, mapping=False):
+            b: int
+
+        from collections.abc import Mapping
+
+        assert not isinstance(Child(1, 2), Mapping)
 
     def test_mapping_not_key_field(self) -> None:
         class Point(Magic, mapping=True):


### PR DESCRIPTION
Closes #33 — the last two of the three places a turned-off option left the base's answer standing. The pickle half went in as #38.

## `match_args`

`match_args=False` left the base's `__match_args__` tuple in place, so a class that asked for no pattern matching still matched — against the base's field list:

```python
class Base(Magic, match_args=True):
    a: int

class Child(Base, match_args=False):
    b: int

match Child(1, 2):
    case Child(x):    # x is `a`, and Child never asked for this
        ...
```

The tuple now goes through the same install path as the generated methods: written privately as `__magic_match_args__`, bound to `__match_args__` only if the class asked for it, and an inherited generated one replaced by the empty tuple — which is what a class with no pattern-matching support has, so `case Child(x)` raises rather than binding the wrong field.

## `mapping`

`mapping=False` on a subclass of a dict-like class could not work, and failed quietly: the subclass stayed registered as a `Mapping`, so `isinstance` still said yes, while the inherited `__getitem__` and friends reported the base's fields.

Turning `__hash__` into `None` is why the same trick works for hashability — `Hashable` asks the type — but `Mapping` has no such hook, so there is nothing to undo. It is refused at class definition now.

The message names **the class that asked to be dict-like**, not the nearest base that happens to be one. Since the option is inherited, those are usually different, and naming the nearest sends you round the same error again:

```
Child gets its dict-like behaviour from Base, and a subclass cannot take it
away: Child would still answer yes to an isinstance check against Mapping,
while the dict-like methods it inherited would report Base's fields instead
of its own. Either leave mapping alone here, or turn it off on Base and ask
for it only on the subclasses that want it.
```

It also no longer quotes `mapping=False` back at someone who wrote `mapping=None`. The restriction is documented in the option lists and the README settings table, so it is not something you only meet as a `TypeError`.

## Prose that assumed everything generated is a method

`__match_args__` is the first *value* to go through `_install`, which made four pieces of wording untrue — most visibly its private-name error, which told you to *call* a tuple. That, `_install`'s and `_generated_methods`' docstrings, and `_NEUTRAL`'s comment all say "method or value" now.

## Review

An independent adversarial review found the `match_args` half correct and everything above in the `mapping` half. It also found a case deliberately left alone: inheriting a genuine `collections.abc.Mapping` while saying `mapping=False` reaches the same end state the ban describes, without a Magic base being involved. Filed as #46, since nothing generated is involved and the answer is a design question rather than a fix.

433 passed; ruff and codespell clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_