### PR TITLE
Add replace, asdict, astuple, fields_dict and is_magic

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,28 @@ class Row(Magic, mapping=True):
 {'name': 'ada', 'age': 36}
 ```
 
+**A handful of functions** that work on any Magic class, or on one of its
+instances — `Point` from the top of this page, say:
+
+```pycon
+>>> from bagof.magic import replace, asdict, astuple
+>>> replace(Point(1.0, 2.0), y=20.0)
+Point(x=1.0, y=20.0)
+>>> asdict(Point(1.0, 2.0))
+{'x': 1.0, 'y': 2.0}
+>>> astuple(Point(1.0, 2.0))
+(1.0, 2.0)
+```
+
+`replace` builds the copy by calling the class again, so conversion,
+validation and the init hooks all run on the new values — which is also why it
+works on a frozen class. `asdict` hands the values back exactly as they are
+stored: it does not copy them, and a field holding another object gives you
+that object rather than a dict of its fields.
+
+There is also `fields` and `fields_dict` for the fields themselves, and
+`is_magic` to ask whether a class was built by `Magic` at all.
+
 **Mutable defaults that are not shared.** In a plain class, `x: list = []`
 hands every instance the *same* list. Here each one gets its own:
 

--- a/README.md
+++ b/README.md
@@ -196,9 +196,12 @@ Point(x=1.0, y=20.0)
 
 `replace` builds the copy by calling the class again, so conversion,
 validation and the init hooks all run on the new values — which is also why it
-works on a frozen class. `asdict` hands the values back exactly as they are
-stored: it does not copy them, and a field holding another object gives you
-that object rather than a dict of its fields.
+works on a frozen class. The other side of that: a `__post_init__` which works
+one field out from another works it out again, starting from the value it
+already worked out, so `replace` with no changes at all can come back
+different. `asdict` hands the values back exactly as they are stored: it does
+not copy them, and a field holding another object gives you that object rather
+than a dict of its fields.
 
 There is also `fields` and `fields_dict` for the fields themselves, and
 `is_magic` to ask whether a class was built by `Magic` at all.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -10,4 +10,9 @@ icon: fontawesome/brands/python
         - magic
         - Arguments
         - fields
+        - fields_dict
+        - asdict
+        - astuple
+        - replace
+        - is_magic
         - HIDE_IF_NONE

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -44,8 +44,8 @@ question of what you want the type hints to *do*.
 | Docstring built from the fields | no | no | no | **yes** |
 | | | | | |
 | **Around the edges** | | | | |
-| Copy with changes | `replace` | `evolve` | `model_copy` | *[not yet][parity]* |
-| Convert to a plain `dict` | `asdict` | `asdict` | `model_dump` | *[not yet][parity]* |
+| Copy with changes | `replace` | `evolve` | `model_copy` | **`replace`** |
+| Convert to a plain `dict` | `asdict` | `asdict` | `model_dump` | **`asdict`**, *without recursing* |
 | JSON schema | no | no | yes | no |
 | Generic classes | yes | yes | yes | **yes**, *[without substitution][generics]* |
 | Runtime dependency | none | `attrs` | `pydantic-core` (compiled) | the `bagof` packages |
@@ -229,7 +229,10 @@ Being honest about the gaps, with links to where they are being worked on:
 
 - **JSON schema and serialisation.** Pydantic's real draw, and `magic` has
   neither yet.
-- **Copy-with-changes and `asdict`.** [In progress][parity].
+- **A recursive `asdict`.** `asdict` hands back the values as they are
+  stored, so a field holding another object gives you that object rather
+  than a dict of its fields. The others walk the whole tree, copying
+  lists and dicts as they go.
 - **Type parameters in a generic class.** `class Box(Magic, Generic[T])`
   works, but a subclass that fills the parameter in — `class IntBox(Box[int])`
   — leaves the field's type as `T`, so conversion and validation have nothing
@@ -245,6 +248,5 @@ Being honest about the gaps, with links to where they are being worked on:
 [dataclasses]: https://docs.python.org/3/library/dataclasses.html
 [attrs]: https://www.attrs.org
 [pydantic]: https://docs.pydantic.dev
-[parity]: https://github.com/bagofseeds/bagof-magic/issues/22
 [generics]: https://github.com/bagofseeds/bagof-magic/issues/50
 [typing]: https://github.com/bagofseeds/bagof-magic/issues/30

--- a/src/bagof/magic/_api.py
+++ b/src/bagof/magic/_api.py
@@ -1,12 +1,65 @@
-"""Functions you call on a Magic class or one of its instances."""
+"""
+Functions you call on a Magic class or one of its instances.
+
+Everything here speaks the names the constructor uses. A field can be
+written under one name in the class body and reach `__init__` under
+another -- because it starts with an underscore, or because it was given
+an alias -- and it is that second name these functions use as a key, and
+that `replace` expects its keyword arguments to be named after. It is
+also the name `repr()` shows.
+"""
 from __future__ import annotations
 
 import typing_extensions as tx
 
-from ._constants import _FIELDS
+from ._constants import _FIELDS, MISSING
 from ._fields import Field
 
-__all__ = ["fields"]
+__all__ = [
+    "fields",
+    "fields_dict",
+    "asdict",
+    "astuple",
+    "replace",
+    "is_magic",
+]
+
+
+def _field_table(obj: tx.Any, caller: str) -> tx.Dict[str, Field]:
+    """Every field of an instance's class, pseudo-fields included.
+
+    The lookup goes through `type(obj)` rather than `obj`, so a class
+    handed in by mistake is reported instead of being read as if it were
+    an instance: a class carries the table, its metaclass does not.
+    """
+    cls = type(obj)
+    table = getattr(cls, _FIELDS, None)
+    if table is None:
+        raise TypeError(
+            f"{caller}() needs an instance of a Magic class, and "
+            f"{obj!r} is not one."
+        )
+    return table
+
+
+def _keyed(found: tx.Sequence[Field]) -> tx.Dict[str, Field]:
+    """Key fields by the name they are known by outside the class.
+
+    Two fields can only collide here when neither is a constructor
+    argument: the constructor refuses to be built with a duplicate
+    parameter, so it has already ruled the common case out.
+    """
+    keyed = {}
+    for field in found:
+        name = field.public_name
+        if name in keyed:
+            raise TypeError(
+                f"fields {keyed[name].name!r} and {field.name!r} are both "
+                f"known as {name!r} outside the class, so they cannot both "
+                f"appear under that name. Give one of them its own alias."
+            )
+        keyed[name] = field
+    return keyed
 
 
 def fields(cls: type) -> tx.Tuple[Field]:
@@ -27,3 +80,271 @@ def fields(cls: type) -> tx.Tuple[Field]:
         field for field in getattr(cls, _FIELDS, {}).values()
         if not field.var
     )
+
+
+def fields_dict(cls: type) -> tx.Dict[str, Field]:
+    """
+    Get the fields of a Magic class, keyed by name.
+
+    The same fields `fields` returns, in the same order, keyed by the
+    name each one is known by outside the class -- the name the
+    constructor takes, which for an aliased or underscored field is not
+    the name the class body uses.
+
+    Parameters
+    ----------
+    cls : type
+        The class to get the fields of.
+
+    Returns
+    -------
+    fields : dict[str, Field]
+        All concrete fields (that are not `ClassVar` or `InitVar`).
+
+    !!! example
+        ```pycon
+        >>> class Point(Magic):
+        ...     x: int
+        ...     y: int
+        ...
+        >>> list(fields_dict(Point))
+        ['x', 'y']
+        >>> fields_dict(Point)["x"].type
+        <class 'int'>
+        ```
+    """
+    return _keyed(fields(cls))
+
+
+def asdict(obj: tx.Any) -> tx.Dict[str, tx.Any]:
+    """
+    Get an object's fields as a plain `dict`.
+
+    Values come back exactly as they are stored: nothing is copied,
+    converted, or looked inside. A field holding a list gives you *that*
+    list, and a field holding another Magic object gives you the object
+    itself, not a dict of its fields. If you want a copy, or a nested
+    object turned into a dict too, do it yourself -- that way you decide
+    how deep to go and what to do with the things that are neither.
+
+    Keys are the names the constructor takes, which for an aliased or
+    underscored field is not the name the class body uses.
+
+    Parameters
+    ----------
+    obj : Magic
+        An instance of a Magic class.
+
+    Returns
+    -------
+    values : dict[str, any]
+        Every concrete field (not `ClassVar` or `InitVar`), in field
+        order.
+
+    !!! example
+        ```pycon
+        >>> class Point(Magic):
+        ...     x: int
+        ...     y: int
+        ...
+        >>> asdict(Point(1, 2))
+        {'x': 1, 'y': 2}
+        ```
+
+    !!! example "A nested object is left alone"
+        ```pycon
+        >>> class Point(Magic):
+        ...     x: int
+        ...     y: int
+        ...
+        >>> class Line(Magic):
+        ...     start: Point
+        ...     end: Point
+        ...
+        >>> asdict(Line(Point(0, 0), Point(1, 2)))
+        {'start': Point(x=0, y=0), 'end': Point(x=1, y=2)}
+        ```
+
+    !!! note "Not the same as `dict(obj)`"
+        A class written with `mapping=True` can be passed to `dict`
+        directly, and that covers the fields marked as keys, under the
+        key names they were given. `asdict` always covers every field.
+
+        ```pycon
+        >>> class Row(Magic, mapping=True):
+        ...     name: str
+        ...     age: NotKey[int]
+        ...
+        >>> dict(Row("ada", 36))
+        {'name': 'ada'}
+        >>> asdict(Row("ada", 36))
+        {'name': 'ada', 'age': 36}
+        ```
+    """
+    table = _field_table(obj, "asdict")
+    keyed = _keyed([field for field in table.values() if not field.var])
+    return {
+        name: getattr(obj, field.name) for name, field in keyed.items()
+    }
+
+
+def astuple(obj: tx.Any) -> tx.Tuple[tx.Any, ...]:
+    """
+    Get an object's field values as a tuple, in field order.
+
+    Values come back exactly as they are stored, the same way `asdict`
+    returns them: nothing is copied, converted, or looked inside.
+
+    Parameters
+    ----------
+    obj : Magic
+        An instance of a Magic class.
+
+    Returns
+    -------
+    values : tuple
+        The value of every concrete field (not `ClassVar` or `InitVar`),
+        in field order.
+
+    !!! example
+        ```pycon
+        >>> class Point(Magic):
+        ...     x: int
+        ...     y: int
+        ...
+        >>> astuple(Point(1, 2))
+        (1, 2)
+        ```
+    """
+    table = _field_table(obj, "astuple")
+    return tuple(
+        getattr(obj, field.name)
+        for field in table.values() if not field.var
+    )
+
+
+# From Python 3.13 `copy.replace(obj, **changes)` calls
+# `type(obj).__replace__(obj, **changes)`, which is the signature this
+# function already has -- so hooking it up is one assignment. It is not
+# done here because `Magic.__replace__ = replace` would only reach the
+# classes that inherit from `Magic`, and miss the ones the `magic`
+# decorator builds; the method belongs with the other generated ones.
+def replace(obj: tx.Any, **changes: tx.Any) -> tx.Any:
+    """
+    Copy an object, changing some of its values.
+
+    The copy is built by calling the class again, so conversion,
+    validation and the `__pre_init__` / `__post_init__` hooks all run on
+    the way in: a replaced value is checked exactly as an original one
+    is. Anything you do not mention is carried over unchanged. It works
+    on a frozen class, which is where it is most useful.
+
+    Name each change after the argument the constructor takes, which for
+    an aliased or underscored field is not the name the class body uses.
+
+    Parameters
+    ----------
+    obj : Magic
+        An instance of a Magic class.
+    **changes : any
+        New values, by constructor argument name.
+
+    Returns
+    -------
+    copy : Magic
+        A new instance of the same class.
+
+    Raises
+    ------
+    TypeError
+        If `obj` is not an instance of a Magic class; if a change names
+        something the constructor does not take; or if the class has an
+        `InitVar` with no default and no value was given for it.
+
+    !!! example
+        ```pycon
+        >>> class Point(Magic, frozen=True):
+        ...     x: int
+        ...     y: int
+        ...
+        >>> replace(Point(1, 2), y=20)
+        Point(x=1, y=20)
+        ```
+
+    !!! note "Two kinds of field cannot be carried over"
+        A field written as `NoInit[...]` is not a constructor argument,
+        so the copy gets whatever the class gives it rather than the
+        value `obj` holds. An `InitVar` is passed in and not kept, so
+        there is nothing to read back off `obj`: give it again, or leave
+        it to its default.
+    """
+    table = _field_table(obj, "replace")
+    given, values = dict(changes), {}
+    for field in table.values():
+        name = field.public_name
+        if not field.init:
+            if name in given:
+                raise TypeError(
+                    f"{type(obj).__name__} does not take {name!r} when it "
+                    f"is built, so replace() has no way to set it."
+                )
+            continue
+        if name in given:
+            values[name] = given.pop(name)
+        elif not field.var:
+            values[name] = getattr(obj, field.name)
+        elif field.default is MISSING and not field.factory:
+            # An InitVar is used during construction and not stored, so
+            # a required one has to be given again every time.
+            raise TypeError(
+                f"{type(obj).__name__} needs {name!r} to be built and does "
+                f"not keep it afterwards, so replace() cannot reuse the "
+                f"one it was built with: pass {name}= as well."
+            )
+    if given:
+        named = ", ".join(repr(name) for name in given)
+        raise TypeError(
+            f"{type(obj).__name__} has no field named {named}."
+        )
+    return type(obj)(**values)
+
+
+def is_magic(obj: tx.Any) -> bool:
+    """
+    Say whether something was built by `Magic`.
+
+    Answers for a class or for one of its instances, and for a class
+    built either way -- by inheriting from `Magic`, or by decorating a
+    plain class with `magic`.
+
+    Parameters
+    ----------
+    obj : any
+        A class, or any object at all.
+
+    Returns
+    -------
+    is_magic : bool
+        Whether the class, or the object's class, is a Magic class.
+
+    !!! example
+        ```pycon
+        >>> class Point(Magic):
+        ...     x: int
+        ...
+        >>> is_magic(Point), is_magic(Point(1))
+        (True, True)
+        >>> is_magic(int), is_magic(3)
+        (False, False)
+        ```
+    """
+    cls = obj if isinstance(obj, type) else type(obj)
+    # The question is whether the class carries the table of fields the
+    # builder writes, which is what every generated method reads. Two
+    # shorter tests answer a different question: `issubclass(cls, Magic)`
+    # says no for a class built by the `magic` decorator, which gains the
+    # fields and the generated methods without gaining `Magic` as a base;
+    # and `isinstance(obj, Magic)` says no for every class, since a class
+    # is not an instance of its own base. Reducing an instance to its
+    # class first is what lets one check cover both shapes.
+    return getattr(cls, _FIELDS, None) is not None

--- a/src/bagof/magic/_api.py
+++ b/src/bagof/magic/_api.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import typing_extensions as tx
 
-from ._constants import _FIELDS, MISSING
+from ._constants import _FIELDS, MISSING, _HasFactory
 from ._fields import Field
 
 __all__ = [
@@ -42,12 +42,13 @@ def _field_table(obj: tx.Any, caller: str) -> tx.Dict[str, Field]:
     return table
 
 
-def _keyed(found: tx.Sequence[Field]) -> tx.Dict[str, Field]:
+def _keyed(found: tx.Iterable[Field]) -> tx.Dict[str, Field]:
     """Key fields by the name they are known by outside the class.
 
-    Two fields can only collide here when neither is a constructor
-    argument: the constructor refuses to be built with a duplicate
-    parameter, so it has already ruled the common case out.
+    At most one of a colliding pair can be a constructor parameter: the
+    constructor refuses to be built with two parameters of one name. It
+    says nothing about a field that is not a parameter, though, so a
+    pair with one of each still reaches here.
     """
     keyed = {}
     for field in found:
@@ -60,6 +61,36 @@ def _keyed(found: tx.Sequence[Field]) -> tx.Dict[str, Field]:
             )
         keyed[name] = field
     return keyed
+
+
+def _is_parameter(field: Field) -> bool:
+    """Whether the constructor takes this field as an argument.
+
+    A field is left out of the signature when it opts out of `__init__`,
+    and also when it can be passed neither by position nor by name.
+    """
+    return bool(field.init and (field.positional or field.kw))
+
+
+def _value(obj: tx.Any, field: Field, caller: str) -> tx.Any:
+    """The value a field holds, or a written error if it holds none."""
+    try:
+        return getattr(obj, field.name)
+    except AttributeError:
+        # A field that is not a constructor argument and has no default
+        # is only ever set by hand, so an object can be perfectly usable
+        # and still have nothing under this name.
+        raise AttributeError(
+            f"{type(obj).__name__}.{field.name} has never been given a "
+            f"value, so {caller}() has nothing to report for it. Give the "
+            f"field a default, or set it in __post_init__."
+        ) from None
+
+
+def _concrete(obj: tx.Any, caller: str) -> tx.Dict[str, Field]:
+    """An instance's real fields, keyed by their outside name."""
+    table = _field_table(obj, caller)
+    return _keyed(field for field in table.values() if not field.var)
 
 
 def fields(cls: type) -> tx.Tuple[Field]:
@@ -100,6 +131,9 @@ def fields_dict(cls: type) -> tx.Dict[str, Field]:
     -------
     fields : dict[str, Field]
         All concrete fields (that are not `ClassVar` or `InitVar`).
+        A class that `Magic` never built simply has none, so the answer
+        is an empty dict -- the same as `fields` gives. `asdict`,
+        `astuple` and `replace` need a real instance and say so instead.
 
     !!! example
         ```pycon
