### PR TITLE
Resolve a hint on first use when it cannot be resolved at class creation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,9 @@ src/bagof/magic/
   _constants.py # sentinels (MISSING, REQUIRED, SHOW_ATTR) and the
                 #   `__magic_*__` attribute names
   _utils.py     # SlotsBase, rebuild_cls, the `slots` decorator
-  _resolve.py   # adapters to bagof-converters / -validators / -factories
+  _resolve.py   # adapters to bagof-converters / -validators / -factories,
+                #   and the deferred resolution of a hint that is still
+                #   a name when the class is built
 tests/
   test_magic.py                 # the builder, option by option
   test_docstrings.py            # every `pycon` block in a docstring or page
@@ -137,15 +139,54 @@ no structure to lose. `_doc_type` renders a type carried by name as that
 name, so generated documentation shows `parent : Node`.
 
 Only the structure is recovered eagerly, because it decides the generated
-`__init__`, which is compiled once. A converter, validator or factory
-resolved from a hint that is still a `ForwardRef` is the other half of the
-problem (#13) and wants deferred resolution instead.
+`__init__`, which is compiled once.
 
 `tests/test_annotations_as_strings.py` is the regression suite, and its
 future import is what makes it one — `tests/test_magic.py` cannot see any of
 this, since annotations there are already objects. The two quoted-annotation
 tests at the end of `test_magic.py` depend on that file *not* having the
 future import.
+
+### Hints that are still names when the class is built
+
+The other half of #13 is the converter, validator and factory a field
+resolves from its type. A hint that is still a `ForwardRef` or a string
+gives each of them something that fails on every value, so `_resolve.py`
+hands back a `_Deferred` instead: it evaluates the text the first time
+the field is *used*, builds the real converter/validator/factory there,
+caches it and delegates from then on. By first use the module has
+finished executing, so a class that names itself and a name written
+further down the file both simply resolve.
+
+Three things make that work, and each is load-bearing:
+
+- **The deferred callable is installed once, at build time.** `_make_init`
+  snapshots `field.converter` into the generated `__init__`'s locals,
+  while `__setattr__` reads it live on every call. Resolving later and
+  writing the answer back onto the `Field` would fix one path and leave
+  the other holding the old callable; doing the resolving *inside* the
+  installed object keeps both paths on the same one.
+- **`Hints` says where to look.** It holds the defining module's globals,
+  plus a namespace that `__post_new__` puts the class itself into under
+  its own name -- which is what lets a class written inside a function
+  (every class in the test suite) refer to itself.
+- **Whatever `_settle` works out is kept**, success or failure alike. A
+  hint that never resolves is therefore reported once for the field and
+  not once per call: a deferred converter on a hot constructor that said
+  so every time would be both a performance bug and a log flood, and
+  would end up suppressed wholesale.
+
+The `unresolved_hints` option chooses the report -- `"warn"` (the
+default) says so once and carries on, `"raise"` makes it a `NameError`,
+`"ignore"` says nothing. The per-resolver asymmetry is deliberate and
+lives in `_Kind.fallback`: a value can be passed through unconverted and
+unvalidated, but nothing can be invented in place of a default that
+cannot be built, so a factory raises whatever the option says.
+
+Evaluating the text later does not reopen the "an annotation is never
+called" rule. `_readable` refuses text with a call in it, so `x:
+_record()` is reported rather than run at first use, exactly as it is at
+class creation.
 
 ## Conventions specific to this repo (do not regress)
 
@@ -305,10 +346,9 @@ cd /tmp && PYTHONPATH=<repo>/src:<each sibling>/src:<site-packages> \
 
 ## Known follow-ups (see the tracking issues)
 
-- **Correctness**: unresolved string/forward annotations breaking
-  `convert`/`validate`/`factory` (#13); fields shared and mutated across
-  classes (#14); a disabled option falling through to `Magic`'s own
-  generated method (#23).
+- **Correctness**: fields shared and mutated across classes (#14); a
+  disabled option falling through to `Magic`'s own generated method
+  (#23).
 - **Model**: naming the field kind instead of inferring it from `init` (#16),
   which also carries the declared/resolved split that makes option inheritance
   work (#20).

--- a/README.md
+++ b/README.md
@@ -164,6 +164,44 @@ The rules come from [`bagof-converters`][converters] and
 containers, unions, enums, `TypedDict`, dates, paths, numpy arrays — works
 here too.
 
+A hint may name something that does not exist yet when the class is
+written: a class that refers to itself, a name defined further down the
+file, a type imported only for type checking. It is looked up the first
+time the field is actually used instead, by which point the module has
+finished loading — so an ordinary forward reference simply works, and
+`Router("9000").port` below is a `Port`.
+
+```python
+class Router(Magic, convert=True):
+    port: "Port" = 8080
+
+class Port(int):
+    pass
+```
+
+If the name is still not there by then, the field carries on unconverted
+and unvalidated, and says so once:
+
+```
+Router.port: the name `Port` is not defined, so `port` is not being
+converted.
+```
+
+A field whose default was to be built from its type has nothing to carry
+on with, so that one raises instead.
+
+`unresolved_hints` decides what that report is. Turning it into an error
+is worth doing in CI, where a hint that never resolves is a mistake
+rather than something to live with:
+
+```python
+class Service(Magic, convert=True, unresolved_hints="raise"):
+    port: int = 8080
+```
+
+The third choice, `"ignore"`, says nothing at all — for a hint you know
+will not resolve and do not want to hear about again.
+
 ---
 
 ## Also included
@@ -406,6 +444,7 @@ class Thing(Magic, frozen=True, kw_only=True, slots=True):
 | `weakref_slot` | `False` | allow weak references under `slots` |
 | `convert` | `False` | convert every field from its type |
 | `validate` | `False` | check every field against its type |
+| `unresolved_hints` | `"warn"` | what to do when a type hint still names something undefined the first time a field needs it; or `"raise"`, or `"ignore"` |
 | `factory` | `False` | build every missing default from its type |
 | `mutable_default` | `"factory"` | give each instance its own copy of `x: list = []`; or `"raise"`, or `"allow"` |
 | `mapping` | `False` | behave like a dictionary; a subclass cannot turn it off again |

--- a/src/bagof/magic/_constants.py
+++ b/src/bagof/magic/_constants.py
@@ -23,6 +23,10 @@ _FIELDS = '__magic_fields__'
 # @magic.
 _OPTIONS = '__magic_options__'
 
+# The name of an attribute on the class that stores where a type the
+# class was annotated with by name is looked up when it is first needed.
+_HINTS = '__magic_hints__'
+
 # The name of a method that is called before the __init__ method,
 # if it exists.
 # It returns (args, kwargs).

--- a/src/bagof/magic/_fields.py
+++ b/src/bagof/magic/_fields.py
@@ -39,6 +39,7 @@ import typing_extensions as tx
 
 from ._constants import HIDE_IF_NONE, MISSING, REQUIRED, SHOW_ATTR
 from ._options import Options
+from ._resolve import Hints
 from ._resolve import make_converter as _make_converter
 from ._resolve import make_factory as _make_factory
 from ._resolve import make_validator as _make_validator
@@ -276,9 +277,16 @@ class Field(SlotsBase):
         field.update(Field(name=name, type=type, default=default))
         return field
 
-    def setdefault(self, options: Options) -> None:
+    def setdefault(
+        self, options: Options, hints: tx.Optional[Hints] = None
+    ) -> None:
         # When field options are not explicitly set (MISSING), they are
         # inherited from the class options.
+        #
+        # `hints` says where to look up a type this field was annotated
+        # with by name -- a class that names itself, a type imported for
+        # type checking only -- when the converter, validator or factory
+        # built here is first used.
         if options.kw_only and options.positional_only:
             raise ValueError(
                 "Cannot set both kw_only and positional_only to True"
@@ -340,17 +348,17 @@ class Field(SlotsBase):
         if self.converter is MISSING:
             self.converter = options.convert
         if self.converter is True:
-            self.converter = _make_converter(self.type)
+            self.converter = _make_converter(self.type, hints, self.name)
         if self.validator is MISSING:
             self.validator = options.validate
         if self.validator is True:
-            self.validator = _make_validator(self.type)
+            self.validator = _make_validator(self.type, hints, self.name)
         if self.factory is MISSING:
             self.factory = options.factory
         if self.factory is True:
             # Resolve the default factory from the field's type hint, the
             # same way converters/validators are resolved from their bag.
-            self.factory = _make_factory(self.type)
+            self.factory = _make_factory(self.type, hints, self.name)
 
 
 # ----------------------------------------------------------------------

--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -64,6 +64,9 @@ convert : bool, default=False
     Use field type as converter if none is provided
 validate : bool, default=False
     Use field type as validator if none is provided
+unresolved_hints : str, default="warn"
+    What to do when a type hint still names something undefined the
+    first time a field needs it: "warn", "raise" or "ignore"
 mapping : bool, default=False
     Implement the `Mapping` protocol; a subclass cannot turn it off.
     Only a field that is holding a value is a key
@@ -159,6 +162,7 @@ from ._constants import (
     _DISCARD,
     _FIELDS,
     _GENERATED,
+    _HINTS,
     _MAGIC,
     _OPTIONS,
     _POST_INIT_NAME,
@@ -178,6 +182,8 @@ from ._fields import __all__ as __all_fields__
 from ._options import *  # noqa: F401, F403
 from ._options import Options
 from ._options import __all__ as __all_options__
+from ._resolve import POLICIES as _HINT_POLICIES
+from ._resolve import Hints
 from ._utils import _get_origin, rebuild_cls
 
 __all__ += __all_arguments__
@@ -197,6 +203,14 @@ __all__ += __all_options__
 def __post_new__(cls: type) -> type:
     # These methods have to be assigned post-new, because they
     # use super and therefore need to reference the class.
+
+    # A class that names itself in an annotation -- `parent: Node` in
+    # `class Node` -- cannot be looked up by name until now, and a class
+    # written inside a function is never in its module at all. Put it
+    # where its own fields will look for it.
+    hints = cls.__dict__.get(_HINTS)
+    if hints is not None:
+        hints.namespace[cls.__name__] = cls
 
     fields = getattr(cls, _FIELDS, {})
     fields = {name: field for name, field in fields.items() if not field.var}
@@ -1236,6 +1250,18 @@ def __pre_new__(
             f"not {options.mutable_default!r}"
         )
 
+    if options.unresolved_hints not in _HINT_POLICIES:
+        raise ValueError(
+            f"unresolved_hints must be 'warn', 'raise' or 'ignore', "
+            f"not {options.unresolved_hints!r}"
+        )
+
+    # Where a type this class was annotated with by name is looked up
+    # when a field first needs it. The class itself is added to the
+    # namespace once it exists, by `__post_new__`.
+    hints = Hints(globals, {}, clsname, options.unresolved_hints)
+    namespace[_HINTS] = hints
+
     # Annotations that are defined in this class (not in base
     # classes).  If __annotations__ isn't present, then this class
     # adds no new   We use this to compute fields that are
@@ -1285,7 +1311,7 @@ def __pre_new__(
             field.default = namespace[field.name]
 
         # Set unset field options from class options
-        field.setdefault(options)
+        field.setdefault(options, hints)
 
         # A mutable default is promoted to a factory (or rejected),
         # so that instances do not end up sharing one object.
@@ -2325,6 +2351,13 @@ class MetaMagic(ABCMeta):
         Use field type as converter if none is provided.
     validate : bool, default=False
         Use field type as validator if none is provided.
+    unresolved_hints : str, default="warn"
+        What to do when a field is annotated with a type that is still
+        not defined the first time the field needs it. "warn" says so
+        once and carries on without converting or validating, "raise"
+        turns it into an error, and "ignore" says nothing. A default
+        value that cannot be built raises whichever is chosen, since
+        there is no value to hand back.
     mapping : bool, default=False
         Implement the `Mapping` protocol. A subclass cannot turn it off
         again. Only a field that is holding a value is a key, so which
@@ -2411,6 +2444,13 @@ class Magic(metaclass=MetaMagic):
         Use field type as converter if none is provided.
     validate : bool, default=False
         Use field type as validator if none is provided.
+    unresolved_hints : str, default="warn"
+        What to do when a field is annotated with a type that is still
+        not defined the first time the field needs it. "warn" says so
+        once and carries on without converting or validating, "raise"
+        turns it into an error, and "ignore" says nothing. A default
+        value that cannot be built raises whichever is chosen, since
+        there is no value to hand back.
     mapping : bool, default=False
         Implement the `Mapping` protocol. A subclass cannot turn it off
         again. Only a field that is holding a value is a key, so which

--- a/src/bagof/magic/_options.py
+++ b/src/bagof/magic/_options.py
@@ -23,6 +23,7 @@ from ._utils import SlotsBase, slots
     'mutable_default',  # What to do with a mutable default (x: list = [])
     'convert',          # Use field type as converter if none is provided
     'validate',         # Use field type as validator if none is provided
+    'unresolved_hints',  # What to do about a type hint that never resolves
     'mapping',          # Generate Mapping methods for dict-like behavior
     'reverse',          # Use the reverse MRO order when listing fields
     'doc',              # Generate class docstring from field docstrings
@@ -60,6 +61,7 @@ class Options(SlotsBase):
         mutable_default="factory",
         convert=False,
         validate=False,
+        unresolved_hints="warn",
         mapping=False,
         reverse=False,
         doc=True,

--- a/src/bagof/magic/_resolve.py
+++ b/src/bagof/magic/_resolve.py
@@ -8,11 +8,34 @@ both called as ``value = f(value)``. A converter already returns the
 converted value, but a validator only *raises* on failure and returns
 ``None`` -- so it is wrapped to return the value it was given. A ``factory``
 is called with no arguments to produce a default value.
+
+A hint is not always a type yet. A class that names itself, a type
+imported under ``if TYPE_CHECKING:``, a name bound further down the
+module -- each of those reaches the builder as the text it was written
+as, because the name it needs is not bound while the class statement is
+running. Building a converter out of that text gives one that fails on
+every value, so instead the three makers hand back a callable that
+resolves the hint the first time it is *used* and builds the real
+converter, validator or factory then. By then the module has finished
+executing, and the ordinary forward reference simply works.
+
+What is still unresolved at that point is reported once for the field --
+not once per call, which would flood a hot constructor -- and the class's
+``unresolved_hints`` option says whether that is a warning, an error, or
+nothing at all. A value can be passed through unconverted and
+unvalidated, so those two carry on; a default value cannot be invented,
+so a factory raises whatever the option says.
 """
 
 from __future__ import annotations
 
-__all__ = ["make_converter", "make_validator", "make_factory"]
+__all__ = ["Hints", "POLICIES", "make_converter", "make_validator",
+           "make_factory"]
+
+# stdlib
+import ast
+import builtins
+import warnings
 
 # dependencies
 import typing_extensions as tx
@@ -22,18 +45,90 @@ from bagof.converters import Converter
 from bagof.factories import get_factory
 from bagof.validators import Validator
 
+from ._constants import MISSING
 
-def make_converter(hint: tx.Any) -> tx.Callable[[tx.Any], tx.Any]:
+#: What `unresolved_hints` accepts, and what each of them does once a
+#: hint has failed to resolve on first use.
+POLICIES = ("warn", "raise", "ignore")
+
+
+class _UnresolvedHint(UserWarning):
+    """A type hint whose name was still not defined when it was needed."""
+
+
+class Hints:
+    """
+    Where the name in an unresolved hint is looked up when the field is
+    first used, and what to do if it is still not there.
+
+    Parameters
+    ----------
+    globals : dict
+        The namespace of the module the class is written in.
+    namespace : dict
+        Names that module does not have. The class being built is put
+        here once it exists, so that a class written inside a function
+        can still name itself.
+    owner : str
+        The name of the class, for the report.
+    policy : str
+        One of `POLICIES`.
+    """
+
+    __slots__ = ("globals", "namespace", "owner", "policy")
+
+    def __init__(
+        self,
+        globals: tx.Optional[dict] = None,
+        namespace: tx.Optional[dict] = None,
+        owner: str = "",
+        policy: str = "warn",
+    ) -> None:
+        self.globals = {} if globals is None else globals
+        self.namespace = {} if namespace is None else namespace
+        self.owner = owner
+        self.policy = policy
+
+    def where(self, name: str) -> str:
+        """`Server.port` -- the field, said the way it was written."""
+        return f"{self.owner}.{name}" if self.owner else name
+
+
+def make_converter(
+    hint: tx.Any, hints: tx.Optional[Hints] = None, name: str = ""
+) -> tx.Callable[[tx.Any], tx.Any]:
     """Return a callable that converts a value to ``hint``."""
-    return Converter.get(hint)
+    return _make(_CONVERTER, hint, hints, name)
 
 
-def make_validator(hint: tx.Any) -> tx.Callable[[tx.Any], tx.Any]:
+def make_validator(
+    hint: tx.Any, hints: tx.Optional[Hints] = None, name: str = ""
+) -> tx.Callable[[tx.Any], tx.Any]:
     """
     Return a callable that validates a value against ``hint`` and returns
     it unchanged (raising on failure).
     """
-    validator = Validator.get(hint)
+    return _make(_VALIDATOR, hint, hints, name)
+
+
+def make_factory(
+    hint: tx.Any, hints: tx.Optional[Hints] = None, name: str = ""
+) -> tx.Callable[[], tx.Any]:
+    """Return a no-argument callable producing a default value for ``hint``."""
+    return _make(_FACTORY, hint, hints, name)
+
+
+# ----------------------------------------------------------------------
+# The three, each built from a type that is really there
+# ----------------------------------------------------------------------
+
+
+def _converter(type: tx.Any) -> tx.Callable[[tx.Any], tx.Any]:
+    return Converter.get(type)
+
+
+def _validator(type: tx.Any) -> tx.Callable[[tx.Any], tx.Any]:
+    validator = Validator.get(type)
 
     def validate(value: tx.Any) -> tx.Any:
         validator(value)
@@ -42,6 +137,191 @@ def make_validator(hint: tx.Any) -> tx.Callable[[tx.Any], tx.Any]:
     return validate
 
 
-def make_factory(hint: tx.Any) -> tx.Callable[[], tx.Any]:
-    """Return a no-argument callable producing a default value for ``hint``."""
-    return get_factory(hint)
+def _factory(type: tx.Any) -> tx.Callable[[], tx.Any]:
+    return get_factory(type)
+
+
+def _unchanged(value: tx.Any) -> tx.Any:
+    # What a field is worth when the hint it was to be checked against
+    # never turned up: whatever it was given.
+    return value
+
+
+class _Kind:
+    # One of the three, and how to talk about it: how it is built from a
+    # type, how the report words the consequence -- once for carrying on
+    # without it, once for refusing -- and what it does instead of the
+    # real thing. `fallback` is None for a factory, which has no value to
+    # hand back and so has no choice but to refuse.
+
+    __slots__ = ("build", "skipped", "blocked", "fallback")
+
+    def __init__(
+        self,
+        build: tx.Callable,
+        skipped: str,
+        blocked: str,
+        fallback: tx.Optional[tx.Callable],
+    ) -> None:
+        self.build = build
+        self.skipped = skipped
+        self.blocked = blocked
+        self.fallback = fallback
+
+
+_CONVERTER = _Kind(
+    _converter,
+    "`{name}` is not being converted",
+    "`{name}` cannot be converted",
+    _unchanged,
+)
+_VALIDATOR = _Kind(
+    _validator,
+    "`{name}` is not being validated",
+    "`{name}` cannot be validated",
+    _unchanged,
+)
+_FACTORY = _Kind(
+    _factory,
+    "",
+    "no default value can be built for `{name}`",
+    None,
+)
+
+#: What to do about it, said the same way wherever the report appears.
+_REMEDY = (
+    "A name that is only imported under `if TYPE_CHECKING:` is not there "
+    "at runtime -- import it normally where the class is written."
+)
+
+
+# ----------------------------------------------------------------------
+# Hints that are still text
+# ----------------------------------------------------------------------
+
+
+def _make(
+    kind: _Kind, hint: tx.Any, hints: tx.Optional[Hints], name: str
+) -> tx.Callable:
+    text = _unresolved(hint)
+    if text is None:
+        return kind.build(hint)
+    return _Deferred(kind, text, Hints() if hints is None else hints, name)
+
+
+def _unresolved(hint: tx.Any) -> tx.Optional[str]:
+    # The text a hint was written as, when it is a name rather than a
+    # type, and None when it is a type and can be used straight away.
+    if isinstance(hint, str):
+        return hint
+    if isinstance(hint, tx.ForwardRef):
+        return hint.__forward_arg__
+    return None
+
+
+class _Deferred:
+    """A converter, validator or factory for a hint that is still a name."""
+
+    __slots__ = ("_kind", "_text", "_hints", "_name", "_call")
+
+    def __init__(
+        self, kind: _Kind, text: str, hints: Hints, name: str
+    ) -> None:
+        self._kind = kind
+        self._text = text
+        self._hints = hints
+        self._name = name
+        self._call = None
+
+    def __call__(self, *value: tx.Any) -> tx.Any:
+        call = self._call
+        if call is None:
+            call = self._call = self._settle()
+        return call(*value)
+
+    def _settle(self) -> tx.Callable:
+        # The first use is the second chance: the module has finished
+        # executing by now, so the name the class statement could not see
+        # is almost always there. What is settled here is kept, so a hint
+        # that is still missing is reported once and not once per call.
+        tree = _readable(self._text)
+        type = MISSING if tree is None else _evaluate(self._text, self._hints)
+        if type is not MISSING:
+            return self._kind.build(type)
+        return self._give_up(tree)
+
+    def _give_up(self, tree: tx.Optional[ast.AST]) -> tx.Callable:
+        hints, kind = self._hints, self._kind
+        if kind.fallback is None or hints.policy == "raise":
+            # A factory has nothing to hand back, so saying so quietly is
+            # not an option for it whatever the policy is.
+            report = self._report(kind.blocked, tree)
+
+            def refuse(*value: tx.Any) -> tx.Any:
+                raise NameError(report)
+
+            return refuse
+        if hints.policy == "warn":
+            # `_give_up`, `_settle`, `__call__`, the generated `__init__`
+            # or `__setattr__`, then the line that built the object --
+            # which is the one worth pointing at.
+            warnings.warn(
+                self._report(kind.skipped, tree), _UnresolvedHint,
+                stacklevel=5,
+            )
+        return kind.fallback
+
+    def _report(self, consequence: str, tree: tx.Optional[ast.AST]) -> str:
+        where = self._hints.where(self._name)
+        reason = _reason(self._text, tree, self._hints)
+        said = consequence.format(name=self._name)
+        return f"{where}: {reason}, so {said}. {_REMEDY}"
+
+
+def _readable(text: str) -> tx.Optional[ast.AST]:
+    # The hint as an expression, when looking up what it names is all it
+    # takes to evaluate it. An annotation is never *called* to find out
+    # what a field holds -- not while the class statement runs, and not
+    # later either -- so text with a call in it is left unread.
+    try:
+        tree = ast.parse(text, mode="eval")
+    except SyntaxError:
+        return None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            return None
+    return tree
+
+
+def _evaluate(text: str, hints: Hints) -> tx.Any:
+    # The type a hint names, or MISSING while the names in it are still
+    # not defined where the class was written.
+    try:
+        return eval(text, hints.globals, hints.namespace)
+    except Exception:
+        return MISSING
+
+
+def _reason(text: str, tree: tx.Optional[ast.AST], hints: Hints) -> str:
+    name = None if tree is None else _undefined_name(tree, hints)
+    if name is None:
+        return f"the type `{text}` could not be worked out"
+    return f"the name `{name}` is not defined"
+
+
+def _undefined_name(tree: ast.AST, hints: Hints) -> tx.Optional[str]:
+    # The first name in the hint that is not defined anywhere it is
+    # looked up, so the report can say which one is missing rather than
+    # quote the whole annotation back.
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and not _defined(node.id, hints):
+            return node.id
+    return None
+
+
+def _defined(name: str, hints: Hints) -> bool:
+    return (
+        name in hints.namespace
+        or name in hints.globals
+        or hasattr(builtins, name)
+    )

--- a/tests/test_annotations_as_strings.py
+++ b/tests/test_annotations_as_strings.py
@@ -22,9 +22,11 @@ from typing import TYPE_CHECKING
 
 import pytest
 import typing_extensions as tx
+from bagof.converters import ConversionError
 from typing_extensions import Annotated, ForwardRef
 
 import bagof.magic._magic as m
+import bagof.magic._resolve as r
 from bagof.magic import (
     Arguments,
     ClassVar,
@@ -38,6 +40,8 @@ from bagof.magic import (
     Magic,
     NoInit,
     NoRepr,
+    Options,
+    Validate,
 )
 
 if TYPE_CHECKING:
@@ -414,3 +418,201 @@ class TestAnnotationsAreNotRun:
 
         assert caught == []
         assert Service.__magic_fields__["rate"].type == "decimal.Decimal"
+
+
+# ======================================================================
+# Hints that are not types yet
+# ======================================================================
+
+
+class Sizes(Magic, convert=True):
+    """A class written above the name its field is annotated with."""
+
+    width: Pixels = 0  # noqa: F821
+
+
+#: Bound after the class that uses it, the way a name further down a
+#: module is when the class statement runs.
+Pixels = int
+
+
+class TestHintsResolvedOnFirstUse:
+
+    def test_a_class_that_names_itself_is_converted_on_first_use(
+        self
+    ) -> None:
+        class Node(Magic, convert=True):
+            value: int = 0
+            parent: KwOnly[tx.Optional[Node]] = None
+
+        assert Node.__magic_fields__["parent"].type == ForwardRef(
+            "tx.Optional[Node]"
+        )
+        assert Node(1, parent=Node(2)).parent.value == 2
+        # The converter really is the one `Node` asks for: it builds a
+        # `Node` out of what it is given, and refuses what it cannot.
+        assert Node(1, parent=7).parent == Node(7)
+        with pytest.raises(ConversionError):
+            Node(1, parent="deep")
+
+    def test_a_name_bound_later_in_the_module_resolves_on_first_use(
+        self
+    ) -> None:
+        assert Sizes.__magic_fields__["width"].type == "Pixels"
+        assert Sizes("3").width == 3
+
+    def test_a_class_whose_types_are_all_there_is_unchanged(self) -> None:
+        class Config(Magic, convert=True, validate=True):
+            host: str = "localhost"
+            port: int = 8080
+            tags: Factory[list]
+
+        for field in Config.__magic_fields__.values():
+            assert not isinstance(field.converter, r._Deferred)
+            assert not isinstance(field.validator, r._Deferred)
+            assert not isinstance(field.factory, r._Deferred)
+        assert Config("h", "9000") == Config(host="h", port=9000)
+        assert Config().tags == []
+
+    def test_a_default_is_built_from_a_name_bound_later(self) -> None:
+        class Basket(Magic):
+            items: Factory[Pixels]  # noqa: F821
+
+        assert Basket().items == 0
+
+
+class TestHintsThatNeverResolve:
+
+    def test_the_field_carries_on_and_says_so_once(self) -> None:
+        class Server(Magic):
+            port: ConvertTo[decimal.Decimal] = 1
+
+        with pytest.warns(UserWarning, match="is not being converted") as told:
+            first = Server("8")
+        assert len(told) == 1
+        assert first.port == "8"
+
+        # Once for the field, not once per call: a converter on a hot
+        # constructor that said this every time would be unusable.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            assert Server("9").port == "9"
+            assert Server("10").port == "10"
+        assert caught == []
+
+    def test_the_message_names_the_field_and_the_missing_name(self) -> None:
+        class Server(Magic):
+            port: ConvertTo[decimal.Decimal] = 1
+
+        with pytest.warns(UserWarning) as told:
+            Server("8")
+        assert str(told[0].message).startswith(
+            "Server.port: the name `decimal` is not defined, so `port` is "
+            "not being converted."
+        )
+
+    def test_building_and_assigning_agree(self) -> None:
+        class Server(Magic):
+            port: ConvertTo[decimal.Decimal] = 1
+
+        with pytest.warns(UserWarning):
+            built = Server("8")
+        assigned = Server(1)
+        assigned.port = "8"
+        assert built.port == assigned.port == "8"
+
+    def test_a_value_is_not_validated_and_says_so(self) -> None:
+        class Server(Magic):
+            port: Validate[decimal.Decimal] = 1
+
+        with pytest.warns(UserWarning, match="is not being validated"):
+            assert Server("8").port == "8"
+
+    def test_they_can_be_made_an_error(self) -> None:
+        class Server(Magic, unresolved_hints="raise"):
+            port: ConvertTo[decimal.Decimal] = 1
+
+        with pytest.raises(NameError, match="`port` cannot be converted"):
+            Server("8")
+        # Settled once, and it stays settled.
+        with pytest.raises(NameError):
+            Server("9")
+
+    def test_they_can_be_passed_over_in_silence(self) -> None:
+        class Server(Magic, unresolved_hints="ignore"):
+            port: Validate[decimal.Decimal] = 1
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            assert Server("8").port == "8"
+        assert caught == []
+
+    def test_a_default_that_cannot_be_built_says_so_when_it_is_needed(
+        self
+    ) -> None:
+        class Basket(Magic):
+            items: Factory[decimal.Decimal]
+
+        with pytest.raises(NameError, match="no default value can be built"):
+            Basket()
+        # Nothing is wrong with a value that was passed in.
+        assert Basket(3).items == 3
+
+    def test_a_default_that_cannot_be_built_raises_whatever_is_asked(
+        self
+    ) -> None:
+        # There is no value to hand back in place of one that cannot be
+        # built, so "ignore" has nothing quieter to offer.
+        class Basket(Magic, unresolved_hints="ignore"):
+            items: Factory[decimal.Decimal]
+
+        with pytest.raises(NameError, match="`items`"):
+            Basket()
+
+    def test_an_unknown_setting_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="unresolved_hints must be"):
+
+            class Server(Magic, unresolved_hints="shrug"):
+                port: int = 1
+
+    def test_a_hint_that_is_a_call_is_still_never_called(self) -> None:
+        _side_effects.clear()
+
+        class Reckless(Magic, convert=True):
+            x: _record() = 1
+
+        with pytest.warns(UserWarning, match="could not be worked out"):
+            assert Reckless("3").x == "3"
+        assert _side_effects == []
+
+    def test_a_hint_that_is_not_an_expression_is_reported(self) -> None:
+        Odd = type(Magic)(
+            "Odd",
+            (Magic,),
+            {"__annotations__": {"x": "1 +"}, "x": 1},
+            convert=True,
+        )
+        with pytest.warns(UserWarning, match=r"`1 \+` could not be worked"):
+            assert Odd("3").x == "3"
+
+    def test_a_hint_whose_names_are_all_defined_is_reported_as_written(
+        self
+    ) -> None:
+        # Every name in it is there; what it spells is not, so there is
+        # no missing name to point at.
+        class Sized(Magic, convert=True):
+            width: inspect.NotAThing = 1
+
+        with pytest.warns(
+            UserWarning, match="`inspect.NotAThing` could not be worked out"
+        ):
+            assert Sized("3").width == "3"
+
+    def test_a_field_with_nowhere_to_look_still_names_itself(self) -> None:
+        # A field resolved on its own, outside a class statement, has no
+        # module to look a name up in and no class to be named after.
+        field = Field(name="port", type="NeverDefined", converter=True)
+        field.setdefault(Options.make_default())
+
+        with pytest.warns(UserWarning, match="^port: the name `NeverDefined`"):
+            assert field.converter("8") == "8"


### PR DESCRIPTION
Closes #13 — the behavioural half. The structural half (`ClassVar`, `KwOnly`, `Frozen`, `alias`, `Doc` under PEP 563) landed as #55.

## Why deferral rather than anything eager

A hint that is unresolvable at class-creation time and perfectly resolvable a millisecond later is the normal case, not an error. `parent: Node` inside `class Node` is the commonest forward reference there is, and the name is not bound until the `class` statement returns.

So when a field's type is still text at build time, its converter, validator and factory become a `_Deferred` that resolves on first call, caches, and delegates from then on. By first use the module has finished executing, so it almost always succeeds silently:

```
self-reference converts: Node(name='child', parent=Node(name='root', parent=None))
```

Retry is free and correct because a failed `ForwardRef` is not poisoned — `__forward_evaluated__` caches only success.

## Installed once, at build time

`_make_init` snapshots the callable into the generated function's locals while `__setattr__` reads `field.converter` live, so "resolve later and write the answer back onto the `Field`" would have fixed one path and not the other, leaving the two disagreeing. The deferred callable is built once in `Field.setdefault` and does its resolving inside itself; `test_building_and_assigning_agree` pins it.

## When it still cannot resolve

Warn **once per field**, not once per call — a deferred converter on a hot constructor that warns every time is a performance bug and a log flood, and it gets suppressed wholesale. Verified across three constructions and an assignment:

```
warnings for 4 uses of one field: 1
  Server.port: the name `widgets` is not defined, so `port` is not being converted…
```

The new `unresolved_hints` option chooses: `"warn"` (default), `"raise"`, `"ignore"`. Registered in all six places convention 6 requires.

```
raise policy  -> NameError: Strict.port: the name `widgets` is not defined, so `port` cannot be converted…
ignore policy -> Quiet(port=1) | warnings: 0
```

The message names the *specific* missing symbol by walking the parsed hint for the first undefined name, rather than reading it back out of a `NameError` — which has no `.name` before 3.10 and would have made messages differ per interpreter.

Evaluating later does not reopen the "an annotation is never called" rule #55 established: the deferred resolver refuses any hint text containing a call.

## The per-resolver asymmetry held, and wanted different handling

Converter and validator fall back to passing the value through. **`factory` raises regardless of policy, `"ignore"` included** — there is no value to invent, and returning `None` would be exactly the quiet wrongness this repo keeps getting bitten by. So `unresolved_hints` has no observable effect on a factory, which is stated in both class docstrings, the README and CLAUDE.md rather than left to be discovered:

```
factory under ignore -> NameError
```

The message also splits by policy: under `"raise"`, "`port` is not being converted" would be a lie, so it reads "cannot be converted".

## Known limits, stated rather than hidden

**Only the top-level hint is deferred.** `list["Node"]` evaluates at class creation to `list[ForwardRef('Node')]`, so it is not text and never reaches the deferral — the sibling packages still get a `ForwardRef` buried inside. Deferring nested forward references means re-resolving the whole hint tree, which is a bigger change; #13 is closed on the top-level case only.

**A class defined inside a function** works because `__post_new__` puts the class into its own resolution namespace under its own name — which is every class in the test suite, and would otherwise never resolve since the name is not in module globals at all.

**The docs harness cannot demonstrate this in a `pycon` block.** `test_docstrings` gives README examples `__name__ == "bagof.magic"`, so a class defined in a block resolves against the package rather than the page. A "name defined further down the page" example therefore cannot resolve under doctest even though it works in a real module — so that part of the README is an executable `python` block plus prose rather than a `pycon` block that would be false.

**Not verified:** 3.8 (the floor) and 3.14 — no interpreter available here. The code is 3.8-clean by inspection and CI covers both.

## Also found, filed not fixed

**#68** — a default goes through the same converter as a caller's value, so `parent: Node = None` fails, and the error names the wrong field. Not caused by this change and reproduces on `main` with a worse message. The question is whether defaults should be converted at all — pydantic does not validate them by default.

737 passed on 3.11, 3.12 and 3.13; `_resolve.py` and the test file both at 100%.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_