### PR TITLE
Let a Magic class be generic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,8 +216,8 @@ codespell src tests
 
 - **Correctness**: unresolved string/forward annotations breaking
   `convert`/`validate`/`factory` (#13); fields shared and mutated across
-  classes (#14); generic classes (#18); a disabled option falling through to
-  `Magic`'s own generated method (#23).
+  classes (#14); a disabled option falling through to `Magic`'s own
+  generated method (#23).
 - **Model**: naming the field kind instead of inferring it from `init` (#16),
   which also carries the declared/resolved split that makes option inheritance
   work (#20).

--- a/README.md
+++ b/README.md
@@ -218,6 +218,31 @@ class Circle(Magic):
 Circle(radius=6.0)
 ```
 
+**Generic classes.** A `Magic` class can take a type parameter like any
+other:
+
+```python
+from typing import Generic, TypeVar
+from bagof.magic import Magic
+
+T = TypeVar("T")
+
+class Box(Magic, Generic[T]):
+    item: T
+```
+
+```pycon
+>>> Box(1)
+Box(item=1)
+>>> Box[str]("hello")
+Box(item='hello')
+```
+
+The parameter is not filled in on the fields, though: a subclass written as
+`class IntBox(Box[int])` still sees `item` as `T`, so conversion and
+validation have nothing to go on there. Annotate the field with a real type
+in the subclass if you need those.
+
 **Documentation that writes itself.** Describe a field and it shows up in the
 class docstring and in the generated `__init__`:
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -47,7 +47,7 @@ question of what you want the type hints to *do*.
 | Copy with changes | `replace` | `evolve` | `model_copy` | *[not yet][parity]* |
 | Convert to a plain `dict` | `asdict` | `asdict` | `model_dump` | *[not yet][parity]* |
 | JSON schema | no | no | yes | no |
-| Generic classes | yes | yes | yes | **yes** |
+| Generic classes | yes | yes | yes | **yes**, *[without substitution][generics]* |
 | Runtime dependency | none | `attrs` | `pydantic-core` (compiled) | the `bagof` packages |
 
 ## The same class, four ways
@@ -230,6 +230,11 @@ Being honest about the gaps, with links to where they are being worked on:
 - **JSON schema and serialisation.** Pydantic's real draw, and `magic` has
   neither yet.
 - **Copy-with-changes and `asdict`.** [In progress][parity].
+- **Type parameters in a generic class.** `class Box(Magic, Generic[T])`
+  works, but a subclass that fills the parameter in — `class IntBox(Box[int])`
+  — leaves the field's type as `T`, so conversion and validation have nothing
+  to work from and let any value through. [Tracked here][generics]. Pydantic
+  substitutes the parameter; `dataclasses` and `attrs` do not either.
 - **Editor and type-checker support.** The others are understood by mypy and
   pyright today, so your editor completes the constructor and catches a wrong
   argument type. `magic` is not, yet — [tracked here][typing]. The route is
@@ -241,4 +246,5 @@ Being honest about the gaps, with links to where they are being worked on:
 [attrs]: https://www.attrs.org
 [pydantic]: https://docs.pydantic.dev
 [parity]: https://github.com/bagofseeds/bagof-magic/issues/22
+[generics]: https://github.com/bagofseeds/bagof-magic/issues/50
 [typing]: https://github.com/bagofseeds/bagof-magic/issues/30

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -47,7 +47,7 @@ question of what you want the type hints to *do*.
 | Copy with changes | `replace` | `evolve` | `model_copy` | *[not yet][parity]* |
 | Convert to a plain `dict` | `asdict` | `asdict` | `model_dump` | *[not yet][parity]* |
 | JSON schema | no | no | yes | no |
-| Generic classes | yes | yes | yes | *[not yet][generics]* |
+| Generic classes | yes | yes | yes | **yes** |
 | Runtime dependency | none | `attrs` | `pydantic-core` (compiled) | the `bagof` packages |
 
 ## The same class, four ways
@@ -230,8 +230,6 @@ Being honest about the gaps, with links to where they are being worked on:
 - **JSON schema and serialisation.** Pydantic's real draw, and `magic` has
   neither yet.
 - **Copy-with-changes and `asdict`.** [In progress][parity].
-- **Generic classes.** `class Box(Magic, Generic[T])` does not work yet
-  — [tracked here][generics].
 - **Editor and type-checker support.** The others are understood by mypy and
   pyright today, so your editor completes the constructor and catches a wrong
   argument type. `magic` is not, yet — [tracked here][typing]. The route is
@@ -243,5 +241,4 @@ Being honest about the gaps, with links to where they are being worked on:
 [attrs]: https://www.attrs.org
 [pydantic]: https://docs.pydantic.dev
 [parity]: https://github.com/bagofseeds/bagof-magic/issues/22
-[generics]: https://github.com/bagofseeds/bagof-magic/issues/18
 [typing]: https://github.com/bagofseeds/bagof-magic/issues/30

--- a/src/bagof/magic/__init__.py
+++ b/src/bagof/magic/__init__.py
@@ -806,6 +806,30 @@ def _prepost_hooks(
     return hooks
 
 
+def _mro(
+    bases: tx.Tuple[type, ...], namespace: dict
+) -> tx.Tuple[type, ...]:
+    """The resolution order of a class built from `bases`.
+
+    Python works an order out for a class that exists, so a throwaway
+    class is built here just to read it back off. Its first entry is
+    that throwaway class; every entry after it is a real base, ending
+    with `object`.
+
+    A class written as `class Box(Magic, Generic[T])` reaches this
+    module with `Generic[T]` already replaced by plain `Generic` in its
+    bases, and `Generic` refuses to be a base on its own. What tells
+    the two apart is `__orig_bases__` -- the bases as they were
+    written -- so the throwaway is given the same one, and is measured
+    against the same bases as the real class.
+    """
+    stand_in = {}
+    orig_bases = namespace.get("__orig_bases__")
+    if orig_bases is not None:
+        stand_in["__orig_bases__"] = orig_bases
+    return type(_DISCARD, bases, stand_in).__mro__
+
+
 def __pre_new__(
 
     metacls: MetaMagic,
@@ -865,7 +889,7 @@ def __pre_new__(
 
     # Find our base classes in reverse MRO order, so that order is
     # obtained from MRO, but value is obtained from most derived class.
-    mro = type(_DISCARD, bases, {}).__mro__
+    mro = _mro(bases, namespace)
     for b in reversed(mro):
         # Only process classes that have been processed by our
         # decorator.  That is, they have a _FIELDS attribute.
@@ -1077,7 +1101,7 @@ def __pre_new__(
     # The generated methods are installed here, once `bases` is settled:
     # the `mapping` option can add one, and working out what a class
     # would otherwise inherit means looking at the bases it really has.
-    base_mro = type(_DISCARD, bases, {}).__mro__[1:]
+    base_mro = _mro(bases, namespace)[1:]
 
     repr_fields = {name: f for name, f in fields.items() if f.repr}
     _install(
@@ -1130,7 +1154,11 @@ def __pre_new__(
         if '__slots__' in namespace:
             raise TypeError(f'{clsname} already specifies __slots__')
         weakref_slot = options.weakref_slot
-        namespace["__slots__"] = _make_slots(bases, real_fields, weakref_slot)
+        # Every class this one inherits from, `object` aside: a field
+        # already given a slot by one of them does not need another.
+        namespace["__slots__"] = _make_slots(
+            base_mro[:-1], real_fields, weakref_slot
+        )
 
     # Saving an object means saving its slots, so this waits until
     # `__slots__` is settled as well as `bases`.
@@ -1748,14 +1776,13 @@ def _get_slots(cls: type) -> tx.Iterator[str]:
 
 
 def _make_slots(
-    bases: tuple[type, ...],
+    ancestors: tx.Sequence[type],
     fields: dict[str, Field],
     weakref_slot: bool = False,
 ) -> tx.Union[tuple[str, ...], dict[str, tx.Optional[str]]]:
-    mro = type(_DISCARD, bases, {}).__mro__[1:-1]
     inherited_slots = set(
         slot
-        for base in mro
+        for base in ancestors
         for slot in _get_slots(base)
     )
 

--- a/src/bagof/magic/__init__.py
+++ b/src/bagof/magic/__init__.py
@@ -833,8 +833,8 @@ def _mro(
 
     Python works an order out for a class that exists, so a throwaway
     class is built here just to read it back off. Its first entry is
-    that throwaway class; every entry after it is a real base, ending
-    with `object`.
+    that throwaway class; every entry after it is an ancestor the real
+    class will have, ending with `object`.
 
     A class written as `class Box(Magic, Generic[T])` reaches this
     module with `Generic[T]` already replaced by plain `Generic` in its
@@ -843,11 +843,10 @@ def _mro(
     written -- so the throwaway is given the same one, and is measured
     against the same bases as the real class.
     """
-    stand_in = {}
-    orig_bases = namespace.get("__orig_bases__")
-    if orig_bases is not None:
-        stand_in["__orig_bases__"] = orig_bases
-    return type(_DISCARD, bases, stand_in).__mro__
+    stand_in_namespace = {}
+    if "__orig_bases__" in namespace:
+        stand_in_namespace["__orig_bases__"] = namespace["__orig_bases__"]
+    return type(_DISCARD, bases, stand_in_namespace).__mro__
 
 
 def __pre_new__(

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -3774,3 +3774,117 @@ class TestInitHookForms:
         # So that a value of any name can be given as a keyword.
         arguments = Arguments(values=1, named=2)
         assert (arguments.values, arguments.named) == (1, 2)
+
+
+# ======================================================================
+# Generic classes
+# ======================================================================
+
+_T = tx.TypeVar("_T")
+_TInt = tx.TypeVar("_TInt", bound=int)
+
+
+class GenericBox(Magic, tx.Generic[_T]):
+    item: _T
+
+
+class GenericPlain(Magic):
+    a: int
+
+
+class GenericChild(GenericPlain, tx.Generic[_T]):
+    b: _T
+
+
+class TestGenericClasses:
+    """A class that takes a type parameter: `class Box(Magic, Generic[T])`."""
+
+    def test_a_generic_class_can_be_defined(self) -> None:
+        # Regression: `Generic` used to refuse the class outright.
+        assert GenericBox.__parameters__ == (_T,)
+        assert [f.name for f in m.fields(GenericBox)] == ["item"]
+
+    def test_the_generated_methods_work(self) -> None:
+        box = GenericBox(1)
+        assert box.item == 1
+        assert repr(box) == "GenericBox(item=1)"
+        assert box == GenericBox(1)
+        assert box != GenericBox(2)
+
+    def test_a_parameterised_class_builds_an_instance(self) -> None:
+        box = GenericBox[int](1)
+        assert isinstance(box, GenericBox)
+        assert box == GenericBox(1)
+
+    def test_a_generic_subclass_of_a_plain_class(self) -> None:
+        child = GenericChild(1, "two")
+        assert (child.a, child.b) == (1, "two")
+        assert GenericChild.__parameters__ == (_T,)
+
+    def test_a_plain_subclass_of_a_generic_class(self) -> None:
+        class Labelled(GenericBox[int]):
+            label: str = "?"
+
+        assert Labelled(1, "one") == Labelled(1, "one")
+        assert repr(Labelled(1)) == "Labelled(item=1, label='?')"
+
+    def test_the_decorator_form(self) -> None:
+        @magic
+        class Box(tx.Generic[_T]):
+            item: _T
+
+        assert Box.__parameters__ == (_T,)
+        assert Box[str]("one").item == "one"
+
+    def test_slots_leave_no_instance_dict(self) -> None:
+        class Box(Magic, tx.Generic[_T], slots=True):
+            item: _T
+
+        assert Box.__slots__ == ("item",)
+        assert not hasattr(Box(1), "__dict__")
+
+    def test_frozen_and_ordered(self) -> None:
+        class Box(Magic, tx.Generic[_T], frozen=True, order=True):
+            item: _T
+
+        assert sorted([Box(2), Box(1)]) == [Box(1), Box(2)]
+        assert hash(Box(1)) == hash(Box(1))
+
+    def test_round_trips(self) -> None:
+        assert _round_trips(GenericBox(1)) == [GenericBox(1)] * 3
+        assert _round_trips(GenericBox[int]) == [GenericBox[int]] * 3
+
+    def test_a_bare_type_parameter_converts_to_nothing(self) -> None:
+        # There is no type to convert to, so the value is left alone.
+        class Box(Magic, tx.Generic[_T], convert=True):
+            item: _T
+
+        assert Box("one").item == "one"
+
+    def test_a_bare_type_parameter_accepts_any_value(self) -> None:
+        class Box(Magic, tx.Generic[_T], validate=True):
+            item: _T
+
+        assert Box("one").item == "one"
+
+    def test_a_bounded_type_parameter_converts_to_its_bound(self) -> None:
+        class Box(Magic, tx.Generic[_TInt], convert=True):
+            item: _TInt
+
+        assert Box("1").item == 1
+
+    def test_a_bounded_type_parameter_validates_against_its_bound(
+        self
+    ) -> None:
+        class Box(Magic, tx.Generic[_TInt], validate=True):
+            item: _TInt
+
+        assert Box(1).item == 1
+        with pytest.raises(ValidationError):
+            Box("one")
+
+    def test_plain_generic_is_still_refused(self) -> None:
+        # `Generic` itself is not a base you can write; only `Generic[T]`.
+        with pytest.raises(TypeError, match="plain Generic"):
+            class Box(Magic, tx.Generic):
+                item: int

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -3894,11 +3894,11 @@ class GenericBox(Magic, tx.Generic[_T]):
     item: _T
 
 
-class GenericPlain(Magic):
+class PlainBase(Magic):
     a: int
 
 
-class GenericChild(GenericPlain, tx.Generic[_T]):
+class GenericSubclass(PlainBase, tx.Generic[_T]):
     b: _T
 
 
@@ -3923,9 +3923,9 @@ class TestGenericClasses:
         assert box == GenericBox(1)
 
     def test_a_generic_subclass_of_a_plain_class(self) -> None:
-        child = GenericChild(1, "two")
+        child = GenericSubclass(1, "two")
         assert (child.a, child.b) == (1, "two")
-        assert GenericChild.__parameters__ == (_T,)
+        assert GenericSubclass.__parameters__ == (_T,)
 
     def test_a_plain_subclass_of_a_generic_class(self) -> None:
         class Labelled(GenericBox[int]):


### PR DESCRIPTION
Closes #18.

## The bug

A generic Magic class could not be defined at all:

```pycon
>>> class Box(Magic, Generic[T]):
...     item: T
TypeError: Cannot inherit from plain Generic
```

## The cause

Not the class statement — the throwaway class the builder makes to work out inheritance order.

By the time the metaclass runs, `__mro_entries__` has already turned `Generic[T]` into plain `Generic`, and the original tuple has been stashed in the namespace as `__orig_bases__`. `Generic.__init_subclass__` refuses plain `Generic` in `__bases__` *unless* the class carries an `__orig_bases__` showing it was written as `Generic[T]`. The throwaway was built with an empty namespace, so it had neither, and was rejected — before any generation had happened.

It now carries the class's own `__orig_bases__` where there is one. Nothing else needed changing: with the throwaway fixed, the real class is created as written.

Two of them became one, as well. `_make_slots` was building a third throwaway to recompute exactly the ancestor list `__pre_new__` already had, so it takes that list instead — one class construction fewer per class defined.

## What works

Definition and `__parameters__`; the generated `__init__`, `__repr__` and `__eq__`; `Box[int]` and `Box[int](1)`; a generic subclass of a plain Magic base and a plain subclass of `Box[int]`; `slots=True` (`__slots__ == ('item',)` and no instance `__dict__`, since `Generic.__slots__` is empty); `frozen` with `order` and hashing; `mapping=True`; the `@magic` decorator form; `types.new_class`; and pickle, copy and deepcopy of both instances and the `Box[int]` alias. `class Box(Magic, Generic)` is still refused, by Python's own error.

A field annotated with a bare `TypeVar` needed a deliberate answer rather than an accident. The sibling packages already give one: conversion and validation pass an unbound `TypeVar` straight through — there is no type to convert to — and use the bound where there is one, so `Box("1").item` is `1` for `TypeVar("B", bound=int)` and `"1"` for an unbound one. All four cases are pinned in tests rather than special-cased in the builder.

Smoke-tested on 3.10, 3.11 and 3.13. `__orig_bases__` is PEP 560, so the 3.8 floor is safe; no 3.8 interpreter was available locally, and CI covers it.

## Deliberately left alone

**No `TypeVar` substitution.** In `class IntBox(Box[int])` the inherited field's type stays `~T` rather than becoming `int`, so conversion and validation use the `TypeVar` rules there. `dataclasses` and `attrs` behave the same way; resolving it is a feature, not this bug.

**`factory=True` with a bare `TypeVar` recurses forever** — and it is not this package. `TypeVarFactory.__call__` resolves an unbound `TypeVar`'s fallback back to a `TypeVar` and dispatches to itself, reproducible in two lines with no `magic` involved. Filed as bagofseeds/bagof-factories#37.

**The functional API with an unresolved alias.** `MetaMagic("X", (Magic, Generic[T]), ns)` raises CPython's own "type() doesn't support MRO entry resolution; use types.new_class()", before any of our code runs — the same as plain `type()`. `types.new_class` works and is tested.

## Docs

The comparison page's "Generic classes" row is now **yes**, and the gap bullet is gone.

575 passed; ruff and codespell clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_