### PR TITLE
Leave a field with no value out of the dict-like view and asdict

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,23 @@ class Row(Magic, mapping=True):
 {'name': 'ada', 'age': 36}
 ```
 
+A key is there while its field is holding a value. A field the constructor
+does not take, and that has no default, holds none until something sets it —
+so it stays out of the view until then, and joins it the moment it is given
+one:
+
+```pycon
+>>> class Draft(Magic, mapping=True):
+...     title: str
+...     slug: NoInit[str]
+>>> draft = Draft("Ada")
+>>> dict(draft)
+{'title': 'Ada'}
+>>> draft["slug"] = "ada"
+>>> dict(draft)
+{'title': 'Ada', 'slug': 'ada'}
+```
+
 **A handful of functions** that work on any Magic class, or on one of its
 instances — `Point` from the top of this page, say:
 
@@ -201,7 +218,9 @@ one field out from another works it out again, starting from the value it
 already worked out, so `replace` with no changes at all can come back
 different. `asdict` hands the values back exactly as they are stored: it does
 not copy them, and a field holding another object gives you that object rather
-than a dict of its fields.
+than a dict of its fields. Like the dict-like view, it leaves out a field that
+is holding no value; `astuple` says so instead, because a position only means
+anything while every field is in the tuple.
 
 There is also `fields` and `fields_dict` for the fields themselves, and
 `is_magic` to ask whether a class was built by `Magic` at all.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -200,6 +200,9 @@ class Header(Magic, mapping=True):
 {'content_type': 'text/plain', 'length': 12}
 ```
 
+A key is there while its field is holding a value, so a field that is only
+filled in later stays out of the view until it is.
+
 ### The docstring writes itself
 
 ```python

--- a/src/bagof/magic/_api.py
+++ b/src/bagof/magic/_api.py
@@ -61,19 +61,29 @@ def _is_parameter(field: Field) -> bool:
     return bool(field.init and (field.positional or field.kw))
 
 
+def _stored(obj: tx.Any, field: Field) -> tx.Tuple[bool, tx.Any]:
+    """The value a field holds, and whether it holds one at all.
+
+    A field that is not a constructor argument and has no default is
+    only ever set by hand, so an object can be perfectly usable and
+    still have nothing under this name.
+    """
+    try:
+        return True, getattr(obj, field.name)
+    except AttributeError:
+        return False, None
+
+
 def _value(obj: tx.Any, field: Field, caller: str) -> tx.Any:
     """The value a field holds, or a written error if it holds none."""
-    try:
-        return getattr(obj, field.name)
-    except AttributeError:
-        # A field that is not a constructor argument and has no default
-        # is only ever set by hand, so an object can be perfectly usable
-        # and still have nothing under this name.
+    has_value, value = _stored(obj, field)
+    if not has_value:
         raise AttributeError(
             f"{type(obj).__name__}.{field.name} has never been given a "
             f"value, so {caller}() has nothing to report for it. Give the "
             f"field a default, or set it in __post_init__."
-        ) from None
+        )
+    return value
 
 
 def _concrete(obj: tx.Any, caller: str) -> tx.Dict[str, Field]:
@@ -161,15 +171,8 @@ def asdict(obj: tx.Any) -> tx.Dict[str, tx.Any]:
     Returns
     -------
     values : dict[str, any]
-        Every concrete field (not `ClassVar` or `InitVar`), in field
-        order.
-
-    Raises
-    ------
-    AttributeError
-        If a field has never been given a value. A field the
-        constructor does not take, with no default, is only set if
-        something sets it by hand.
+        Every concrete field (not `ClassVar` or `InitVar`) that is
+        holding a value, in field order.
 
     !!! example
         ```pycon
@@ -180,6 +183,29 @@ def asdict(obj: tx.Any) -> tx.Dict[str, tx.Any]:
         >>> asdict(Point(1, 2))
         {'x': 1, 'y': 2}
         ```
+
+    !!! note "A field with no value is left out"
+        A field the constructor does not take, and that has no default,
+        holds nothing until something sets it -- so it is simply absent,
+        the way an optional key is absent from a dict. It comes back as
+        soon as it is given a value:
+
+        ```pycon
+        >>> class Draft(Magic):
+        ...     title: str
+        ...     slug: NoInit[str]
+        ...
+        >>> draft = Draft("Ada")
+        >>> asdict(draft)
+        {'title': 'Ada'}
+        >>> draft.slug = "ada"
+        >>> asdict(draft)
+        {'title': 'Ada', 'slug': 'ada'}
+        ```
+
+        `astuple` is the one that insists instead: a key says which
+        field it belongs to, a position does not, so a tuple is only
+        readable while every field is in it.
 
     !!! example "A nested object is left alone"
         ```pycon