@@ -141,6 +175,13 @@ def asdict(obj: tx.Any) -> tx.Dict[str, tx.Any]:
         Every concrete field (not `ClassVar` or `InitVar`), in field
         order.
 
+    Raises
+    ------
+    AttributeError
+        If a field has never been given a value. A field the
+        constructor does not take, with no default, is only set if
+        something sets it by hand.
+
     !!! example
         ```pycon
         >>> class Point(Magic):
@@ -181,10 +222,9 @@ def asdict(obj: tx.Any) -> tx.Dict[str, tx.Any]:
         {'name': 'ada', 'age': 36}
         ```
     """
-    table = _field_table(obj, "asdict")
-    keyed = _keyed([field for field in table.values() if not field.var])
     return {
-        name: getattr(obj, field.name) for name, field in keyed.items()
+        name: _value(obj, field, "asdict")
+        for name, field in _concrete(obj, "asdict").items()
     }
 
 
@@ -206,6 +246,11 @@ def astuple(obj: tx.Any) -> tx.Tuple[tx.Any, ...]:
         The value of every concrete field (not `ClassVar` or `InitVar`),
         in field order.
 
+    Raises
+    ------
+    AttributeError
+        If a field has never been given a value, as for `asdict`.
+
     !!! example
         ```pycon
         >>> class Point(Magic):
@@ -216,10 +261,12 @@ def astuple(obj: tx.Any) -> tx.Tuple[tx.Any, ...]:
         (1, 2)
         ```
     """
