### PR TITLE
Derive init from kw and positional

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Each of these can be used bare (`x: Frozen[int]`) or with a value
 | `Factory[T]` | build the default by calling something | — |
 | `ConvertTo[T]` | convert whatever comes in | — |
 | `Validate[T]` | reject anything that does not fit | — |
-| `Init[T]` | may be passed by name or by position | `NoInit` |
+| `Init[T]` | say it is an argument, which it is anyway | `NoInit` |
 | `Kw[T]` | may be passed by name | `NotKw` |
 | `Positional[T]` | may be passed by position | `NotPositional` |
 | `KwOnly[T]` | by name only | `NotKwOnly` |
@@ -326,24 +326,30 @@ Each of these can be used bare (`x: Frozen[int]`) or with a value
 
 Each one sets exactly what its name mentions, and what it sets wins over
 the class setting: on a `kw_only=True` class, `x: Positional[int]` can be
-passed by position anyway, and `x: Init[int]` either way. What an
-annotation says nothing about follows the class as usual.
+passed by position anyway. What an annotation says nothing about follows
+the class as usual.
 
-A field that can be passed neither by name nor by position is no argument
-at all, which is what `NoInit` says. So `NotKwOnly` means "by position as
-well" and `NotPositionalOnly` means "by name as well" — they are aliases
-for `Positional` and `Kw`, not opposites of `KwOnly` and
+`Init` and `NoInit` say *whether* a field is an argument at all; `Kw`,
+`Positional` and the two `...Only` pairs say *how* it may be passed. A
+field is an argument unless something says otherwise, so `Init[T]` is
+there to say that out loud and changes nothing — it is `NoInit` that
+does the work, by forbidding both ways at once.
+
+That is also why `NotKwOnly` means "by position as well" and
+`NotPositionalOnly` means "by name as well": each negates its own name
+and leaves the other half alone, which makes them aliases for
+`Positional` and `Kw` rather than opposites of `KwOnly` and
 `PositionalOnly`.
 
-One thing to know before reaching for `Positional`, `NotKwOnly` or
-`Init` on a `kw_only=True` class: a field that can be passed by position
-moves to the front of the signature, ahead of the keyword-only ones,
-whatever order it was declared in.
+One thing to know before reaching for `Positional` or `NotKwOnly` on a
+`kw_only=True` class: a field that can be passed by position moves to the
+front of the signature, ahead of the keyword-only ones, whatever order it
+was declared in.
 
 ```python
 class Point(Magic, kw_only=True):
     a: int
-    x: Init[int]
+    x: Positional[int]
 ```
 
 ```pycon
@@ -351,8 +357,7 @@ class Point(Magic, kw_only=True):
 Point(a=2, x=1)
 ```
 
-`x` is declared second and is the first positional argument. That is true
-of `Positional` today as well; `Init` joins it.
+`x` is declared second and is the first positional argument.
 
 Anything you cannot say with one of these, say with `Field(...)` inside an
 `Annotated`: `x: Annotated[int, Field(alias="ex", metadata={"unit": "m"})]`.

--- a/README.md
+++ b/README.md
@@ -327,10 +327,32 @@ Each of these can be used bare (`x: Frozen[int]`) or with a value
 Each one sets exactly what its name mentions, and what it sets wins over
 the class setting: on a `kw_only=True` class, `x: Positional[int]` can be
 passed by position anyway, and `x: Init[int]` either way. What an
-annotation says nothing about follows the class as usual. Since a field that can be passed neither by name nor
-by position is no argument at all — which is what `NoInit` says —
-`NotKwOnly` reads as "by position as well", the same as `Positional`, and
-`NotPositionalOnly` as "by name as well", the same as `Kw`.
+annotation says nothing about follows the class as usual.
+
+A field that can be passed neither by name nor by position is no argument
+at all, which is what `NoInit` says. So `NotKwOnly` means "by position as
+well" and `NotPositionalOnly` means "by name as well" — they are aliases
+for `Positional` and `Kw`, not opposites of `KwOnly` and
+`PositionalOnly`.
+
+One thing to know before reaching for `Positional`, `NotKwOnly` or
+`Init` on a `kw_only=True` class: a field that can be passed by position
+moves to the front of the signature, ahead of the keyword-only ones,
+whatever order it was declared in.
+
+```python
+class Point(Magic, kw_only=True):
+    a: int
+    x: Init[int]
+```
+
+```pycon
+>>> Point(1, a=2)
+Point(a=2, x=1)
+```
+
+`x` is declared second and is the first positional argument. That is true
+of `Positional` today as well; `Init` joins it.
 
 Anything you cannot say with one of these, say with `Field(...)` inside an
 `Annotated`: `x: Annotated[int, Field(alias="ex", metadata={"unit": "m"})]`.

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Each of these can be used bare (`x: Frozen[int]`) or with a value
 | `Factory[T]` | build the default by calling something | — |
 | `ConvertTo[T]` | convert whatever comes in | — |
 | `Validate[T]` | reject anything that does not fit | — |
-| `Init[T]` | include in `__init__` | `NoInit` |
+| `Init[T]` | may be passed by name or by position | `NoInit` |
 | `Kw[T]` | may be passed by name | `NotKw` |
 | `Positional[T]` | may be passed by position | `NotPositional` |
 | `KwOnly[T]` | by name only | `NotKwOnly` |
@@ -323,6 +323,14 @@ Each of these can be used bare (`x: Frozen[int]`) or with a value
 | `ClassVar[T]` | shared by every instance | — |
 | `InitVar[T]` | passed in, used, not kept | — |
 | `Doc[T, "..."]` | describe the field | — |