@@ -198,7 +224,8 @@ def asdict(obj: tx.Any) -> tx.Dict[str, tx.Any]:
     !!! note "Not the same as `dict(obj)`"
         A class written with `mapping=True` can be passed to `dict`
         directly, and that covers the fields marked as keys, under the
-        key names they were given. `asdict` always covers every field.
+        key names they were given. `asdict` covers every field. The two
+        agree about a field with no value: neither shows one.
 
         ```pycon
         >>> class Row(Magic, mapping=True):
@@ -211,10 +238,12 @@ def asdict(obj: tx.Any) -> tx.Dict[str, tx.Any]:
         {'name': 'ada', 'age': 36}
         ```
     """
-    return {
-        name: _value(obj, field, "asdict")
-        for name, field in _concrete(obj, "asdict").items()
-    }
+    found = {}
+    for name, field in _concrete(obj, "asdict").items():
+        has_value, value = _stored(obj, field)
+        if has_value:
+            found[name] = value
+    return found
 
 
 def astuple(obj: tx.Any) -> tx.Tuple[tx.Any, ...]:
@@ -238,7 +267,9 @@ def astuple(obj: tx.Any) -> tx.Tuple[tx.Any, ...]:
     Raises
     ------
     AttributeError
-        If a field has never been given a value, as for `asdict`.
+        If a field has never been given a value. A field the
+        constructor does not take, with no default, is only set if
+        something sets it by hand.
 
     !!! example
         ```pycon
@@ -249,10 +280,19 @@ def astuple(obj: tx.Any) -> tx.Tuple[tx.Any, ...]:
         >>> astuple(Point(1, 2))
         (1, 2)
         ```
+
+    !!! note "A field with no value is an error here"
+        `asdict` and `dict(obj)` leave such a field out; this one says
+        so. A position only means anything while every field is in the
+        tuple: drop one and everything after it moves up, so the same
+        index would stand for a different field from one instance to
+        the next, with nothing in the tuple to show it.
     """
     # The same fields `asdict` reports, worked out the same way: a class
     # whose fields cannot be told apart by name is refused by both,