-    table = _field_table(obj, "astuple")
+    # The same fields `asdict` reports, worked out the same way: a class
+    # whose fields cannot be told apart by name is refused by both,
+    # rather than answering a tuple here and an error there.
     return tuple(
-        getattr(obj, field.name)
-        for field in table.values() if not field.var
+        _value(obj, field, "astuple")
+        for field in _concrete(obj, "astuple").values()
     )
 
 
@@ -277,36 +324,80 @@ def replace(obj: tx.Any, **changes: tx.Any) -> tx.Any:
         value `obj` holds. An `InitVar` is passed in and not kept, so
         there is nothing to read back off `obj`: give it again, or leave
         it to its default.
+
+    !!! warning "A `__post_init__` that derives a field runs again"
+        The copy starts from the values as they are *stored*, so a hook
+        that works one field out from another works it out a second
+        time -- from the already worked-out value. `replace` with no
+        changes at all can then come back different:
+
+        ```pycon
+        >>> class Priced(Magic):
+        ...     total: float
+        ...     vat: InitVar[float] = 0.2
+        ...
+        ...     def __post_init__(self, arguments):
+        ...         self.total = self.total * (1 + arguments.vat)
+        ...
+        >>> order = Priced(100.0)
+        >>> order
+        Priced(total=120.0)
+        >>> replace(order)
+        Priced(total=144.0)
+        ```
+
+        A hook that only checks its arguments, or that fills in a field
+        the constructor does not take, is unaffected.
     """
-    table = _field_table(obj, "replace")
-    given, values = dict(changes), {}
-    for field in table.values():
-        name = field.public_name
-        if not field.init:
+    cls = type(obj)
+    # Every field, pseudo-fields included: a change has to be turned
+    # down by name whether or not the name belongs to a real field, and
+    # a class that cannot tell two of its fields apart cannot say which
+    # one a change was meant for.
+    keyed = _keyed(_field_table(obj, "replace").values())
+    given, arguments = dict(changes), []
+    for name, field in keyed.items():
+        if not _is_parameter(field):
             if name in given:
                 raise TypeError(
-                    f"{type(obj).__name__} does not take {name!r} when it "
-                    f"is built, so replace() has no way to set it."
+                    f"{cls.__name__} does not take {name!r} when it is "
+                    f"built, so replace() has no way to set it."
                 )
             continue
         if name in given:
-            values[name] = given.pop(name)
+            value = given.pop(name)
         elif not field.var:
-            values[name] = getattr(obj, field.name)
-        elif field.default is MISSING and not field.factory:
+            value = _value(obj, field, "replace")
+        elif field.factory:
             # An InitVar is used during construction and not stored, so
-            # a required one has to be given again every time.
+            # there is nothing to carry over: its default stands in.
+            # The constructor resolves a factory itself, and this is
+            # what it would have been handed.
+            value = _HasFactory(field.factory)
+        elif field.default is not MISSING:
+            value = field.default
+        else:
             raise TypeError(
-                f"{type(obj).__name__} needs {name!r} to be built and does "
-                f"not keep it afterwards, so replace() cannot reuse the "
-                f"one it was built with: pass {name}= as well."
+                f"{cls.__name__} needs {name!r} to be built and does not "
+                f"keep it afterwards, so replace() cannot reuse the one it "
+                f"was built with: pass {name}= as well."
             )
+        arguments.append((field, value))
     if given:
         named = ", ".join(repr(name) for name in given)
-        raise TypeError(
-            f"{type(obj).__name__} has no field named {named}."
-        )
-    return type(obj)(**values)
+        raise TypeError(f"{cls.__name__} has no field named {named}.")
+    # A positional-only field cannot be named and a keyword-only one
+    # cannot be counted off, so each value goes back the way its own
+    # field is allowed to be passed. Positional-only fields come first
+    # in the signature, in field order, which is the order they were
+    # collected in.
+    positional, keyword = [], {}
+    for field, value in arguments:
+        if field.positional and not field.kw:
+            positional.append(value)
+        else:
+            keyword[field.public_name] = value
+    return cls(*positional, **keyword)
 
 
 def is_magic(obj: tx.Any) -> bool:

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -3995,3 +3995,324 @@ class TestGenericClasses:
         with pytest.raises(TypeError, match="plain Generic"):
             class Box(Magic, tx.Generic):
                 item: int
+
+
+# ======================================================================
+# replace / asdict / astuple / fields_dict / is_magic
+# ======================================================================
+
+
+class TestParityHelpers:
+    """The functions that work on a built class or one of its instances."""
+
+    # -- replace -------------------------------------------------------
+
+    def test_replace_changes_one_value_and_keeps_the_rest(self) -> None:
+        class Point(Magic):
+            x: int
+            y: int
+
+        assert _api.replace(Point(1, 2), y=20) == Point(1, 20)
+
+    def test_replace_works_on_a_frozen_class(self) -> None:
+        class Point(Magic, frozen=True):
+            x: int
+            y: int
+
+        original = Point(1, 2)
+        assert _api.replace(original, x=10) == Point(10, 2)
+        # The original is untouched: a copy was built, not mutated.
+        assert original == Point(1, 2)
+
+    def test_replace_converts_the_new_value(self) -> None:
+        class Conv(Magic, convert=True):
+            n: int
+
+        assert _api.replace(Conv(1), n="5").n == 5
+
+    def test_replace_validates_the_new_value(self) -> None:
+        class Check(Magic, validate=True):
+            n: int
+
+        with pytest.raises(ValidationError):
+            _api.replace(Check(1), n="five")
+
+    def test_replace_runs_post_init(self) -> None:
+        class Doubled(Magic):
+            n: int
+
+            def __post_init__(self) -> None:
+                object.__setattr__(self, "n", self.n * 2)
+
+        assert Doubled(3).n == 6
+        assert _api.replace(Doubled(3), n=5).n == 10
+
+    def test_replace_names_changes_after_the_constructor(self) -> None:
+        class Account(Magic):
+            _id: Annotated[int, Field(alias="id")]
+
+        account = _api.replace(Account(1), id=2)
+        assert account._id == 2
+        with pytest.raises(TypeError, match="no field named '_id'"):
+            _api.replace(Account(1), _id=2)
+
+    def test_replace_rejects_a_name_that_is_not_a_field(self) -> None:
+        class Point(Magic):
+            x: int
+
+        with pytest.raises(TypeError, match="no field named 'z'"):
+            _api.replace(Point(1), z=2)
+
+    def test_replace_rejects_a_field_the_constructor_does_not_take(
+        self
+    ) -> None:
+        class Cached(Magic):
+            x: int
+            seen: NoInit[int] = 0
+
+        with pytest.raises(TypeError, match="does not take 'seen'"):
+            _api.replace(Cached(1), seen=5)
+
+    def test_replace_does_not_carry_over_a_non_init_field(self) -> None:
+        # It is not a constructor argument, so there is no way to hand it
+        # across: the copy gets whatever the class gives it.
+        class Cached(Magic):
+            x: int
+            seen: NoInit[int] = 0
+
+        original = Cached(1)
+        object.__setattr__(original, "seen", 99)
+        assert _api.replace(original, x=2).seen == 0
+
+    def test_replace_rejects_a_class_var(self) -> None:
+        class Counted(Magic):
+            x: int
+            unit: ClassVar[str] = "clicks"
+
+        with pytest.raises(TypeError, match="does not take 'unit'"):
+            _api.replace(Counted(1), unit="taps")
+
+    def test_replace_needs_an_init_var_that_has_no_default(self) -> None:
+        class Shifted(Magic):
+            x: int
+            by: InitVar[int]
+
+            def __post_init__(self, arguments: Arguments) -> None:
+                object.__setattr__(self, "x", self.x + arguments.by)
+
+        shifted = Shifted(1, by=2)
+        assert shifted.x == 3
+        with pytest.raises(TypeError, match="pass by= as well"):
+            _api.replace(shifted, x=10)
+        assert _api.replace(shifted, x=10, by=5).x == 15
+
+    def test_replace_lets_a_defaulted_init_var_default_again(self) -> None:
+        class Scaled(Magic):
+            size: float
+            scale: InitVar[float] = 1.0
+
+            def __post_init__(self, arguments: Arguments) -> None:
+                object.__setattr__(self, "size", self.size * arguments.scale)
+
+        scaled = Scaled(2.0, scale=3.0)
+        assert scaled.size == 6.0
+        assert _api.replace(scaled).size == 6.0
+        assert _api.replace(scaled, scale=2.0).size == 12.0
+
+    def test_replace_needs_an_instance(self) -> None:
+        class Point(Magic):
+            x: int
+
+        with pytest.raises(TypeError, match="needs an instance"):
+            _api.replace(Point, x=1)
+        with pytest.raises(TypeError, match="needs an instance"):
+            _api.replace(object())
+
+    # -- asdict --------------------------------------------------------
+
+    def test_asdict_returns_every_field_in_order(self) -> None:
+        class Point(Magic):
+            x: int
+            y: int
+
+        assert _api.asdict(Point(1, 2)) == {"x": 1, "y": 2}
+        assert list(_api.asdict(Point(1, 2))) == ["x", "y"]
+
+    def test_asdict_does_not_recurse_or_copy(self) -> None:
+        class Inner(Magic):
+            n: int
+
+        class Outer(Magic):
+            inner: Inner
+            items: list
+
+        items = [1, 2]
+        outer = Outer(Inner(1), items)
+        assert _api.asdict(outer) == {"inner": Inner(1), "items": [1, 2]}
+        assert isinstance(_api.asdict(outer)["inner"], Inner)
+        assert _api.asdict(outer)["items"] is items
+
+    def test_asdict_keys_by_the_constructor_name(self) -> None:
+        class Account(Magic):
+            _id: Annotated[int, Field(alias="id")]
+            _tag: str
+
+        assert _api.asdict(Account(1, "a")) == {"id": 1, "tag": "a"}
+
+    def test_asdict_skips_pseudo_fields(self) -> None:
+        class Shifted(Magic):
+            x: int
+            unit: ClassVar[str] = "m"
+            by: InitVar[int] = 0
+
+        assert _api.asdict(Shifted(1)) == {"x": 1}
+
+    def test_asdict_covers_more_than_dict(self) -> None:
+        # The dict-like interface is about the fields marked as keys;
+        # asdict is about all of them.
+        class Row(Magic, mapping=True):
+            name: str
+            age: Annotated[int, Field(key=False)]
+
+        row = Row("ada", 36)
+        assert dict(row) == {"name": "ada"}
+        assert _api.asdict(row) == {"name": "ada", "age": 36}
+
+    def test_asdict_needs_an_instance(self) -> None:
+        with pytest.raises(TypeError, match="needs an instance"):
+            _api.asdict(object())
+
+    # -- astuple -------------------------------------------------------
+
+    def test_astuple_returns_the_values_in_field_order(self) -> None:
+        class Point(Magic):
+            x: int
+            y: int
+
+        assert _api.astuple(Point(1, 2)) == (1, 2)
+
+    def test_astuple_follows_the_reverse_option(self) -> None:
+        class Base(Magic, reverse=True):
+            a: int
+
+        class Derived(Base):
+            b: int
+
+        assert [f.name for f in _api.fields(Derived)] == ["b", "a"]
+        assert _api.astuple(Derived(1, 2)) == (1, 2)
+        assert _api.asdict(Derived(1, 2)) == {"b": 1, "a": 2}
+
+    def test_astuple_does_not_recurse_or_copy(self) -> None:
+        class Inner(Magic):
+            n: int
+
+        class Outer(Magic):
+            inner: Inner
+
+        inner = Inner(1)
+        assert _api.astuple(Outer(inner)) == (inner,)
+        assert _api.astuple(Outer(inner))[0] is inner
+
+    def test_astuple_skips_pseudo_fields(self) -> None:
+        class Shifted(Magic):
+            x: int
+            unit: ClassVar[str] = "m"
+            by: InitVar[int] = 0
+
+        assert _api.astuple(Shifted(1)) == (1,)
+
+    def test_astuple_needs_an_instance(self) -> None:
+        with pytest.raises(TypeError, match="needs an instance"):
+            _api.astuple(object())
+
+    # -- fields_dict ---------------------------------------------------
+
+    def test_fields_dict_is_the_mapping_form_of_fields(self) -> None:
+        class Point(Magic):
+            x: int
+            y: int
+
+        found = _api.fields_dict(Point)
+        assert list(found) == ["x", "y"]
+        assert tuple(found.values()) == _api.fields(Point)
+
+    def test_fields_dict_keys_by_the_constructor_name(self) -> None:
+        class Account(Magic):
+            _id: Annotated[int, Field(alias="id")]
+
+        found = _api.fields_dict(Account)
+        assert list(found) == ["id"]
+        assert found["id"].name == "_id"
+
+    def test_fields_dict_skips_pseudo_fields(self) -> None:
+        class Shifted(Magic):
+            x: int
+            unit: ClassVar[str] = "m"
+            by: InitVar[int] = 0
+
+        assert list(_api.fields_dict(Shifted)) == ["x"]
+
+    def test_fields_dict_of_a_plain_class_is_empty(self) -> None:
+        # The same answer `fields` gives, for the same reason: a class
+        # that was never built has no fields to report.
+        class Plain:
+            x: int
+
+        assert _api.fields_dict(Plain) == {}
+
+    def test_two_fields_under_one_public_name_are_rejected(self) -> None:
+        # Only reachable when neither is a constructor argument: the
+        # constructor refuses to be built with a duplicate parameter.
+        class Clash(Magic):
+            x: NoInit[int] = 1
+            _x: int = 2
+
+        with pytest.raises(TypeError, match="both known as 'x'"):
+            _api.fields_dict(Clash)
+        with pytest.raises(TypeError, match="both known as 'x'"):
+            _api.asdict(Clash(5))
+
+    # -- is_magic ------------------------------------------------------
+
+    def test_is_magic_on_every_shape(self) -> None:
+        class Point(Magic):
+            x: int
+
+        class Sub(Point):
+            y: int
+
+        @magic
+        class Decorated:
+            x: int
+
+        class Plain:
+            x: int
+
+        assert _api.is_magic(Point) and _api.is_magic(Point(1))
+        assert _api.is_magic(Sub) and _api.is_magic(Sub(1, 2))
+        assert _api.is_magic(Decorated) and _api.is_magic(Decorated(1))
+        assert _api.is_magic(Magic)
+        assert not _api.is_magic(Plain)
+        assert not _api.is_magic(Plain())
+        assert not _api.is_magic(int)
+        assert not _api.is_magic(3)
+
+    def test_is_magic_is_not_inheritance_from_magic(self) -> None:
+        # A decorated class gets the fields and the generated methods
+        # without gaining `Magic` as a base.
+        @magic
+        class Decorated:
+            x: int
+
+        assert not issubclass(Decorated, Magic)
+        assert _api.is_magic(Decorated)
+
+    # -- the public face -----------------------------------------------
+
+    def test_every_helper_is_exported(self) -> None:
+        import bagof.magic as package
+
+        for name in ("fields", "fields_dict", "asdict", "astuple",
+                     "replace", "is_magic"):
+            assert name in package.__all__
+            assert getattr(package, name) is getattr(_api, name)

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -4261,16 +4261,38 @@ class TestParityHelpers:
         assert _api.fields_dict(Plain) == {}
 
     def test_two_fields_under_one_public_name_are_rejected(self) -> None:
-        # Only reachable when neither is a constructor argument: the
-        # constructor refuses to be built with a duplicate parameter.
+        # At most one of the two can be a constructor parameter -- here
+        # `_x` is, under the name `x` -- because the constructor refuses
+        # to be built with two parameters of one name. It says nothing
+        # about `x` itself, which is not a parameter at all.
         class Clash(Magic):
             x: NoInit[int] = 1
             _x: int = 2
 
-        with pytest.raises(TypeError, match="both known as 'x'"):
-            _api.fields_dict(Clash)
-        with pytest.raises(TypeError, match="both known as 'x'"):
-            _api.asdict(Clash(5))
+        for call in (
+            lambda: _api.fields_dict(Clash),
+            lambda: _api.asdict(Clash(5)),
+            lambda: _api.astuple(Clash(5)),
+            lambda: _api.replace(Clash(5), x=6),
+        ):
+            with pytest.raises(TypeError, match="both known as 'x'"):
+                call()
+
+    def test_an_alias_can_collide_with_a_plain_field(self) -> None:
+        # No underscore in sight: an alias lands on the name another
+        # field already has.
+        class Coll(Magic):
+            a: Annotated[int, Field(alias="b")] = 1
+            b: NoInit[int] = 2
+
+        for call in (
+            lambda: _api.fields_dict(Coll),
+            lambda: _api.asdict(Coll(1)),
+            lambda: _api.astuple(Coll(1)),
+            lambda: _api.replace(Coll(1), b=9),
+        ):
+            with pytest.raises(TypeError, match="both known as 'b'"):
+                call()
 
     # -- is_magic ------------------------------------------------------
 
@@ -4306,6 +4328,121 @@ class TestParityHelpers:
 
         assert not issubclass(Decorated, Magic)
         assert _api.is_magic(Decorated)
+
+    # -- how each value is passed back ---------------------------------
+
+    def test_replace_with_a_positional_only_field(self) -> None:
+        # A positional-only parameter cannot be passed by name, so the
+        # copy has to count it off instead.
+        class P(Magic):
+            a: PositionalOnly[int] = 1
+            b: int = 2
+
+        assert _api.replace(P(7, 8), b=9) == P(7, 9)
+        assert _api.replace(P(7, 8), a=0) == P(0, 8)
+
+    def test_replace_on_a_positional_only_class(self) -> None:
+        class PO(Magic, positional_only=True):
+            x: int
+            y: int
+
+        assert _api.replace(PO(1, 2), y=3) == PO(1, 3)
+
+    def test_replace_with_every_kind_of_parameter(self) -> None:
+        class Mix(Magic):
+            a: PositionalOnly[int]
+            b: int
+            c: KwOnly[int] = 3
+
+        mixed = Mix(1, 2, c=4)
+        assert _api.replace(mixed, b=20) == Mix(1, 20, c=4)
+        assert _api.replace(mixed, a=9, c=5) == Mix(9, 2, c=5)
+
+    def test_replace_keeps_positional_only_arguments_lined_up(self) -> None:
+        # A defaulted InitVar sits between two positional-only fields.
+        # Leaving it out would shift every value after it along by one,
+        # so its default is passed in its place.
+        class Mid(Magic, positional_only=True):
+            seed: InitVar[int] = 1
+            value: int = 2
+
+            def __post_init__(self, arguments: Arguments) -> None:
+                object.__setattr__(self, "value", self.value + arguments.seed)
+
+        assert Mid(7, 8).value == 15
+        assert _api.replace(Mid(7, 8)).value == 16
+
+    def test_replace_hands_an_init_var_factory_back_to_the_class(
+        self
+    ) -> None:
+        class Seeded(Magic):
+            n: int = 0
+            extra: Annotated[list, Field(var=True, init=True, factory=list)]
+
+            def __post_init__(self, arguments: Arguments) -> None:
+                object.__setattr__(self, "n", self.n + len(arguments.extra))
+
+        assert Seeded(5).n == 5
+        assert _api.replace(Seeded(5), n=7).n == 7
+
+    def test_replace_rejects_a_field_that_is_no_kind_of_argument(
+        self
+    ) -> None:
+        # Neither by position nor by name leaves it out of the
+        # signature altogether, the same as opting out of `__init__`.
+        class Neither(Magic):
+            x: Annotated[int, Field(kw=False, positional=False)] = 5
+
+        assert _api.replace(Neither()) == Neither()
+        with pytest.raises(TypeError, match="does not take 'x'"):
+            _api.replace(Neither(), x=1)
+
+    # -- the sharp edges -----------------------------------------------
+
+    def test_replace_reruns_a_post_init_that_derives_a_field(self) -> None:
+        # The copy starts from the stored value, which the hook has
+        # already worked on, so it works on it again. Documented rather
+        # than papered over: there is no way to tell a derived value
+        # from an original one.
+        class Post(Magic):
+            x: int = 1
+            scale: InitVar[int] = 10
+
+            def __post_init__(self, arguments: Arguments) -> None:
+                object.__setattr__(self, "x", self.x * arguments.scale)
+
+        post = Post(5)
+        assert post.x == 50
+        assert _api.replace(post).x == 500
+        assert _api.replace(post, scale=1).x == 50
+
+    def test_an_unset_field_is_reported_not_leaked(self) -> None:
+        class Lazy(Magic):
+            a: int = 1
+            b: Annotated[int, Field(init=False, repr=False)]
+
+        lazy = Lazy()
+        assert lazy.a == 1
+        for call in (lambda: _api.asdict(lazy), lambda: _api.astuple(lazy)):
+            with pytest.raises(
+                AttributeError, match="Lazy.b has never been given a value"
+            ):
+                call()
+
+    def test_an_unset_field_is_reported_by_replace_too(self) -> None:
+        # Reachable through a hand-written `__init__` that leaves a
+        # constructor argument unassigned.
+        class Half(Magic, init=False):
+            a: int
+            b: int
+
+            def __init__(self, a: int) -> None:
+                object.__setattr__(self, "a", a)
+
+        with pytest.raises(
+            AttributeError, match="Half.b has never been given a value"
+        ):
+            _api.replace(Half(1), a=2)
 
     # -- the public face -----------------------------------------------
 


### PR DESCRIPTION
Closes #22 — the helpers, on the layout #51 settled. All five live in `_api.py`.

## What they do

```pycon
>>> p = Point(1, 2)
>>> asdict(p)
{'x': 1, 'y': 2}
>>> astuple(p)
(1, 2)
>>> replace(p, y=9)
Point(x=1, y=9)
>>> is_magic(Point), is_magic(p), is_magic(int)
(True, True, False)
```

`replace` goes back through `__init__`, so conversion, validation and the init hooks all run — a replaced value is as checked as an original one. On a `convert=True` class, `replace(p, y="9")` gives you an `int`.

## The decisions

**Everything is keyed by the public name** — the name the constructor takes, not the class-body name. `replace` has no choice, since it forwards to `__init__`, and it is what `__repr__` already prints. So `type(obj)(**asdict(obj))` round-trips for a class whose fields are all constructor arguments.

**`asdict` returns stored values verbatim** — no recursion, no copying, no conversion of a nested Magic instance, as you decided. Someone coming from `dataclasses.asdict` will expect recursion, so the docstring says so with a nested example, and the comparison table reads `**asdict**, *without recursing*` rather than a bare yes.

A second docstring note contrasts it with `dict(obj)` on a `mapping=True` class, since the two look interchangeable and are not: that view uses the fields marked as keys under their key names, this uses every field.

**`replace` refuses rather than silently doing nothing.** A field the constructor does not take (`NoInit`, `ClassVar`) raises if you name it in the changes, and is not carried over otherwise — accepting a change that has no effect is worse than refusing it. A required `InitVar` raises telling you to pass it, since the value was consumed during construction and never stored. An unknown name is reported by `replace` itself rather than by the generated `__init__`, whose `TypeError` would name `__magic_init__`.

**`is_magic` looks for the field table the builder writes**, and a code comment records why the two obvious alternatives are wrong: `issubclass(obj, Magic)` says no for a class built by the `@magic` decorator, which gains the fields and methods but not the base, and `isinstance(obj, Magic)` says no for every class.

**Strictness splits deliberately.** `fields`/`fields_dict` keep the lenient empty answer for a class that was never built; `asdict`/`astuple`/`replace` raise, because `{}` or `()` for an arbitrary object would be silently wrong.

**`copy.replace` (3.13+)** is genuinely a one-liner — `replace(obj, **changes)` is exactly the `__replace__` signature — but it is not wired up here: `Magic.__replace__ = replace` reaches only classes that inherit from `Magic` and misses every decorated one, so it belongs in the builder's generated-method namespace. Recorded as a comment above `replace`.

## Two bugs found on the way, filed not fixed

**#52** — two fields sharing one public name print the same key twice (`Clash(x=1, x=5)`). The existing duplicate check only sees fields that are constructor parameters, so a `NoInit` field slips past it. `_keyed` raises here rather than silently dropping one, but `__repr__` still lies.

**#53** — `ClassVar` and `InitVar` leak into the dict-like view, because `mapping`'s field selection is missing the `not f.var` filter every other accessor has. A required `InitVar` makes `dict(obj)` raise outright.

614 passed; ruff and codespell clean; `_api.py` at 100% statement coverage.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_