+
+Each one sets exactly what its name mentions, and what it sets wins over
+the class setting: on a `kw_only=True` class, `x: Positional[int]` can be
+passed by position anyway, and `x: Init[int]` either way. What an
+annotation says nothing about follows the class as usual. Since a field that can be passed neither by name nor
+by position is no argument at all — which is what `NoInit` says —
+`NotKwOnly` reads as "by position as well", the same as `Positional`, and
+`NotPositionalOnly` as "by name as well", the same as `Kw`.
 
 Anything you cannot say with one of these, say with `Field(...)` inside an
 `Annotated`: `x: Annotated[int, Field(alias="ex", metadata={"unit": "m"})]`.

--- a/src/bagof/magic/_api.py
+++ b/src/bagof/magic/_api.py
@@ -337,9 +337,9 @@ def replace(obj: tx.Any, **changes: tx.Any) -> tx.Any:
     keyed = _keyed(_field_table(obj, "replace").values())
     given, arguments = dict(changes), []
     for name, field in keyed.items():
-        # A field the constructor does not take -- `NoInit`, or one
-        # that can be passed neither by position nor by name -- has no
-        # way in.
+        # A field the constructor does not take -- one that can be
+        # passed neither by position nor by name, which is what `NoInit`
+        # says -- has no way in.
         if not field.init:
             if name in given:
                 raise TypeError(

--- a/src/bagof/magic/_api.py
+++ b/src/bagof/magic/_api.py
@@ -63,15 +63,6 @@ def _keyed(found: tx.Iterable[Field]) -> tx.Dict[str, Field]:
     return keyed
 
 
-def _is_parameter(field: Field) -> bool:
-    """Whether the constructor takes this field as an argument.
-
-    A field is left out of the signature when it opts out of `__init__`,
-    and also when it can be passed neither by position nor by name.
-    """
-    return bool(field.init and (field.positional or field.kw))
-
-
 def _value(obj: tx.Any, field: Field, caller: str) -> tx.Any:
     """The value a field holds, or a written error if it holds none."""
     try:
@@ -357,7 +348,10 @@ def replace(obj: tx.Any, **changes: tx.Any) -> tx.Any:
     keyed = _keyed(_field_table(obj, "replace").values())
     given, arguments = dict(changes), []
     for name, field in keyed.items():
-        if not _is_parameter(field):
+        # A field the constructor does not take -- `NoInit`, or one
+        # that can be passed neither by position nor by name -- has no
+        # way in.
+        if not field.init:
             if name in given:
                 raise TypeError(
                     f"{cls.__name__} does not take {name!r} when it is "

--- a/src/bagof/magic/_fields.py
+++ b/src/bagof/magic/_fields.py
@@ -92,7 +92,7 @@ class Field(SlotsBase):
             The default value for the field.
         factory : Callable[[], any], default=`Options().factory`
             A factory function that generates a default value for the field.
-        init : bool
+        init : bool, optional
             Whether this field is a parameter of the generated `__init__`.
             It is not stored but worked out from `kw` and `positional`:
             reading it gives `kw or positional`, so a field that can be
@@ -174,9 +174,10 @@ class Field(SlotsBase):
         if compare is not MISSING:
             kwargs.setdefault("eq", compare)
             kwargs.setdefault("order", compare)
-        # `init` is not stored either: a field is an argument of the
-        # generated `__init__` when it can be passed by name, by
-        # position, or both, so `init` sets that pair.
+        # `init` has no slot of its own, for the same reason `compare`
+        # has none: a field is an argument of the generated `__init__`
+        # when it can be passed by name, by position, or both, so `init`
+        # sets that pair.
         init = kwargs.pop("init", MISSING)
         if init is not MISSING:
             kwargs.setdefault("kw", init)
@@ -200,8 +201,9 @@ class Field(SlotsBase):
         argument.
 
         A field is an argument when it can be passed by keyword, by
-        position, or both, and is none when it can be passed neither
-        way. Reading this works that out from `kw` and `positional`;
+        position, or both, and is no argument at all when it can be
+        passed neither way. Reading this works that out from `kw` and
+        `positional`;
         assigning to it writes the pair, so `field.init = False` forbids
         both ways and `field.init = True` allows both -- the same thing
         `NoInit` and `Init` say.

--- a/src/bagof/magic/_fields.py
+++ b/src/bagof/magic/_fields.py
@@ -97,9 +97,10 @@ class Field(SlotsBase):
             It is not stored but worked out from `kw` and `positional`:
             reading it gives `kw or positional`, so a field that can be
             passed neither by name nor by position is no parameter at
-            all, and assigning to it sets both of them. Passing `init=`
-            here sets both of them too, except for a half spelled out
-            beside it, which stands.
+            all. Passing `init=False` here forbids both ways; passing
+            `init=True` says nothing, since a field is a parameter
+            unless something says otherwise. Assigning to `field.init`
+            afterwards always sets both.
             Whether that method is generated at all is the class-level
             `init` option, which is a separate question.
         repr : bool, default=True (False for a pseudo-field)
@@ -177,8 +178,12 @@ class Field(SlotsBase):
         # `init` has no slot of its own, for the same reason `compare`
         # has none: a field is an argument of the generated `__init__`
         # when it can be passed by name, by position, or both, so `init`
-        # sets that pair.
+        # sets that pair. Only `init=False` says anything, though -- a
+        # field is an argument unless something says otherwise, so
+        # `init=True` is what it already would have been.
         init = kwargs.pop("init", MISSING)
+        if init is True:
+            init = MISSING
         if init is not MISSING:
             kwargs.setdefault("kw", init)
             kwargs.setdefault("positional", init)
@@ -203,16 +208,19 @@ class Field(SlotsBase):
         A field is an argument when it can be passed by keyword, by
         position, or both, and is no argument at all when it can be
         passed neither way. Reading this works that out from `kw` and
-        `positional`;
-        assigning to it writes the pair, so `field.init = False` forbids
-        both ways and `field.init = True` allows both -- the same thing
-        `NoInit` and `Init` say.
+        `positional`.
 
-        Assignment replaces whatever the pair held, including a half
-        that was set on purpose: it says "this is a parameter now".
-        Writing `init=` when the field is built behaves a little
-        differently -- there, a `kw` or `positional` spelled out beside
-        it is a declaration of its own, and stands.
+        There are three ways to say it, and they do not all say the
+        same thing:
+
+        - `field.init = True` or `field.init = False` sets both `kw`
+          and `positional` to that, replacing whatever they held.
+          Assignment comes after the declarations have been read, so
+          there is nothing left for it to defer to.
+        - `Field(init=False)`, like `NoInit`, forbids both ways.
+        - `Field(init=True)`, like `Init`, says nothing at all: a field
+          is an argument unless something says otherwise, so how it may
+          be passed is left to `kw`, `positional` and the class.
         """
         return bool(self.kw or self.positional)
 
@@ -559,33 +567,27 @@ class Init(BoolAnnotatedField):
     """
     Include a field in the generated `__init__`, or leave it out.
 
-    `Init` lets the field be passed either way, by name or by position,
-    even on a class that asks for one of them only. `NoInit` lets it be
-    passed neither way: the field still exists and takes its default or
-    factory value, it just cannot be passed in.
+    `NoInit` lets a field be passed neither by name nor by position: it
+    still exists and takes its default or factory value, it just cannot
+    be passed in.
+
+    `Init` is the other way round and says nothing new -- a field is a
+    parameter unless something says otherwise -- so it changes nothing
+    and is there to say so out loud. How the field may be passed stays
+    with the class, or with `Kw` and `Positional` if you want to say.
 
     !!! example "How it lowers"
         ```pycon
         >>> Init()
-        Init(kw=True, positional=True)
+        Init()
         >>> NoInit()
         NoInit(kw=False, positional=False)
         >>> NoInit[int]
         typing.Annotated[int, NoInit(kw=False, positional=False)]
         ```
-
-    !!! example "In a class"
-        ```pycon
-        >>> class Point(Magic, kw_only=True):
-        ...     x: Init[int]
-        ...     y: int
-        ...
-        >>> Point(1, y=2)
-        Point(x=1, y=2)
-        ```
     """
 
-    __set_slots__ = ('kw', 'positional')
+    __set_slots__ = ()
 
 
 @slots

--- a/src/bagof/magic/_fields.py
+++ b/src/bagof/magic/_fields.py
@@ -92,12 +92,14 @@ class Field(SlotsBase):
             The default value for the field.
         factory : Callable[[], any], default=`Options().factory`
             A factory function that generates a default value for the field.
-        init : bool, read-only
+        init : bool
             Whether this field is a parameter of the generated `__init__`.
-            It is not stored but worked out: `kw or positional`, so a
-            field that can be passed neither by name nor by position is
-            no parameter at all. Passing `init=` here sets both of those
-            at once.
+            It is not stored but worked out from `kw` and `positional`:
+            reading it gives `kw or positional`, so a field that can be
+            passed neither by name nor by position is no parameter at
+            all, and assigning to it sets both of them. Passing `init=`
+            here sets both of them too, except for a half spelled out
+            beside it, which stands.
             Whether that method is generated at all is the class-level
             `init` option, which is a separate question.
         repr : bool, default=True (False for a pseudo-field)
@@ -199,10 +201,22 @@ class Field(SlotsBase):
 
         A field is an argument when it can be passed by keyword, by
         position, or both, and is none when it can be passed neither
-        way. Writing `init=False` is how you say that: it sets `kw` and
-        `positional` together, and `init=True` sets them both back.
+        way. Reading this works that out from `kw` and `positional`;
+        assigning to it writes the pair, so `field.init = False` forbids
+        both ways and `field.init = True` allows both -- the same thing
+        `NoInit` and `Init` say.
+
+        Assignment replaces whatever the pair held, including a half
+        that was set on purpose: it says "this is a parameter now".
+        Writing `init=` when the field is built behaves a little
+        differently -- there, a `kw` or `positional` spelled out beside
+        it is a declaration of its own, and stands.
         """
         return bool(self.kw or self.positional)
+
+    @init.setter
+    def init(self, value: bool) -> None:
+        self.kw = self.positional = value
 
     @property
     def public_name(self) -> str:

--- a/src/bagof/magic/_fields.py
+++ b/src/bagof/magic/_fields.py
@@ -53,7 +53,6 @@ T = tx.TypeVar("T")
     'default',          # Default value for this field.
     # A factory function that generates a default value for this field.
     'factory',
-    'init',             # Include this field in the generated __init__ method.
     'repr',             # Include this field in the generated __repr__ method.
     'hash',             # Include this field in the generated __hash__ method.
     'eq',               # Include this field in the generated __eq__ method.
@@ -93,8 +92,12 @@ class Field(SlotsBase):
             The default value for the field.
         factory : Callable[[], any], default=`Options().factory`
             A factory function that generates a default value for the field.
-        init : bool, default=True
+        init : bool, read-only
             Whether this field is a parameter of the generated `__init__`.
+            It is not stored but worked out: `kw or positional`, so a
+            field that can be passed neither by name nor by position is
+            no parameter at all. Passing `init=` here sets both of those
+            at once.
             Whether that method is generated at all is the class-level
             `init` option, which is a separate question.
         repr : bool, default=True (False for a pseudo-field)
@@ -115,7 +118,8 @@ class Field(SlotsBase):
         kw : bool, default=`not Options().positional_only`
             Make this field a keyword argument in the generated `__init__`
             method. To make the field keyword-only, set `positional=False`
-            as well.
+            as well; with both set to False the field is no argument at
+            all, the same as `init=False`.
         positional : bool, default=`not Options().kw_only`
             Make this field a positional argument in the generated `__init__`
             method. To make the field positional-only, set `kw=False` as well.
@@ -132,8 +136,9 @@ class Field(SlotsBase):
         var : bool, default=False
             Whether this field is a pseudo-field (InitVar or ClassVar).
             Pseudo-fields are not set by the generated `__init__` method,
-            but may one of its arguments (when `init=True`), or used in
-            the generated `__repr__` method (when `init=False, repr=True`).
+            but may be one of its arguments (when `init=True`), or used
+            in the generated `__repr__` method (when `init=False,
+            repr=True`).
             It is often more readable to use the `InitVar` and `ClassVar`
             annotations.
         doc : str, optional
@@ -167,6 +172,13 @@ class Field(SlotsBase):
         if compare is not MISSING:
             kwargs.setdefault("eq", compare)
             kwargs.setdefault("order", compare)
+        # `init` is not stored either: a field is an argument of the
+        # generated `__init__` when it can be passed by name, by
+        # position, or both, so `init` sets that pair.
+        init = kwargs.pop("init", MISSING)
+        if init is not MISSING:
+            kwargs.setdefault("kw", init)
+            kwargs.setdefault("positional", init)
         # set slots from keywords
         super().__init__(**kwargs)
 
@@ -179,6 +191,18 @@ class Field(SlotsBase):
             t = (t,)
         t, *args = t
         return tx.Annotated[(t, cls(True)) + tuple(args)]
+
+    @property
+    def init(self) -> bool:
+        """Whether the generated `__init__` takes this field as an
+        argument.
+
+        A field is an argument when it can be passed by keyword, by
+        position, or both, and is none when it can be passed neither
+        way. Writing `init=False` is how you say that: it sets `kw` and
+        `positional` together, and `init=True` sets them both back.
+        """
+        return bool(self.kw or self.positional)
 
     @property
     def public_name(self) -> str:
@@ -239,15 +263,12 @@ class Field(SlotsBase):
             self.doc = None
         if self.var is MISSING:
             self.var = False
-        # `init`, `repr`, `eq` and `order` are deliberately *not* read
-        # from the class options. Those decide whether a method is
-        # generated at all; this decides whether a field takes part in
-        # one. Conflating them made every generated method on a class
-        # that had opted out cover no fields -- so `__magic_eq__` on an
-        # `eq=False` class compared nothing and answered True for any
-        # two instances.
-        if self.init is MISSING:
-            self.init = True
+        # `repr`, `eq` and `order` are deliberately *not* read from the
+        # class options. Those decide whether a method is generated at
+        # all; this decides whether a field takes part in one. Conflating
+        # them made every generated method on a class that had opted out
+        # cover no fields -- so `__magic_eq__` on an `eq=False` class
+        # compared nothing and answered True for any two instances.
         if self.repr is MISSING:
             # A sentinel on the class option is a per-field instruction
             # ("show it only when it has a value"), so it propagates;
@@ -522,26 +543,38 @@ class Init(BoolAnnotatedField):
     """
     Include a field in the generated `__init__`, or leave it out.
 
-    A field left out still exists -- it takes its default or factory value --
-    it just cannot be passed in.
+    `Init` lets the field be passed either way, by name or by position,
+    even on a class that asks for one of them only. `NoInit` lets it be
+    passed neither way: the field still exists and takes its default or
+    factory value, it just cannot be passed in.
 
     !!! example "How it lowers"
         ```pycon
         >>> Init()
-        Init(init=True)
+        Init(kw=True, positional=True)
         >>> NoInit()
-        NoInit(init=False)
+        NoInit(kw=False, positional=False)
         >>> NoInit[int]
-        typing.Annotated[int, NoInit(init=False)]
+        typing.Annotated[int, NoInit(kw=False, positional=False)]
+        ```
+
+    !!! example "In a class"
+        ```pycon
+        >>> class Point(Magic, kw_only=True):
+        ...     x: Init[int]
+        ...     y: int
+        ...
+        >>> Point(1, y=2)
+        Point(x=1, y=2)
         ```
     """
 
-    __set_slots__ = 'init'
+    __set_slots__ = ('kw', 'positional')
 
 
 @slots
 class NoInit(Init, InversedBoolAnnotatedField):
-    __set_slots__ = 'init'
+    __set_slots__ = ('kw', 'positional')
 
 
 @slots
@@ -551,7 +584,7 @@ class Kw(BoolAnnotatedField):
 
     Pair it with `Positional` to say exactly how a field may be given.
     `KwOnly` and `PositionalOnly` are the two useful combinations, ready
-    made.
+    made; forbidding both is `NoInit`.
 
     !!! example "How it lowers"
         ```pycon
@@ -606,8 +639,11 @@ class NotPositional(Positional, InversedBoolAnnotatedField):
 class KwOnly(Kw, NotPositional): ...
 
 
+# Each inverse negates its own name: not keyword-only means the field may
+# also be passed by position, and not positional-only means it may also be
+# passed by name. Neither says anything about the other half of the pair.
 @slots
-class NotKwOnly(Kw, Positional): ...
+class NotKwOnly(Positional): ...
 
 
 @slots
@@ -615,7 +651,7 @@ class PositionalOnly(Positional, NotKw): ...
 
 
 @slots
-class NotPositionalOnly(Kw, Positional): ...
+class NotPositionalOnly(Kw): ...
 
 
 @slots
@@ -672,11 +708,11 @@ class Var(BoolAnnotatedField):
         >>> Var()
         Var(var=True)
         >>> InitVar()
-        InitVar(init=True, var=True)
+        InitVar(var=True)
         >>> ClassVar()
-        ClassVar(init=False, var=True)
+        ClassVar(kw=False, positional=False, var=True)
         >>> ClassVar[str]
-        typing.Annotated[str, ClassVar(init=False, var=True)]
+        typing.Annotated[str, ClassVar(kw=False, positional=False, var=True)]
         ```
 
     !!! example "In a class"
@@ -696,7 +732,7 @@ class Var(BoolAnnotatedField):
 
 
 @slots
-class InitVar(Var, Init): ...
+class InitVar(Var): ...
 
 
 @slots

--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -1398,9 +1398,10 @@ def __pre_new__(
             if isinstance(options.match_args, str)
             else "__match_args__"
         ),
-        tuple(
-            f.public_name for f in fields.values() if f.init and f.positional
-        ),
+        # Only the fields that can be matched by position: a
+        # keyword-only field, or one the constructor does not take at
+        # all, has no place to be matched from.
+        tuple(f.public_name for f in fields.values() if f.positional),
         bool(options.match_args),
     )
 
@@ -1747,13 +1748,14 @@ def _make_init(
     # is where such a field gets its value.
     own_defaults = {}
     for name, field in fields.items():
-        if field.init and field.positional and not field.kw:
+        if field.positional and not field.kw:
             positional_onlys[name] = field
-        elif field.init and field.positional and field.kw:
+        elif field.positional and field.kw:
             args[name] = field
-        elif field.init and not field.positional and field.kw:
+        elif field.kw:
             kw_onlys[name] = field
         else:
+            # Neither by position nor by name: no parameter at all.
             if not field.var and (
                 field.default is not MISSING or field.factory
             ):

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -555,6 +555,26 @@ class TestFieldInit:
     ) -> None:
         assert Field(kw=kw, positional=positional).init is expected
 
+    @pytest.mark.parametrize("value", [True, False])
+    @pytest.mark.parametrize(
+        "kw,positional", [case[:2] for case in CASES]
+    )
+    def test_init_writes_the_pair(
+        self, kw: bool, positional: bool, value: bool
+    ) -> None:
+        field = Field(kw=kw, positional=positional)
+        field.init = value
+        assert (field.kw, field.positional, field.init) == (
+            value, value, value
+        )
+
+    def test_assignment_replaces_a_half_that_was_spelled_out(self) -> None:
+        # Assignment is not a default: whatever the pair held, saying
+        # `init` afterwards decides both halves.
+        field = Field(kw=False, positional=True)
+        field.init = True
+        assert (field.kw, field.positional) == (True, True)
+
     def test_init_false_forbids_both(self) -> None:
         field = Field(init=False)
         assert (field.kw, field.positional, field.init) == (
@@ -566,10 +586,15 @@ class TestFieldInit:
         assert (field.kw, field.positional, field.init) == (True, True, True)
 
     def test_a_half_given_on_its_own_wins(self) -> None:
-        field = Field(init=True, kw=False)
-        assert (field.kw, field.positional, field.init) == (
-            False, True, True
-        )
+        # In the constructor the two are declarations resolved
+        # together, so the half that was spelled out stands. Which of
+        # them is written first makes no difference.
+        for field in (
+            Field(init=True, kw=False), Field(kw=False, init=True)
+        ):
+            assert (field.kw, field.positional, field.init) == (
+                False, True, True
+            )
 
     def test_init_false_keeps_the_field_out_of_the_constructor(self) -> None:
         class C(Magic):

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -458,7 +458,7 @@ class TestParameterAnnotations:
     # (annotation, on a plain class, on kw_only=True, on
     #  positional_only=True)
     CASES = [
-        (Init, BOTH, BOTH, BOTH),
+        (Init, BOTH, BY_NAME, BY_POSITION),
         (NoInit, NEITHER, NEITHER, NEITHER),
         (Kw, BOTH, BY_NAME, BOTH),
         (NotKw, BY_POSITION, NEITHER, BY_POSITION),
@@ -489,19 +489,39 @@ class TestParameterAnnotations:
             is positional_only
         )
 
-    def test_init_on_a_kw_only_class_also_takes_a_position(self) -> None:
-        # `Init` says both ways, which is not what the class asks for --
-        # and an annotation written on one field beats the class.
-        class C(Magic, kw_only=True):
+    @pytest.mark.parametrize(
+        "options",
+        [{}, {"kw_only": True}, {"positional_only": True}],
+        ids=["plain", "kw_only", "positional_only"],
+    )
+    def test_init_leaves_the_signature_alone(
+        self, options: tx.Dict[str, bool]
+    ) -> None:
+        # `Init` only says a field is an argument, which it already
+        # was, so the signature must come out as if it were not there.
+        class Bare(Magic, **options):
+            a: int
+            b: int = 0
+
+        class Spelled(Magic, **options):
+            a: Init[int]
+            b: Init[int] = 0
+
+        assert str(signature(Spelled)) == str(signature(Bare))
+
+    def test_init_does_not_move_a_field_up_the_signature(self) -> None:
+        # A field that can be passed by position is bound before the
+        # keyword-only ones whatever order it was declared in, so an
+        # annotation that only means "yes, an argument" must not make
+        # one passable by position.
+        class E(Magic, kw_only=True):
+            a: int
             x: Init[int]
 
-        assert (C(1).x, C(x=1).x) == (1, 1)
-
-    def test_init_on_a_positional_only_class_also_takes_a_name(self) -> None:
-        class C(Magic, positional_only=True):
-            x: Init[int]
-
-        assert (C(1).x, C(x=1).x) == (1, 1)
+        assert list(signature(E).parameters) == ["a", "x"]
+        assert E(a=2, x=1) == E(x=1, a=2)
+        with pytest.raises(TypeError):
+            E(1, a=2)
 
     def test_the_two_inverses_differ(self) -> None:
         # Each is the negation of its own name: not keyword-only leaves
@@ -539,7 +559,7 @@ class TestParameterAnnotations:
 
 
 class TestFieldInit:
-    """`init` is what the pair adds up to, and a way to set both."""
+    """`init` is what the pair adds up to, and a way to write it."""
 
     def test_setting_init_reaches_the_signature(self) -> None:
         # The slots are the mechanism; the signature is what a user
@@ -598,19 +618,21 @@ class TestFieldInit:
             False, False, False
         )
 
-    def test_init_true_allows_both(self) -> None:
+    def test_init_true_says_nothing(self) -> None:
+        # The pair is left for the class options to resolve, exactly as
+        # if `init` had not been given.
         field = Field(init=True)
-        assert (field.kw, field.positional, field.init) == (True, True, True)
+        assert (field.kw, field.positional) == (MISSING, MISSING)
 
     def test_a_half_given_on_its_own_wins(self) -> None:
         # In the constructor the two are declarations resolved
         # together, so the half that was spelled out stands. Which of
         # them is written first makes no difference.
         for field in (
-            Field(init=True, kw=False), Field(kw=False, init=True)
+            Field(init=False, kw=True), Field(kw=True, init=False)
         ):
             assert (field.kw, field.positional, field.init) == (
-                False, True, True
+                True, False, True
             )
 
     def test_init_false_keeps_the_field_out_of_the_constructor(self) -> None:
@@ -2862,7 +2884,9 @@ class TestAnnotationPolarity:
 
     # (annotation, expected {slot: value})
     CASES = [
-        ("Init", {"kw": True, "positional": True}),
+        # `Init` sets neither half: a field is an argument unless
+        # something says otherwise.
+        ("Init", {"kw": MISSING, "positional": MISSING}),
         ("NoInit", {"kw": False, "positional": False}),
         ("Kw", {"kw": True}),
         ("NotKw", {"kw": False}),

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -23,8 +23,10 @@ from bagof.magic import (
     Factory,
     Field,
     Frozen,
+    Init,
     InitVar,
     Key,
+    Kw,
     KwOnly,
     Magic,
     NoCompare,
@@ -36,6 +38,10 @@ from bagof.magic import (
     NotFrozen,
     NotKey,
     NotKw,
+    NotKwOnly,
+    NotPositional,
+    NotPositionalOnly,
+    Positional,
     PositionalOnly,
     Validate,
     magic,
@@ -415,6 +421,163 @@ class TestInit:
         p = Point()
         assert p.x == 0
         assert p.y == 0
+
+
+# ======================================================================
+# The parameter annotations
+# ======================================================================
+
+
+def _parameter_kind(annotation: tx.Any, **options: tx.Any) -> tx.Any:
+    """How the constructor of a one-field class takes that field.
+
+    `None` when it does not take it at all.
+    """
+
+    class One(Magic, **options):
+        x: annotation[int] = 0
+
+    parameter = signature(One).parameters.get("x")
+    return None if parameter is None else parameter.kind
+
+
+class TestParameterAnnotations:
+    """What each annotation makes of the field it is written on.
+
+    An annotation sets the halves of the pair its own name mentions --
+    may this field be passed by name, may it be passed by position --
+    and what it sets beats the class setting. Whatever it says nothing
+    about follows the class.
+    """
+
+    BOTH = Parameter.POSITIONAL_OR_KEYWORD
+    BY_NAME = Parameter.KEYWORD_ONLY
+    BY_POSITION = Parameter.POSITIONAL_ONLY
+    NEITHER = None
+
+    # (annotation, on a plain class, on kw_only=True, on
+    #  positional_only=True)
+    CASES = [
+        (Init, BOTH, BOTH, BOTH),
+        (NoInit, NEITHER, NEITHER, NEITHER),
+        (Kw, BOTH, BY_NAME, BOTH),
+        (NotKw, BY_POSITION, NEITHER, BY_POSITION),
+        (Positional, BOTH, BOTH, BY_POSITION),
+        (NotPositional, BY_NAME, BY_NAME, NEITHER),
+        (KwOnly, BY_NAME, BY_NAME, BY_NAME),
+        (PositionalOnly, BY_POSITION, BY_POSITION, BY_POSITION),
+        (NotKwOnly, BOTH, BOTH, BY_POSITION),
+        (NotPositionalOnly, BOTH, BY_NAME, BOTH),
+    ]
+
+    @pytest.mark.parametrize(
+        "annotation,plain,kw_only,positional_only",
+        CASES,
+        ids=[case[0].__name__ for case in CASES],
+    )
+    def test_signature(
+        self,
+        annotation: tx.Any,
+        plain: tx.Any,
+        kw_only: tx.Any,
+        positional_only: tx.Any,
+    ) -> None:
+        assert _parameter_kind(annotation) is plain
+        assert _parameter_kind(annotation, kw_only=True) is kw_only
+        assert (
+            _parameter_kind(annotation, positional_only=True)
+            is positional_only
+        )
+
+    def test_init_on_a_kw_only_class_also_takes_a_position(self) -> None:
+        # `Init` says both ways, which is not what the class asks for --
+        # and an annotation written on one field beats the class.
+        class C(Magic, kw_only=True):
+            x: Init[int]
+
+        assert (C(1).x, C(x=1).x) == (1, 1)
+
+    def test_init_on_a_positional_only_class_also_takes_a_name(self) -> None:
+        class C(Magic, positional_only=True):
+            x: Init[int]
+
+        assert (C(1).x, C(x=1).x) == (1, 1)
+
+    def test_the_two_inverses_differ(self) -> None:
+        # Each is the negation of its own name: not keyword-only leaves
+        # the field passable by position, not positional-only leaves it
+        # passable by name.
+        class ByPositionToo(Magic, kw_only=True):
+            x: NotKwOnly[int]
+
+        class ByNameOnly(Magic, kw_only=True):
+            x: NotPositionalOnly[int]
+
+        assert ByPositionToo(1).x == 1
+        with pytest.raises(TypeError):
+            ByNameOnly(1)
+
+    def test_a_field_that_is_neither_is_no_parameter(self) -> None:
+        # The fourth state of the pair: on a class that asks for
+        # keywords only, forbidding keywords leaves no way in at all,
+        # and the field takes its default like a `NoInit` one.
+        class C(Magic, kw_only=True):
+            x: NotKw[int] = 7
+
+        assert C().x == 7
+        with pytest.raises(TypeError):
+            C(7)
+
+    def test_no_init_still_takes_its_default(self) -> None:
+        class C(Magic):
+            x: int = 1
+            y: NoInit[int] = 2
+
+        assert (C().x, C().y) == (1, 2)
+        with pytest.raises(TypeError):
+            C(1, 2)
+
+
+class TestFieldInit:
+    """`init` is what the pair adds up to, and a way to set both."""
+
+    # (kw, positional, is it a parameter)
+    CASES = [
+        (True, True, True),
+        (True, False, True),
+        (False, True, True),
+        (False, False, False),
+    ]
+
+    @pytest.mark.parametrize("kw,positional,expected", CASES)
+    def test_init_reads_the_pair(
+        self, kw: bool, positional: bool, expected: bool
+    ) -> None:
+        assert Field(kw=kw, positional=positional).init is expected
+
+    def test_init_false_forbids_both(self) -> None:
+        field = Field(init=False)
+        assert (field.kw, field.positional, field.init) == (
+            False, False, False
+        )
+
+    def test_init_true_allows_both(self) -> None:
+        field = Field(init=True)
+        assert (field.kw, field.positional, field.init) == (True, True, True)
+
+    def test_a_half_given_on_its_own_wins(self) -> None:
+        field = Field(init=True, kw=False)
+        assert (field.kw, field.positional, field.init) == (
+            False, True, True
+        )
+
+    def test_init_false_keeps_the_field_out_of_the_constructor(self) -> None:
+        class C(Magic):
+            x: Annotated[int, Field(init=False)] = 3
+
+        assert C().x == 3
+        with pytest.raises(TypeError):
+            C(3)
 
 
 # ======================================================================
@@ -1079,9 +1242,9 @@ class TestField:
         assert f.frozen is True
 
     def test_field_repr(self) -> None:
-        f = Field(init=True, repr=False)
+        f = Field(kw=True, repr=False)
         r = repr(f)
-        assert "init=True" in r
+        assert "kw=True" in r
         assert "repr=False" in r
 
     def test_field_compare_alias(self) -> None:
@@ -2577,16 +2740,16 @@ class TestAnnotationPolarity:
 
     # (annotation, expected {slot: value})
     CASES = [
-        ("Init", {"init": True}),
-        ("NoInit", {"init": False}),
+        ("Init", {"kw": True, "positional": True}),
+        ("NoInit", {"kw": False, "positional": False}),
         ("Kw", {"kw": True}),
         ("NotKw", {"kw": False}),
         ("Positional", {"positional": True}),
         ("NotPositional", {"positional": False}),
         ("KwOnly", {"kw": True, "positional": False}),
         ("PositionalOnly", {"kw": False, "positional": True}),
-        ("NotKwOnly", {"kw": True, "positional": True}),
-        ("NotPositionalOnly", {"kw": True, "positional": True}),
+        ("NotKwOnly", {"positional": True}),
+        ("NotPositionalOnly", {"kw": True}),
         ("Frozen", {"frozen": True}),
         ("NotFrozen", {"frozen": False}),
         ("Repr", {"repr": True}),
@@ -2602,8 +2765,8 @@ class TestAnnotationPolarity:
         ("Key", {"key": True}),
         ("NotKey", {"key": False}),
         ("Var", {"var": True}),
-        ("InitVar", {"init": True, "var": True}),
-        ("ClassVar", {"init": False, "var": True}),
+        ("InitVar", {"var": True}),
+        ("ClassVar", {"kw": False, "positional": False, "var": True}),
     ]
 
     @pytest.mark.parametrize("name,expected", CASES, ids=[c[0] for c in CASES])

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -541,6 +541,23 @@ class TestParameterAnnotations:
 class TestFieldInit:
     """`init` is what the pair adds up to, and a way to set both."""
 
+    def test_setting_init_reaches_the_signature(self) -> None:
+        # The slots are the mechanism; the signature is what a user
+        # sees, so the setter is worth checking through one.
+        kept, dropped = Field(), Field()
+        kept.init = True
+        dropped.init = False
+
+        class C(Magic, kw_only=True):
+            a: Annotated[int, kept] = 1
+            b: Annotated[int, dropped] = 2
+
+        parameters = signature(C.__init__).parameters
+        assert list(parameters) == ["self", "a"]
+        # `kept` said both ways, which beats the class's kw_only.
+        assert parameters["a"].kind is Parameter.POSITIONAL_OR_KEYWORD
+        assert C().b == 2
+
     # (kw, positional, is it a parameter)
     CASES = [
         (True, True, True),


### PR DESCRIPTION
Closes #56. The design is the one settled on that issue.

## The model

`init` stops being a slot and becomes a read-only property, `kw or positional`. Two booleans already encoded four states, one of which was meaningless; the meaningless corner is now exactly what `NoInit` means, and the pair is well-formed — four states, four meanings:

| `kw` | `positional` | is | spelled |
|---|---|---|---|
| True | True | an ordinary parameter | `Init[T]` |
| True | False | keyword-only | `KwOnly[T]` |
| False | True | positional-only | `PositionalOnly[T]` |
| False | False | not a parameter | `NoInit[T]` |

The code already agreed. `_make_init` classified fields with `field.init and …` on all three branches and an `else: continue` that already treated `init=False` and `kw=False, positional=False` as one thing. The guards lose their prefix and the `else` stops being a catch-all.

## The rule the family follows

**Each annotation sets only the slots its name mentions, and what it sets beats the class option.**

| annotation | sets |
|---|---|
| `Init` | `kw=True, positional=True` |
| `NoInit` | `kw=False, positional=False` |
| `Kw` / `NotKw` | `kw` |
| `Positional` / `NotPositional` | `positional` |
| `KwOnly` | `kw=True, positional=False` |
| `PositionalOnly` | `kw=False, positional=True` |
| `NotKwOnly` | `positional=True` |
| `NotPositionalOnly` | `kw=True` |

Two of those change today's behaviour, both deliberate.

**`Init` did nothing at all.** It set `init=True`, which is what `init` defaulted to, so `Init[T]` and a bare `T` produced identical signatures under every class option. It now sets both, giving it the meaning its name claims.

**`NotKwOnly` and `NotPositionalOnly` were distinct classes setting identical slots** (`kw=True, positional=True`). Each now sets only the one its name is about: "not keyword-only" is a claim that you are not restricted to keywords, so it says you may also pass positionally — and leaves the keyword route to the class, which is a separate question its name never mentions. On a `kw_only=True` class, where the unset half is the half that matters, they finally differ:

```
Kw                   (self, *, a = 1)
Positional           (self, a = 1)
NotKwOnly            (self, a = 1)        <- was (self, a = 1) for both
NotPositionalOnly    (self, *, a = 1)
```

That makes `NotKwOnly` a synonym for `Positional` and `NotPositionalOnly` one for `Kw` — not because they are negations of each other, but because "not restricted to keywords" and "passable positionally" are the same statement.

## Behaviour change to know about

On a `kw_only=True` class, `a: Init[int]` now makes that one field positional-or-keyword where it was keyword-only:

```
class K(Magic, kw_only=True):
    a: int = 1
    b: Init[int] = 2

(self, b = 2, *, a = 1)
```

That is the intended reading — it is how `Kw` and `Positional` already behave — but it is a change for anyone who wrote `Init[T]` there as documentation, expecting the no-op it was.

## One thing the plan got wrong

`InitVar` was defined as `class InitVar(Var, Init)`. Giving `Init` real slots would have made **every** `InitVar` positional-or-keyword regardless of the class option — which is not what `InitVar` means: it marks a pseudo-field and says nothing about how the argument is passed. It broke a `replace` test with a defaulted `InitVar` between positional-only fields.

It is now `class InitVar(Var)`, which reproduces today's behaviour exactly — its old `init=True` was as much a no-op as `Init`'s. Verified:

```
class IV(Magic, kw_only=True):
    a: int = 1
    s: InitVar[int] = 2

(self, *, a = 1, s = 2)      <- still follows the class option
```

Consequence worth naming: `isinstance(InitVar(), Init)` is now `False`, and `InitVar()` reprs as `InitVar(var=True)`. `ClassVar(Var, NoInit)` needed no change — `kw=False, positional=False` is exactly what it wants.

## Compatibility

`Field(init=...)` stays a public constructor argument with no slot behind it: `init=False` sets both False, `init=True` sets both True, and an explicitly given half wins over it. `field.init` stays readable and keeps its place in `Field.__init__`'s numpydoc block, retyped `bool, read-only` and described as derived, per convention 4.

`_api._is_parameter` — written *because* `field.init` gave the wrong answer — is deleted; with `init` derived it **is** `field.init`. That was its only call site.

`#42`'s behaviour is intact: a `NoInit` field is still assigned from its default.

## Also

Filed **#61**: `NotKw` on a `kw_only=True` class silently produces a field with no parameter at all, the two settings cancelling out. Unchanged by this PR — the old `else: continue` did the same — but it now has a name in the model rather than being an accident, so it is worth deciding whether it should be louder. I lean towards leaving it, since an error would make the same two settings legal or not depending on a class option possibly written on a base several levels up.

687 passed on 3.11, 3.12 and 3.13; ruff and codespell clean.