-    # rather than answering a tuple here and an error there.
+    # rather than answering a tuple here and an error there. A field
+    # holding no value is where the two part: a caller can see that a
+    # key is missing, but a short tuple looks like any other.
     return tuple(
         _value(obj, field, "astuple")
         for field in _concrete(obj, "astuple").values()

--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -65,7 +65,8 @@ convert : bool, default=False
 validate : bool, default=False
     Use field type as validator if none is provided
 mapping : bool, default=False
-    Implement the `Mapping` protocol; a subclass cannot turn it off
+    Implement the `Mapping` protocol; a subclass cannot turn it off.
+    Only a field that is holding a value is a key
 reverse : bool, default=False
     Use the reverse MRO order to determine field order
 doc : bool | str, default=True
@@ -141,6 +142,7 @@ from collections import abc as _abc
 from functools import partial
 from inspect import Parameter, signature
 from textwrap import dedent, indent
+from types import MemberDescriptorType
 
 # externals
 import typing_extensions as tx
@@ -2136,42 +2138,102 @@ def _make_slots(
 def _make_mapping(
     qualname: str, fields: dict[str, Field]
 ) -> tx.Mapping[str, tx.Callable]:
+    """The dict-like methods, over the fields that carry a key.
+
+    A key is there while the field behind it is holding a value, so
+    which keys an instance has is a question about that instance rather
+    than about its class. A field holds nothing when the constructor
+    does not take it and it has no default -- one like that is only ever
+    set by hand -- and a field can also ask to be left out for as long
+    as its value is `None`.
+    """
+
+    def _stored(self: Magic, field: Field) -> tx.Tuple[bool, tx.Any]:
+        """The value a field is holding, and whether it holds one."""
+        try:
+            return True, getattr(self, field.name)
+        except AttributeError:
+            return False, None
+
+    def _is_key(self: Magic, field: Field) -> bool:
+        """Whether a field is one of the keys as things stand."""
+        has_value, value = _stored(self, field)
+        return has_value and bool(field.key(value))
+
+    def _value(self: Magic, key: str, field: Field) -> tx.Any:
+        """The value behind a key, or a `KeyError` saying why there is none.
+
+        A field holding nothing gets a written message: it is a real
+        field of a usable object, so "no such key" on its own reads as
+        if the name had been misspelt.
+        """
+        has_value, value = _stored(self, field)
+        if not has_value:
+            raise KeyError(
+                f"{type(self).__name__}.{field.name} has no value, so "
+                f"{key!r} is not one of the keys. Give the field a "
+                f"default, or set it in __post_init__."
+            )
+        if not field.key(value):
+            raise KeyError(key)
+        return value
 
     def __getitem__(self: Magic, key: str) -> tx.Any:
+        """The value behind a key.
+
+        Raises `KeyError` if the class has no such key, or if the field
+        behind it is holding no value.
+        """
         field = fields.get(key)
-        if field:
-            value = getattr(self, field.name)
-            if not field.key(value):
-                raise KeyError(key)
-            return value
-        raise KeyError(key)
+        if field is None:
+            raise KeyError(key)
+        return _value(self, key, field)
 
     def __setitem__(self: Magic, key: str, value: tx.Any) -> None:
+        """Give a key its value, adding it if it had none."""
         field = fields.get(key)
-        if field:
-            setattr(self, field.name, value)
-        else:
+        if field is None:
             raise KeyError(key)
+        setattr(self, field.name, value)
 
     def __delitem__(self: Magic, key: str) -> None:
+        """Take a key's value away, so the key goes with it."""
         field = fields.get(key)
-        if field:
-            delattr(self, field.name)
-        else:
+        if field is None:
             raise KeyError(key)
+        # Turn down a key that is not there before touching anything.
+        _value(self, key, field)
+        # A default sits on the class itself, where deleting cannot
+        # reach it: the field would go straight back to that value and
+        # the key would still be there afterwards. Under `slots` the
+        # class carries a slot rather than a value, and the field is
+        # left holding nothing, which is what deleting a key means.
+        standing_by = getattr(type(self), field.name, MISSING)
+        if standing_by is not MISSING and not isinstance(
+            standing_by, MemberDescriptorType
+        ):
+            raise TypeError(
+                f"{type(self).__name__}.{field.name} has a default, so "
+                f"deleting {key!r} would only put the default back and "
+                f"leave the key where it is. Give it another value "
+                f"instead."
+            )
+        delattr(self, field.name)
 
     def __iter__(self: Magic) -> tx.Iterator[str]:
+        """The keys that have a value, in field order."""
         for key, field in fields.items():
-            if field:
-                if not field.key(getattr(self, field.name)):
-                    continue
+            if _is_key(self, field):
                 yield key
 
     def __len__(self: Magic) -> int:
-        return sum(
-            field.key(getattr(self, field.name))
-            for field in fields.values()
-        )
+        """How many keys have a value.
+
+        Only the fields holding a value are counted, so two instances of
+        the same class can be of different lengths, and one instance's
+        length can change as it is filled in.
+        """
+        return sum(_is_key(self, field) for field in fields.values())
 
     __getitem__.__qualname__ = f"{qualname}.__getitem__"
     __setitem__.__qualname__ = f"{qualname}.__setitem__"
@@ -2263,7 +2325,10 @@ class MetaMagic(ABCMeta):
         Use field type as validator if none is provided.
     mapping : bool, default=False
         Implement the `Mapping` protocol. A subclass cannot turn it off
-        again.
+        again. Only a field that is holding a value is a key, so which
+        keys an instance has is a question about that instance: the
+        length can differ between two instances of one class, and can
+        change over an instance's life.
     reverse : bool, default=False
         Use the reverse MRO order to determine field order.
         This only affects the relative order of the fields of one class
@@ -2346,7 +2411,10 @@ class Magic(metaclass=MetaMagic):
         Use field type as validator if none is provided.
     mapping : bool, default=False
         Implement the `Mapping` protocol. A subclass cannot turn it off
-        again.
+        again. Only a field that is holding a value is a key, so which
+        keys an instance has is a question about that instance: the
+        length can differ between two instances of one class, and can
+        change over an instance's life.
     reverse : bool, default=False
         Use the reverse MRO order to determine field order.
         This only affects the relative order of the fields of one class

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1336,6 +1336,202 @@ class TestMapping:
         with pytest.raises(KeyError):
             meta["unit"]
 
+    # -- a key is there only while its field has a value ---------------
+
+    def test_mapping_skips_a_field_with_no_value(self) -> None:
+        class Note(Magic, mapping=True):
+            text: str
+            pinned: NoInit[bool]
+
+        note = Note("hello")
+        assert dict(note) == {"text": "hello"}
+        assert list(note) == ["text"]
+        assert len(note) == 1
+
+    def test_a_field_filled_in_by_post_init_is_there_from_the_start(
+        self
+    ) -> None:
+        class Draft(Magic, mapping=True):
+            title: str
+            slug: NoInit[str]
+
+            def __post_init__(self, arguments: Arguments) -> None:
+                self.slug = self.title.lower()
+
+        draft = Draft("Ada")
+        assert dict(draft) == {"title": "Ada", "slug": "ada"}
+        assert len(draft) == 2
+
+    def test_a_key_arrives_when_its_field_is_given_a_value(self) -> None:
+        class Note(Magic, mapping=True):
+            text: str
+            pinned: NoInit[bool]
+
+        note = Note("hello")
+        assert "pinned" not in note
+        assert len(note) == 1
+
+        note["pinned"] = True
+
+        assert "pinned" in note
+        assert note["pinned"] is True
+        assert len(note) == 2
+        assert dict(note) == {"text": "hello", "pinned": True}
+        assert list(note) == ["text", "pinned"]
+
+    def test_two_instances_of_one_class_can_be_of_different_lengths(
+        self
+    ) -> None:
+        class Note(Magic, mapping=True):
+            text: str
+            pinned: NoInit[bool]
+
+        filled = Note("a")
+        filled["pinned"] = False
+        assert len(filled) == 2
+        assert len(Note("b")) == 1
+
+    def test_a_mapping_of_nothing_but_unset_fields_is_empty(self) -> None:
+        class Blank(Magic, mapping=True):
+            here: NoInit[int]
+            there: NoInit[int]
+
+        blank = Blank()
+        assert dict(blank) == {}
+        assert list(blank) == []
+        assert len(blank) == 0
+        assert not blank
+
+    def test_getitem_says_which_field_has_no_value(self) -> None:
+        class Note(Magic, mapping=True):
+            pinned: NoInit[bool]
+
+        with pytest.raises(KeyError, match="Note.pinned has no value"):
+            Note()["pinned"]
+
+    def test_the_dict_like_helpers_agree_about_a_field_with_no_value(
+        self
+    ) -> None:
+        # `in`, `get`, `keys`, `values` and `items` come from
+        # `Mapping`, and each is built on `__getitem__` and `__iter__`.
+        class Note(Magic, mapping=True):
+            text: str
+            pinned: NoInit[bool]
+
+        note = Note("hello")
+        assert "pinned" not in note
+        assert note.get("pinned") is None
+        assert note.get("pinned", "no") == "no"
+        assert list(note.keys()) == ["text"]
+        assert list(note.values()) == ["hello"]
+        assert list(note.items()) == [("text", "hello")]
+
+        note["pinned"] = True
+
+        assert "pinned" in note
+        assert note.get("pinned") is True
+        assert list(note.keys()) == ["text", "pinned"]
+        assert list(note.values()) == ["hello", True]
+        assert list(note.items()) == [("text", "hello"), ("pinned", True)]
+
+    def test_the_mutable_helpers_work_over_a_field_with_no_value(
+        self
+    ) -> None:
+        # `pop`, `setdefault` and `clear` come from `MutableMapping`,
+        # and each of them expects a key that is not there to answer
+        # with a `KeyError`.
+        class Note(Magic, mapping=True):
+            text: str
+            pinned: NoInit[bool]
+
+        note = Note("hello")
+        assert note.pop("pinned", "none") == "none"
+        assert note.setdefault("pinned", True) is True
+        assert note.pop("pinned") is True
+        assert dict(note) == {"text": "hello"}
+
+        note.clear()
+        assert dict(note) == {}
+
+    def test_delitem_takes_the_key_away_with_the_value(self) -> None:
+        class Note(Magic, mapping=True):
+            text: str
+            pinned: NoInit[bool]
+
+        note = Note("hello")
+        note["pinned"] = True
+
+        del note["pinned"]
+
+        assert "pinned" not in note
+        assert len(note) == 1
+        assert list(note) == ["text"]
+        assert dict(note) == {"text": "hello"}
+
+        note["pinned"] = False
+        assert dict(note) == {"text": "hello", "pinned": False}
+
+    def test_delitem_of_a_field_with_no_value_says_so(self) -> None:
+        class Note(Magic, mapping=True):
+            pinned: NoInit[bool]
+
+        with pytest.raises(KeyError, match="Note.pinned has no value"):
+            del Note()["pinned"]
+
+    def test_delitem_is_refused_when_a_default_stands_behind_the_key(
+        self
+    ) -> None:
+        class Note(Magic, mapping=True):
+            pinned: bool = False
+
+        note = Note(True)
+        with pytest.raises(TypeError, match="Note.pinned has a default"):
+            del note["pinned"]
+        # Refused, so nothing moved.
+        assert dict(note) == {"pinned": True}
+        assert len(note) == 1
+
+    def test_delitem_empties_a_defaulted_field_under_slots(self) -> None:
+        # With `slots` the default is written into the instance rather
+        # than left on the class, so there is nothing behind it.
+        class Note(Magic, mapping=True, slots=True):
+            pinned: bool = False
+
+        note = Note(True)
+        del note["pinned"]
+        assert dict(note) == {}
+        assert len(note) == 0
+
+    def test_a_frozen_mapping_refuses_to_fill_a_field_in(self) -> None:
+        class Note(Magic, mapping=True, frozen=True):
+            text: str
+            pinned: NoInit[bool]
+
+        note = Note("hello")
+        assert dict(note) == {"text": "hello"}
+        with pytest.raises(AttributeError, match="frozen field 'pinned'"):
+            note["pinned"] = True
+        with pytest.raises(AttributeError, match="frozen field 'text'"):
+            del note["text"]
+        assert dict(note) == {"text": "hello"}
+
+    def test_a_dict_is_what_compares_equal_to_a_dict(self) -> None:
+        # An instance compares as an instance of its class, whether or
+        # not it is dict-like, so the plain dict to compare with a
+        # plain dict is the one `dict()` builds.
+        class Note(Magic, mapping=True):
+            text: str
+            pinned: NoInit[bool]
+
+        note = Note("hello")
+        assert dict(note) == {"text": "hello"}
+        assert note != {"text": "hello"}
+
+        note["pinned"] = True
+        same = Note("hello")
+        same["pinned"] = True
+        assert note == same
+
     def test_mapping_default_off(self) -> None:
         class Point(Magic):
             x: int
@@ -4459,18 +4655,42 @@ class TestParityHelpers:
         assert _api.replace(post).x == 500
         assert _api.replace(post, scale=1).x == 50
 
-    def test_an_unset_field_is_reported_not_leaked(self) -> None:
+    def test_an_unset_field_is_left_out_of_asdict(self) -> None:
         class Lazy(Magic):
             a: int = 1
             b: Annotated[int, Field(init=False, repr=False)]
 
         lazy = Lazy()
         assert lazy.a == 1
-        for call in (lambda: _api.asdict(lazy), lambda: _api.astuple(lazy)):
-            with pytest.raises(
-                AttributeError, match="Lazy.b has never been given a value"
-            ):
-                call()
+        assert _api.asdict(lazy) == {"a": 1}
+        lazy.b = 2
+        assert _api.asdict(lazy) == {"a": 1, "b": 2}
+
+    def test_an_unset_field_is_reported_not_leaked_by_astuple(self) -> None:
+        class Lazy(Magic):
+            a: int = 1
+            b: Annotated[int, Field(init=False, repr=False)]
+
+        with pytest.raises(
+            AttributeError, match="Lazy.b has never been given a value"
+        ):
+            _api.astuple(Lazy())
+
+    def test_the_three_views_of_one_unset_field(self) -> None:
+        # A key names the field it belongs to and a position does not,
+        # so the two dict-shaped answers can leave a field out where
+        # the tuple cannot.
+        class Draft(Magic, mapping=True):
+            title: str
+            slug: NoInit[str]
+
+        draft = Draft("Ada")
+        assert _api.asdict(draft) == {"title": "Ada"}
+        assert dict(draft) == _api.asdict(draft)
+        with pytest.raises(
+            AttributeError, match="Draft.slug has never been given a value"
+        ):
+            _api.astuple(draft)
 
     def test_an_unset_field_is_reported_by_replace_too(self) -> None:
         # Reachable through a hand-written `__init__` that leaves a


### PR DESCRIPTION
Closes #60.

## The bug

A concrete field that was never given a value broke the whole view:

```pycon
>>> class N(Magic, mapping=True):
...     x: NoInit[int]
>>> len(N())
AttributeError: 'N' object has no attribute 'x'
```

The field is real, so the `not f.var` filter from #53 did not cover it. It has no parameter and no default, so nothing assigns it — it is meant to be set in `__post_init__`, or not at all. `n.x` raising is correct; `len(n)` raising is not.

## What it does now

**The view holds the fields that currently have a value.** An unset field is simply absent:

```
len 1 | dict {'y': 1} | list ['y'] | 'x' in n: False
```

and arrives when it gets one:

```
>>> n["x"] = 5
len 2 | dict {'x': 5, 'y': 1}
```

`__iter__` and `__len__` share one predicate so they cannot disagree, and `__getitem__` raises a `KeyError` that says why rather than leaking the `AttributeError`:

> `N.x` has no value, so `'x'` is not one of the keys. Give the field a default, or set it in `__post_init__`.

The consequence, stated in `__len__`'s docstring and in the `mapping` option text: **`len()` can differ between two instances of one class, and change over an instance's life.** That is honest for a mapping and is the point of the decision, but it is surprising for something that also reads as a record, so it is written where a user meets it.

## `asdict` skips too; `astuple` still raises

A field left unset is the class author's decision — it reads like an optional key in a `TypedDict` — so `asdict` agrees with the view, and `dict(obj) == asdict(obj)`.

`astuple` keeps raising, and the reason is not strictness: **a key names its field and a position does not.** Omit a key and the caller can see it is missing; omit a value from a tuple and every position after the gap shifts, so `astuple(a)[2]` means one field for one instance and another for the next, with nothing in the value to say so. Putting a sentinel in the slot was considered and rejected — `MISSING` is not public, so that would leak an internal into a public return value.

Both docstrings carry the reason, so three accessors with two behaviours read as a decision rather than an accident.

## `__delitem__`

It **removes the value**: the field goes back to holding nothing, the key leaves the view, and `m[k] = v` brings it back. That is the only reading consistent with "the view is what is there", and the `MutableMapping` mixins need it — `pop`, `popitem` and `clear` are all built on `__delitem__` plus `KeyError`.

It **refuses with a `TypeError`** in one case: when a class-level default sits behind the value on a non-`slots` class. `delattr` cannot reach a class attribute, so the field would spring straight back to the default and the key would still be there — a delete that silently does not delete. That also closes a path where `clear()` used to fail halfway through.

## What the ABCs gave for free

`__contains__`, `get`, `keys`, `values`, `items`, `pop`, `popitem`, `setdefault`, `update` and `clear` are all correct with entries absent — each is built on the four methods above and treats a missing key as `KeyError`, which is exactly what was escaping as `AttributeError`.

`Mapping.__eq__` gives nothing: `Magic` precedes `Mapping` in the MRO and always carries a generated `__eq__`, so an instance never compares equal to a plain `dict` (even under `eq=False`, which falls through to `Magic`'s own — that is #23). Left alone and pinned in a test; `dict(obj)` is the thing to compare with a dict.

## Two more found on the way, filed not fixed

**#63** — `repr()` and `==` raise on an unset field, the same gap one layer up. An object whose `repr()` raises is very hard to debug, and it is the first thing anyone reaches for. `__repr__` can probably skip, the way `HIDE_IF_NONE` already does; `__eq__` cannot just skip, since two objects differing only in *which* fields are unset should not be equal — that needs a real decision, and `__hash__` needs the same one.

**`__setitem__` with `None` on a `HIDE_IF_NONE` field** sets the attribute but leaves the key out of the view, so `m[k] = None` then `k not in m`. Pre-existing and arguably what the sentinel asks for, but it breaks the `MutableMapping` expectation that what you just set reads back. Not filed yet — say if you want it as its own issue.

680 passed on 3.11 and 3.13; ruff and codespell clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_