### PR TITLE
Let repr, == and hash cope with a field that holds nothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,30 @@ anything while every field is in the tuple.
 There is also `fields` and `fields_dict` for the fields themselves, and
 `is_magic` to ask whether a class was built by `Magic` at all.
 
+**A field with no value** is left out of `repr()` as well, so an object you
+are half-way through filling in still prints. Equality counts it rather than
+skipping it: two objects are equal when the same fields are holding values and
+those values match — one that has been given a value is never equal to one
+that is still without, and `hash` agrees. Ordering is the one that refuses,
+for the same reason `astuple` does: a comparison reads the fields in turn, so
+it needs all of them.
+
+```pycon
+>>> class Draft(Magic):
+...     title: str
+...     slug: NoInit[str]
+>>> Draft("Ada")
+Draft(title='Ada')
+>>> Draft("Ada") == Draft("Ada")
+True
+>>> ada = Draft("Ada")
+>>> ada.slug = "ada"
+>>> ada
+Draft(title='Ada', slug='ada')
+>>> ada == Draft("Ada")
+False
+```
+
 **Mutable defaults that are not shared.** In a plain class, `x: list = []`
 hands every instance the *same* list. Here each one gets its own:
 

--- a/src/bagof/magic/_api.py
+++ b/src/bagof/magic/_api.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import typing_extensions as tx
 
 from ._constants import _FIELDS, MISSING, _HasFactory
