### PR TITLE
Refuse a shared public name, and keep pseudo-fields out of the dict view

### DIFF
--- a/src/bagof/magic/_api.py
+++ b/src/bagof/magic/_api.py
@@ -45,22 +45,11 @@ def _field_table(obj: tx.Any, caller: str) -> tx.Dict[str, Field]:
 def _keyed(found: tx.Iterable[Field]) -> tx.Dict[str, Field]:
     """Key fields by the name they are known by outside the class.
 
-    At most one of a colliding pair can be a constructor parameter: the
-    constructor refuses to be built with two parameters of one name. It
-    says nothing about a field that is not a parameter, though, so a
-    pair with one of each still reaches here.
+    One name reaches one field: a class with two fields under a single
+    outside name is refused when it is built, so the keys here never
+    collide.
     """
-    keyed = {}
-    for field in found:
-        name = field.public_name
-        if name in keyed:
-            raise TypeError(
-                f"fields {keyed[name].name!r} and {field.name!r} are both "
-                f"known as {name!r} outside the class, so they cannot both "
-                f"appear under that name. Give one of them its own alias."
-            )
-        keyed[name] = field
-    return keyed
+    return {field.public_name: field for field in found}
 
 
 def _is_parameter(field: Field) -> bool:

--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -1403,7 +1403,14 @@ def __pre_new__(
     real_fields = {name: f for name, f in fields.items() if not f.var}
 
     if options.mapping:
-        dict_fields = {f.public_key: f for f in fields.values() if f.key}
+        # Only real fields: a `ClassVar` belongs to the class and an
+        # `InitVar` is a constructor argument, so neither is part of the
+        # data and neither is stored on the instance. Reading one back
+        # off an instance answers with the class attribute, or with
+        # nothing at all.
+        dict_fields = {
+            f.public_key: f for f in real_fields.values() if f.key
+        }
         for name, func in _make_mapping(qualname, dict_fields).items():
             namespace.setdefault(name, func)
         Mapping = _abc.Mapping if options.frozen else _abc.MutableMapping

--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -306,6 +306,32 @@ def _add_fields(
             fields.setdefault(name, old_field)
 
 
+def _check_public_names(clsname: str, fields: dict[str, Field]) -> None:
+    # Two fields cannot answer to one outside name.
+    #
+    # A field is known outside the class by its alias, or by its own name
+    # with any leading underscore removed. That one name is the
+    # constructor parameter, the key `repr()` shows, the key of the
+    # dict-like view, and the key `fields_dict`, `asdict` and `replace`
+    # speak -- so when two fields share it, only one of them is ever
+    # reachable and the other is silently unreachable under it. The class
+    # is refused here, whether or not the pair would meet in a signature,
+    # so that every accessor can key by that name and trust it.
+    seen = {}
+    for name, field in fields.items():
+        public = field.public_name
+        if public in seen:
+            raise TypeError(
+                f"{clsname} has two fields, {seen[public]!r} and {name!r}, "
+                f"and both are known as {public!r} outside the class: that "
+                f"is the name the constructor takes and repr() shows. A "
+                f"field is known by its alias, or by its own name with any "
+                f"leading underscore removed. Rename one of the two fields, "
+                f"or give one of them an alias of its own."
+            )
+        seen[public] = name
+
+
 #: Names that mark the *structure* of an annotation: the family declared
 #: in `_fields.py` (`KwOnly`, `Frozen`, `ClassVar`, ...) plus the typing
 #: spellings the builder reads. Used to recognise a structural marker by
@@ -585,10 +611,6 @@ def _resolve_string_annotations(
 
 class _BadSignature(SyntaxError):
     """A field layout that cannot produce an `__init__` signature."""
-
-
-class _DuplicateParameter(TypeError):
-    """Two fields that would become the same `__init__` parameter."""
 
 
 def _unbuildable_init(clsname: str, reason: str) -> tx.Callable:
@@ -1306,6 +1328,8 @@ def __pre_new__(
                 f'{attr_name!r} is a field but has no type annotation'
             )
 
+    _check_public_names(clsname, fields)
+
     # Remember all of the fields on our class (including bases).
     namespace[_FIELDS] = fields
 
@@ -1350,7 +1374,7 @@ def __pre_new__(
     # name has to wait until `insert_fns` has compiled it (below).
     try:
         init_kwargs = _make_init(fields, prepost)
-    except (_BadSignature, _DuplicateParameter) as error:
+    except _BadSignature as error:
         if init_name:
             raise
         # This class does not want an `__init__`, so being unable to
@@ -1739,7 +1763,6 @@ def _make_init(
     positional_onlys, args, kw_onlys = {}, {}, {}
 
     SELF = "self"
-    seen_params = {}
     # Fields that are stored on the instance without being a parameter:
     # they are assigned their own default. A pseudo-field (`ClassVar`,
     # `InitVar`) is not stored on the instance, and a field with neither
@@ -1761,16 +1784,10 @@ def _make_init(
             continue
         # The parameter is named after the field's *public* name, which
         # differs from the field name for an aliased or underscored
-        # field. Two fields that reduce to the same parameter would
-        # generate a signature with a duplicate argument.
-        public = field.public_name
-        if public in seen_params:
-            raise _DuplicateParameter(
-                f"fields {seen_params[public]!r} and {name!r} both map to "
-                f"the __init__ parameter {public!r}"
-            )
-        seen_params[public] = name
-        if public == "self":
+        # field. No two fields reach here under one public name: a class
+        # whose fields collide that way is refused before any method is
+        # built.
+        if field.public_name == "self":
             SELF = _SELF
 
     def _make_signature_elem(field: Field) -> tx.Tuple[str, str]:

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -2560,10 +2560,48 @@ class TestPublicName:
         assert C(1, seed=7).x == 8
 
     def test_two_fields_mapping_to_one_parameter_is_rejected(self) -> None:
-        with pytest.raises(TypeError, match="both map to"):
+        with pytest.raises(TypeError, match="known as 'y'"):
             class Bad(Magic):
                 _y: int
                 y: int
+
+    def test_a_field_out_of_the_constructor_still_collides(self) -> None:
+        # `x` is not a parameter, so the two never meet in the
+        # signature -- but they do meet in the repr, which showed two
+        # keys called `x`.
+        with pytest.raises(TypeError, match="known as 'x'"):
+            class Clash(Magic):
+                x: NoInit[int] = 1
+                _x: int = 2
+
+    def test_an_alias_colliding_with_a_plain_field_is_rejected(self) -> None:
+        # No underscore in sight: an alias lands on the name another
+        # field already has.
+        with pytest.raises(TypeError, match="known as 'b'"):
+            class Coll(Magic):
+                a: Annotated[int, Field(alias="b")] = 1
+                b: NoInit[int] = 2
+
+    def test_a_pseudo_field_collides_too(self) -> None:
+        with pytest.raises(TypeError, match="known as 'unit'"):
+            class Shifted(Magic):
+                _unit: ClassVar[str] = "m"
+                unit: str = "m"
+
+    def test_a_collision_inherited_from_a_base_is_rejected(self) -> None:
+        class Base(Magic):
+            _x: int = 0
+
+        with pytest.raises(TypeError, match="known as 'x'"):
+            class Sub(Base):
+                x: NoInit[int] = 1
+
+    def test_an_alias_of_its_own_settles_the_collision(self) -> None:
+        class Fixed(Magic):
+            x: NoInit[int] = 1
+            _x: Annotated[int, Field(alias="ex")] = 2
+
+        assert repr(Fixed(5)) == "Fixed(x=1, ex=5)"
 
     def test_a_field_named_self_still_works(self) -> None:
         class C(Magic):
@@ -2886,21 +2924,17 @@ class TestInitFalseIsAnEscapeHatch:
 
         assert D(5).y == 5
 
-    def test_two_fields_sharing_a_public_name(self) -> None:
-        class X(Magic, init=False):
-            a: Annotated[int, Field(alias="v")]
-            b: Annotated[int, Field(alias="v")]
-
-        assert X.__name__ == "X"
-
-    def test_the_same_layouts_still_raise_when_init_is_on(self) -> None:
+    def test_the_same_layout_still_raises_when_init_is_on(self) -> None:
         with pytest.raises(SyntaxError, match="without a default"):
             class D(Magic):
                 x: int = 0
                 y: int
 
-        with pytest.raises(TypeError, match="both map to"):
-            class X(Magic):
+    def test_a_name_collision_is_refused_even_without_an_init(self) -> None:
+        # Two fields under one name are a problem wherever that name is
+        # used, so turning `__init__` off does not excuse it.
+        with pytest.raises(TypeError, match="known as 'v'"):
+            class X(Magic, init=False):
                 a: Annotated[int, Field(alias="v")]
                 b: Annotated[int, Field(alias="v")]
 
@@ -4260,40 +4294,6 @@ class TestParityHelpers:
             x: int
 
         assert _api.fields_dict(Plain) == {}
-
-    def test_two_fields_under_one_public_name_are_rejected(self) -> None:
-        # At most one of the two can be a constructor parameter -- here
-        # `_x` is, under the name `x` -- because the constructor refuses
-        # to be built with two parameters of one name. It says nothing
-        # about `x` itself, which is not a parameter at all.
-        class Clash(Magic):
-            x: NoInit[int] = 1
-            _x: int = 2
-
-        for call in (
-            lambda: _api.fields_dict(Clash),
-            lambda: _api.asdict(Clash(5)),
-            lambda: _api.astuple(Clash(5)),
-            lambda: _api.replace(Clash(5), x=6),
-        ):
-            with pytest.raises(TypeError, match="both known as 'x'"):
-                call()
-
-    def test_an_alias_can_collide_with_a_plain_field(self) -> None:
-        # No underscore in sight: an alias lands on the name another
-        # field already has.
-        class Coll(Magic):
-            a: Annotated[int, Field(alias="b")] = 1
-            b: NoInit[int] = 2
-
-        for call in (
-            lambda: _api.fields_dict(Coll),
-            lambda: _api.asdict(Coll(1)),
-            lambda: _api.astuple(Coll(1)),
-            lambda: _api.replace(Coll(1), b=9),
-        ):
-            with pytest.raises(TypeError, match="both known as 'b'"):
-                call()
 
     # -- is_magic ------------------------------------------------------
 

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1294,6 +1294,48 @@ class TestMapping:
         d = Derived(1, 2)
         assert dict(d) == {"x": 1, "y": 2}
 
+    def test_mapping_skips_pseudo_fields(self) -> None:
+        class Row(Magic, mapping=True):
+            name: str
+            unit: ClassVar[str] = "m"
+            by: InitVar[int] = 0
+
+        row = Row("ada")
+        assert dict(row) == {"name": "ada"}
+        assert list(row) == ["name"]
+        assert len(row) == 1
+        # Still a perfectly ordinary class attribute, just not a key.
+        assert row.unit == "m"
+        for key in ("unit", "by"):
+            with pytest.raises(KeyError):
+                row[key]
+            with pytest.raises(KeyError):
+                row[key] = 1
+            with pytest.raises(KeyError):
+                del row[key]
+
+    def test_mapping_skips_an_init_var_with_no_default(self) -> None:
+        class Shift(Magic, mapping=True):
+            x: int
+            by: InitVar[int]
+
+        shift = Shift(1, 2)
+        assert dict(shift) == {"x": 1}
+        assert list(shift) == ["x"]
+        assert len(shift) == 1
+
+    def test_mapping_of_nothing_but_pseudo_fields(self) -> None:
+        class Meta(Magic, mapping=True):
+            unit: ClassVar[str] = "m"
+            by: InitVar[int] = 0
+
+        meta = Meta()
+        assert dict(meta) == {}
+        assert list(meta) == []
+        assert len(meta) == 0
+        with pytest.raises(KeyError):
+            meta["unit"]
+
     def test_mapping_default_off(self) -> None:
         class Point(Magic):
             x: int


### PR DESCRIPTION
Closes #52 and #53. Two independent fixes, one commit each.

## Two fields sharing one public name (#52)

```pycon
>>> class Clash(Magic):
...     x: NoInit[int] = 1
...     _x: int = 2
>>> Clash(5)
Clash(x=1, x=5)
```

Two keys called `x`, from two different fields, so the repr was no longer something you could paste back. The existing check only saw fields that were `__init__` parameters, so a `NoInit` field slipped past it — and the alias form reaches the same collision with no underscore in sight:

```python
class Coll(Magic):
    a: Annotated[int, Field(alias="b")] = 1
    b: NoInit[int] = 2
```

**Refused at class definition now, over every field including `ClassVar` and `InitVar`.** The public name is simultaneously the constructor parameter, the repr key, the dict-view key, and the key `fields_dict`, `asdict`, `astuple` and `replace` all report — so if two fields share it, one is unreachable under it no matter which accessor you use. Restricting the refusal to "where it is observable" would need either a rule per accessor or a rule that changes with the options (`init=False` tolerating what `init=True` rejects), which is harder to state and to predict than one check in one place.

Including pseudo-fields is deliberate: an `InitVar` really is a constructor parameter and a `ClassVar` really is an attribute on the class, so `C(unit=...)` setting something that is not `C.unit` is exactly the ambiguity worth refusing.

> `Clash` has two fields, `'x'` and `'_x'`, and both are known as `'x'` outside the class: that is the name the constructor takes and `repr()` shows. A field is known by its alias, or by its own name with any leading underscore removed. Rename one of the two fields, or give one of them an alias of its own.

Two things fall out. `_make_init`'s `_DuplicateParameter` check and `_api._keyed`'s collision guard both became unreachable — the class-level check is a strict superset and runs first — so both are gone rather than left as uncovered lines. And an `init=False` class no longer keeps a collision it cannot express in a signature.

## Pseudo-fields in the dict-like view (#53)

```pycon
>>> class Row(Magic, mapping=True):
...     name: str
...     unit: ClassVar[str] = "m"
>>> dict(Row("ada"))
{'name': 'ada', 'unit': 'm'}
```

A `ClassVar` is a class attribute deliberately not part of the data. A defaulted `InitVar` appeared the same way holding its class-level default, and a required one made `dict(obj)` raise outright.

`dict_fields` is built from the real fields now, and all five item methods close over that one dict, so `__len__`, `__iter__`, `__getitem__`, `__setitem__` and `__delitem__` all follow from the single filter. Verified after:

```
dict: {'name': 'ada'} | len: 1 | list: ['name'] | Row.unit still: m
required InitVar: {'a': 1}
```

The `Mapping`/`MutableMapping` registration reads only `options.frozen`, not the field selection.

## Two more found on the way, filed not fixed

**#59** — the same shape as #52 one level down: an explicit `Key("k")` on two fields bypasses the public-name rule, and `dict(R())` is `{'k': 2}` with `len` 1, the first field silently unreachable.

**#60** — a *concrete* field that was never given a value breaks the dict view the way a required `InitVar` did: `x: NoInit[int]` with no default makes `len()`, `dict()` and iteration raise `AttributeError`. The `not f.var` filter does not cover it, since the field is real. `_api._value` already turns exactly this into a written message for `asdict`/`astuple`; the mapping view has no equivalent, and a harder question to answer — `__len__` and `__iter__` have to decide whether an unset field counts.

663 passed; ruff and codespell clean; also run on 3.12 and 3.13.