-from ._fields import Field
+from ._fields import Field, _stored
 
 __all__ = [
     "fields",
@@ -50,19 +50,6 @@ def _keyed(found: tx.Iterable[Field]) -> tx.Dict[str, Field]:
     collide.
     """
     return {field.public_name: field for field in found}
-
-
-def _stored(obj: tx.Any, field: Field) -> tx.Tuple[bool, tx.Any]:
-    """The value a field holds, and whether it holds one at all.
-
-    A field that is not a constructor argument and has no default is
-    only ever set by hand, so an object can be perfectly usable and
-    still have nothing under this name.
-    """
-    try:
-        return True, getattr(obj, field.name)
-    except AttributeError:
-        return False, None
 
 
 def _value(obj: tx.Any, field: Field, caller: str) -> tx.Any:

--- a/src/bagof/magic/_fields.py
+++ b/src/bagof/magic/_fields.py
@@ -353,6 +353,19 @@ class Field(SlotsBase):
             self.factory = _make_factory(self.type)
 
 
+def _stored(obj: tx.Any, field: Field) -> tx.Tuple[bool, tx.Any]:
+    """The value a field holds on an object, and whether it holds one.
+
+    A field that is not a constructor argument and has no default is
+    only ever set by hand, so an object can be perfectly usable and
+    still have nothing under this name.
+    """
+    try:
+        return True, getattr(obj, field.name)
+    except AttributeError:
+        return False, None
+
+
 # ----------------------------------------------------------------------
 # Annotations
 # ----------------------------------------------------------------------

--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -35,11 +35,13 @@ Parameters
 init : bool | str, default=True
     Generate `__init__` method
 repr : bool | str, default=True
-    Generate `__repr__` method
+    Generate `__repr__` method; a field holding no value is left out
 eq : bool | str, default=True
-    Generate `__eq__` method
+    Generate `__eq__` method; two objects are equal when the same
+    fields are holding values and those values match
 order : bool | str, default=False
-    Generate `__lt__`, `__le__`, `__gt__` and `__ge__` methods
+    Generate `__lt__`, `__le__`, `__gt__` and `__ge__` methods; a field
+    holding no value stops the comparison
 hash : bool | str, default=None
     Generate `__hash__` method; if `None`, decide automatically
 unsafe_hash : bool, default=False
@@ -173,7 +175,7 @@ from ._constants import (
     _HasFactory,
 )
 from ._fields import *  # noqa: F401, F403
-from ._fields import Field
+from ._fields import Field, _stored
 from ._fields import __all__ as __all_fields__
 from ._options import *  # noqa: F401, F403
 from ._options import Options
@@ -1659,7 +1661,11 @@ def _hash_add(qualname: str, fields: dict) -> int:
     ]
 
     def __hash__(self: Magic) -> int:
-        values = tuple(getattr(self, f.name) for f in fields)
+        # What is hashed is what `__eq__` compares: for each field,
+        # whether it is holding a value and the value it holds. Two
+        # objects that are equal hash together, a field holding nothing
+        # included.
+        values = tuple(_stored(self, f) for f in fields)
         return hash(values)
 
     __hash__.__qualname__ = f"{qualname}.__hash__"
@@ -1940,18 +1946,44 @@ def _make_init(
 
 
 def _make_repr(qualname: str, fields: dict[str, Field]) -> tx.Callable:
+    """Build `__repr__`, over the fields that are shown.
+
+    A field is shown while it is holding a value, so which fields an
+    instance shows is a question about that instance rather than about
+    its class. A field holds nothing when the constructor does not take
+    it and it has no default -- one like that is only ever set by hand
+    -- and a field can also ask to be left out for as long as its value
+    is `None`.
+    """
 
     def __repr__(self: Magic) -> str:
-        params = [
-            f"{field.public_name}={getattr(self, field.name)!r}"
-            for field in fields.values()
-            if field.repr(getattr(self, field.name))
-        ]
+        params = []
+        for field in fields.values():
+            has_value, value = _stored(self, field)
+            if has_value and field.repr(value):
+                params.append(f"{field.public_name}={value!r}")
         params = ", ".join(params)
         return f"{self.__class__.__name__}({params})"
 
     __repr__.__qualname__ = f"{qualname}.__repr__"
     return __repr__
+
+
+def _matching(
+    this: tx.Tuple[bool, tx.Any], that: tx.Tuple[bool, tx.Any]
+) -> tx.Any:
+    """Whether two fields hold the same thing, or neither holds one.
+
+    Both halves of what `_stored` reports are compared, not just the
+    value. Two objects that differ in *which* of their fields have been
+    given a value are different objects, even where the values they do
+    have match -- otherwise `a == b` would be true while reading `a.x`
+    raises and reading `b.x` does not.
+    """
+    (this_has_value, this_value), (that_has_value, that_value) = this, that
+    if this_has_value != that_has_value:
+        return False
+    return not this_has_value or this_value == that_value
 
 
 def _make_eq(qualname: str, fields: dict[str, Field]) -> tx.Callable:
@@ -1961,7 +1993,7 @@ def _make_eq(qualname: str, fields: dict[str, Field]) -> tx.Callable:
             return True
         if other.__class__ is self.__class__:
             return all(
-                getattr(self, field.name) == getattr(other, field.name)
+                _matching(_stored(self, field), _stored(other, field))
                 for field in fields.values()
                 if field.eq
             )
@@ -1979,20 +2011,35 @@ def _make_order(
     # that take part in the ordering, as a tuple.
     name, compare = _ORDER_METHODS[slot]
 
+    def ordered_values(obj: Magic) -> tx.Tuple:
+        """The values being compared, in field order.
+
+        A field holding no value stops the comparison, with a message
+        naming it. Skipping it would move every field after it up a
+        position, so one position would stand for a different field
+        from one object to the next and the answer would mean nothing.
+        """
+        values = []
+        for field in fields.values():
+            if not field.order:
+                continue
+            has_value, value = _stored(obj, field)
+            if not has_value:
+                raise AttributeError(
+                    f"{type(obj).__name__}.{field.name} has never been "
+                    f"given a value, so these two cannot be ordered: a "
+                    f"comparison reads every field that takes part in the "
+                    f"ordering, and this one has nothing to read. Give the "
+                    f"field a default, set it in __post_init__, or leave "
+                    f"it out of the ordering with NoOrder."
+                )
+            values.append(value)
+        return tuple(values)
+
     def method(self: Magic, other: tx.Any) -> tx.Any:
         if other.__class__ is not self.__class__:
             return NotImplemented
-        this_value = tuple(
-            getattr(self, field.name)
-            for field in fields.values()
-            if field.order
-        )
-        other_value = tuple(
-            getattr(other, field.name)
-            for field in fields.values()
-            if field.order
-        )
-        return compare(this_value, other_value)
+        return compare(ordered_values(self), ordered_values(other))
 
     method.__name__ = name
     method.__qualname__ = f"{qualname}.{name}"
@@ -2150,13 +2197,6 @@ def _make_mapping(
     as its value is `None`.
     """
 
-    def _stored(self: Magic, field: Field) -> tx.Tuple[bool, tx.Any]:
-        """The value a field is holding, and whether it holds one."""
-        try:
-            return True, getattr(self, field.name)
-        except AttributeError:
-            return False, None
-
     def _is_key(self: Magic, field: Field) -> bool:
         """Whether a field is one of the keys as things stand."""
         has_value, value = _stored(self, field)
@@ -2290,14 +2330,20 @@ class MetaMagic(ABCMeta):
     init : bool | str, default=True
         Generate `__init__` method.
     repr : bool | str, default=True
-        Generate `__repr__` method.
+        Generate `__repr__` method. A field is shown while it is
+        holding a value, so a field the constructor does not take, with
+        no default, is left out until something sets it.
     eq : bool | str, default=True
-        Generate `__eq__` method.
+        Generate `__eq__` method. Two objects are equal when the same
+        fields are holding values and those values match: one that has
+        been given a value is never equal to one that is still without.
     order : bool | str, default=False
         Generate `__lt__`, `__le__`, `__gt__` and `__ge__` methods.
         Given a name, generate the `<` comparison under that name; the
         class is then left with none of the four comparison operators,
-        including any it would otherwise inherit.
+        including any it would otherwise inherit. A field holding no
+        value stops the comparison and says so, since an order over
+        part of an object is not an order over the object.
     hash : bool | str, default=None
         Generate `__hash__` method.
         If `None`, decide automatically.
@@ -2376,14 +2422,20 @@ class Magic(metaclass=MetaMagic):
     init : bool | str, default=True
         Generate `__init__` method.
     repr : bool | str, default=True
-        Generate `__repr__` method.
+        Generate `__repr__` method. A field is shown while it is
+        holding a value, so a field the constructor does not take, with
+        no default, is left out until something sets it.
     eq : bool | str, default=True
-        Generate `__eq__` method.
+        Generate `__eq__` method. Two objects are equal when the same
+        fields are holding values and those values match: one that has
+        been given a value is never equal to one that is still without.
     order : bool | str, default=False
         Generate `__lt__`, `__le__`, `__gt__` and `__ge__` methods.
         Given a name, generate the `<` comparison under that name; the
         class is then left with none of the four comparison operators,
-        including any it would otherwise inherit.
+        including any it would otherwise inherit. A field holding no
+        value stops the comparison and says so, since an order over
+        part of an object is not an order over the object.
     hash : bool | str, default=None
         Generate `__hash__` method.
         If `None`, decide automatically.

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -667,6 +667,60 @@ class TestRepr:
         p = Point(1, 2)
         assert "Point" not in repr(p) or "x=" not in repr(p)
 
+    # -- a field is shown only while it is holding a value -------------
+
+    def test_repr_leaves_out_a_field_with_no_value(self) -> None:
+        class Note(Magic):
+            text: str
+            pinned: NoInit[bool]
+
+        assert repr(Note("hello")) == "Note(text='hello')"
+
+    def test_a_repr_of_nothing_but_unset_fields_still_reads(self) -> None:
+        class Blank(Magic):
+            here: NoInit[int]
+            there: NoInit[int]
+
+        assert repr(Blank()) == "Blank()"
+
+    def test_a_field_given_a_value_joins_the_repr(self) -> None:
+        class Note(Magic):
+            text: str
+            pinned: NoInit[bool]
+
+        note = Note("hello")
+        note.pinned = True
+        assert repr(note) == "Note(text='hello', pinned=True)"
+
+    def test_a_field_filled_in_by_post_init_is_shown(self) -> None:
+        class Draft(Magic):
+            title: str
+            slug: NoInit[str]
+
+            def __post_init__(self, arguments: Arguments) -> None:
+                self.slug = self.title.lower()
+
+        assert repr(Draft("Ada")) == "Draft(title='Ada', slug='ada')"
+
+    def test_hidden_while_none_and_holding_nothing_are_both_left_out(
+        self
+    ) -> None:
+        class C(Magic):
+            x: Annotated[Optional[int], Field(repr=HIDE_IF_NONE)]
+            y: NoInit[int]
+
+        c = C(None)
+        assert repr(c) == "C()"
+        c.x, c.y = 1, 2
+        assert repr(c) == "C(x=1, y=2)"
+
+    def test_a_class_whose_fields_all_have_values_is_unchanged(self) -> None:
+        class Point(Magic):
+            x: int
+            y: int = 1
+
+        assert repr(Point(1)) == "Point(x=1, y=1)"
+
 
 # ======================================================================
 # Eq / Order
@@ -817,6 +871,81 @@ class TestEqOrder:
             with pytest.raises(TypeError, match="not supported between"):
                 compare(Child(1, 0), Child(2, 0))
 
+    # -- a field with no value is counted, not skipped -----------------
+
+    def test_two_objects_with_the_same_field_unset_are_equal(self) -> None:
+        class Note(Magic):
+            text: str
+            pinned: NoInit[bool]
+
+        assert Note("hello") == Note("hello")
+        assert Note("hello") != Note("goodbye")
+
+    def test_a_field_with_a_value_differs_from_one_without(self) -> None:
+        class Note(Magic):
+            text: str
+            pinned: NoInit[bool]
+
+        filled, empty = Note("hello"), Note("hello")
+        filled.pinned = True
+        assert filled != empty
+        assert empty != filled
+        # Both holding the same value, they are equal again.
+        empty.pinned = True
+        assert filled == empty
+
+    def test_a_field_holding_none_is_not_a_field_holding_nothing(
+        self
+    ) -> None:
+        class Note(Magic):
+            pinned: NoInit[Optional[bool]]
+
+        holding_none = Note()
+        holding_none.pinned = None
+        assert holding_none != Note()
+
+    def test_a_field_left_out_of_eq_need_not_have_a_value(self) -> None:
+        class Note(Magic):
+            text: str
+            pinned: Annotated[bool, NoInit(), NoEq()]
+
+        filled, empty = Note("hello"), Note("hello")
+        filled.pinned = True
+        assert filled == empty
+
+    def test_ordering_says_which_field_has_no_value(self) -> None:
+        class Note(Magic, order=True):
+            text: str
+            weight: NoInit[int]
+
+        with pytest.raises(AttributeError, match="Note.weight has never"):
+            operator.lt(Note("a"), Note("b"))
+
+    def test_every_comparison_refuses_a_field_with_no_value(self) -> None:
+        class Note(Magic, order=True):
+            weight: NoInit[int]
+
+        for compare in (operator.lt, operator.le, operator.gt, operator.ge):
+            with pytest.raises(AttributeError, match="cannot be ordered"):
+                compare(Note(), Note())
+
+    def test_ordering_reads_the_other_object_as_well(self) -> None:
+        class Note(Magic, order=True):
+            weight: NoInit[int]
+
+        filled = Note()
+        filled.weight = 1
+        with pytest.raises(AttributeError, match="Note.weight has never"):
+            operator.lt(filled, Note())
+
+    def test_a_field_out_of_the_ordering_need_not_have_a_value(self) -> None:
+        class Note(Magic, order=True):
+            text: str
+            pinned: Annotated[bool, NoInit(), NoOrder()]
+
+        assert Note("a") < Note("b")
+        assert not Note("b") < Note("a")
+
     def test_order_requires_eq(self) -> None:
         with pytest.raises(ValueError, match="eq must be true"):
             class Bad(Magic):
@@ -864,6 +993,30 @@ class TestHash:
 
         s = {Point(1, 2), Point(1, 2), Point(3, 4)}
         assert len(s) == 2
+
+    # -- a field with no value hashes as one --------------------------
+
+    def test_hash_agrees_with_eq_about_a_field_with_no_value(self) -> None:
+        class Note(Magic, frozen=True, eq=True):
+            text: str
+            pinned: NoInit[bool]
+
+        assert Note("a") == Note("a")
+        assert hash(Note("a")) == hash(Note("a"))
+        assert len({Note("a"), Note("a")}) == 1
+
+    def test_hash_tells_a_field_with_a_value_from_one_without(self) -> None:
+        # Mutable, so that one of the two can be given a value: on a
+        # frozen class the field could never be set in the first place.
+        class Note(Magic, unsafe_hash=True):
+            text: str
+            pinned: NoInit[bool]
+
+        empty, filled = Note("a"), Note("a")
+        filled.pinned = True
+        assert filled != empty
+        assert hash(filled) != hash(empty)
+        assert len({empty, filled}) == 2
 
 
 # ======================================================================


### PR DESCRIPTION
Closes #63.

## The bug

A concrete field with no parameter and no default is never assigned — it is meant to be set in `__post_init__`, or not at all. Both generated methods read it unconditionally:

```pycon
>>> class N(Magic):
...     x: NoInit[int]
...     y: int = 1
>>> repr(N())
AttributeError: 'N' object has no attribute 'x'
>>> N() == N()
AttributeError: 'N' object has no attribute 'x'
```

An object whose `repr()` raises is very hard to debug, and `repr()` is the first thing anyone reaches for when something is wrong.

## What each method does now

**`repr` shows a field while it is holding a value.** There was already precedent — `HIDE_IF_NONE` omits a field holding `None` — so a field simply not appearing is an established shape here.

```
repr(N())  ->  N(y=1)
```

**`==` compares `(is it set, the value)` pairs**, not values. Two objects that differ in *which* fields are set are different objects, so `a == b` can never be true while `a.x` raises and `b.x` does not. A field holding `None` is therefore not equal to one holding nothing:

```
both unset          -> True
set vs unset        -> False
one None, one unset -> False
```

**`hash` hashes the same pairs**, so equal objects hash together and a `set` keeps one entry — and a set field is told apart from an unset one.

**Ordering raises**, with a message rather than the bare `AttributeError`:

> `F.x` has never been given a value, so these two cannot be ordered: a comparison reads every field that takes part in the order…

An order over part of an object is not an order over the object, and skipping a field would shift every position after it — which is exactly why `astuple` refuses. It stays an `AttributeError`, the type the reader got by accident before, so anything catching it still works. `NotImplemented` was rejected: it produces "'<' not supported between instances of 'P' and 'P'", which blames the type for something the instance is responsible for.

## Consistent with what `main` already decided

| accessor | an unset field |
|---|---|
| the dict-like view, `asdict`, `repr` | absent |
| `astuple`, ordering | an error, because a position is only meaningful if all of them are there |
| `==`, `hash` | part of the value: set-and-equal, or both unset |

## The shared predicate

`_stored(obj, field) -> (has_value, value)` moved from `_api.py` down to `_fields.py`, next to the `Field` it answers about. `_magic` importing `_api` would have pointed the builder at the module of public functions built on top of it; `_fields` is already imported by both and depends only on `_constants`/`_options`/`_resolve`/`_utils`, so nothing new can cycle. It also removed a third copy that had grown inside `_make_mapping`.

One deliberate non-change: `__eq__` keeps its per-field `all(... == ...)` shape rather than comparing one big tuple, because tuple comparison applies an identity shortcut per element and would have silently changed NaN behaviour.

## Also found, filed not fixed

**#66** — on a frozen class, a field with no parameter and no default can never be given a value at all: `__post_init__` assigning it raises `Cannot set frozen field`. This PR makes that quieter rather than louder — the field is now silently absent from `repr`, `==` and the view instead of raising from all three. Worth deciding whether `__post_init__` should be allowed to assign, or whether a computed-field spelling should cover it.

**A pseudo-field explicitly given `repr=True`** — `Annotated[int, InitVar(), Field(repr=True)]` used to raise from `repr()` because it is never stored, and is now simply skipped. Harmless, but that spelling silently does nothing.

731 passed on 3.11, 3.12 and 3.13; every source and test file at 100% coverage bar the pre-existing version branch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_