### PR TITLE
Refuse two fields that take the same mapping key

### DIFF
--- a/src/bagof/magic/_fields.py
+++ b/src/bagof/magic/_fields.py
@@ -320,7 +320,13 @@ class Field(SlotsBase):
             # a set kept both.
             self.hash = None
         if self.key is MISSING:
-            self.key = options.mapping
+            # Like `repr`, and for the same reason: the class option
+            # says whether there is a dict-like view at all, which is
+            # not this field's business. What is the field's business is
+            # whether it belongs in one -- and a real field does, so
+            # that a class turning `mapping` on later, or a subclass
+            # turning it on, finds every field already in the view.
+            self.key = not self.var
         if self.eq is MISSING:
             self.eq = True
         if self.order is MISSING:

--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -366,11 +366,10 @@ def _check_public_keys(clsname: str, fields: dict[str, Field]) -> None:
     # that asks for one, and refusing it there would name two fields
     # the reader did not write there.
     #
-    # A pseudo-field is left out. It is not stored on the instance, so
-    # it is never part of the view, and on a dict-like class it takes
-    # its key from its own name by default -- counting it would refuse
-    # a class whose `ClassVar` merely happens to be named after another
-    # field's key, whose view is perfectly well-formed.
+    # A pseudo-field is left out: it is not stored on the instance, so
+    # it is never part of the view and has no key to clash with. A
+    # `ClassVar` named after another field's key is a class whose view
+    # is perfectly well-formed.
     seen = {}
     for name, field in fields.items():
         if field.var:

--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -336,6 +336,49 @@ def _check_public_names(clsname: str, fields: dict[str, Field]) -> None:
         seen[public] = name
 
 
+def _check_public_keys(clsname: str, fields: dict[str, Field]) -> None:
+    # Two fields cannot answer to one key of the dict-like view.
+    #
+    # A field's key is the one `Key("...")` gives it, or its public
+    # name. The view has room for only one field under a key, so when
+    # two share one, the second silently wins the key and the first is
+    # unreachable through the view -- and `len()` counts one field
+    # fewer than the class has.
+    #
+    # The class is refused whether or not it is dict-like. A key is a
+    # property of the field, so it is inherited, and `mapping` can be
+    # turned on further down the chain: a pair of keys written on a
+    # class with no view is a collision waiting for the first subclass
+    # that asks for one, and refusing it there would name two fields
+    # the reader did not write there.
+    #
+    # A pseudo-field is left out. It is not stored on the instance, so
+    # it is never part of the view, and on a dict-like class it takes
+    # its key from its own name by default -- counting it would refuse
+    # a class whose `ClassVar` merely happens to be named after another
+    # field's key, whose view is perfectly well-formed.
+    seen = {}
+    for name, field in fields.items():
+        if field.var:
+            continue
+        key = field.public_key
+        if key is None:
+            continue
+        if key in seen:
+            raise TypeError(
+                f"{clsname} has two fields, {seen[key]!r} and {name!r}, "
+                f"and both take {key!r} as their key: only one of them "
+                f"can be reached under {key!r} in the dict-like view, and "
+                f"len() would count one field fewer than the class has. A "
+                f"field's key is the one Key() gives it, or its public "
+                f"name -- and a key stays with the field, so a subclass "
+                f"built with mapping=True inherits both. Give one of the "
+                f"two a key of its own, or leave it out of the view with "
+                f"NotKey."
+            )
+        seen[key] = name
+
+
 #: Names that mark the *structure* of an annotation: the family declared
 #: in `_fields.py` (`KwOnly`, `Frozen`, `ClassVar`, ...) plus the typing
 #: spellings the builder reads. Used to recognise a structural marker by
@@ -1333,6 +1376,7 @@ def __pre_new__(
             )
 
     _check_public_names(clsname, fields)
+    _check_public_keys(clsname, fields)
 
     # Remember all of the fields on our class (including bases).
     namespace[_FIELDS] = fields

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -3229,6 +3229,38 @@ class TestPublicName:
 
 
 class TestMappingKey:
+
+    def test_a_subclass_turning_mapping_on_sees_inherited_fields(self) -> None:
+        # The class option says whether there is a view at all; every
+        # real field belongs in one, whichever class declared it.
+        class Base(Magic):
+            x: int = 1
+
+        class Sub(Base, mapping=True):
+            z: int = 3
+
+        assert dict(Sub()) == {"x": 1, "z": 3}
+        assert len(Sub()) == 2
+
+    def test_a_class_turning_mapping_on_below_two_levels(self) -> None:
+        class Base(Magic):
+            x: int = 1
+
+        class Middle(Base):
+            y: int = 2
+
+        class Sub(Middle, mapping=True):
+            z: int = 3
+
+        assert dict(Sub()) == {"x": 1, "y": 2, "z": 3}
+
+    def test_a_pseudo_field_still_has_no_key(self) -> None:
+        class C(Magic, mapping=True):
+            a: int = 1
+            tag: ClassVar[str] = "x"
+
+        assert dict(C()) == {"a": 1}
+        assert C.__magic_fields__["tag"].public_key is None
     """Two fields cannot share one key of the dict-like view."""
 
     def test_two_explicit_keys_that_are_the_same_are_rejected(self) -> None:

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -3228,6 +3228,78 @@ class TestPublicName:
         assert C(1).self == 1
 
 
+class TestMappingKey:
+    """Two fields cannot share one key of the dict-like view."""
+
+    def test_two_explicit_keys_that_are_the_same_are_rejected(self) -> None:
+        # Both fields answered to `k`, so `a` was unreachable through
+        # the view and `len()` came out one short of the field count.
+        with pytest.raises(TypeError, match="both take 'k' as their key"):
+            class Row(Magic, mapping=True):
+                a: Annotated[int, Key("k")] = 1
+                b: Annotated[int, Key("k")] = 2
+
+    def test_the_same_pair_is_rejected_without_a_view(self) -> None:
+        # A key is carried by the field, and `mapping` can be turned on
+        # by any subclass, so the pair is refused where it is written
+        # rather than on the first subclass that asks for a view.
+        with pytest.raises(TypeError, match="both take 'k' as their key"):
+            class Row(Magic):
+                a: Annotated[int, Key("k")] = 1
+                b: Annotated[int, Key("k")] = 2
+
+    def test_an_explicit_key_landing_on_a_field_name_is_rejected(self) -> None:
+        # `k` takes its key from its own name, `b` asks for the same one.
+        with pytest.raises(TypeError, match="'k' and 'b'"):
+            class Row(Magic, mapping=True):
+                k: int = 1
+                b: Annotated[int, Key("k")] = 2
+
+    def test_a_collision_inherited_from_a_base_is_rejected(self) -> None:
+        class Base(Magic, mapping=True):
+            a: Annotated[int, Key("k")] = 1
+
+        with pytest.raises(TypeError, match="'a' and 'b'"):
+            class Sub(Base):
+                b: Annotated[int, Key("k")] = 2
+
+    def test_keys_of_their_own_are_fine(self) -> None:
+        class Row(Magic, mapping=True):
+            a: Annotated[int, Key("first")] = 1
+            b: Annotated[int, Key("second")] = 2
+
+        assert dict(Row()) == {"first": 1, "second": 2}
+        assert len(Row()) == 2
+
+    def test_a_field_out_of_the_view_cannot_collide(self) -> None:
+        # `b` has no key at all, so `a` may have the one it gave up.
+        class Row(Magic, mapping=True):
+            a: Annotated[int, Key("b")] = 1
+            b: NotKey[int] = 2
+
+        assert dict(Row()) == {"b": 1}
+
+    def test_a_pseudo_field_named_after_a_key_is_fine(self) -> None:
+        # `unit` is a class attribute, never part of the view, so it
+        # leaves the key of that name free for a field that is.
+        class Row(Magic, mapping=True):
+            unit: ClassVar[str] = "m"
+            by: InitVar[int] = 0
+            length: Annotated[int, Key("unit")] = 1
+
+        row = Row()
+        assert dict(row) == {"unit": 1}
+        assert row.unit == "m"
+
+    def test_the_public_name_check_still_comes_first(self) -> None:
+        # Two fields sharing a public name share a key as well; the
+        # name is what the reader has to fix, so that is what is said.
+        with pytest.raises(TypeError, match="known as 'y'"):
+            class Row(Magic, mapping=True):
+                _y: int = 1
+                y: int = 2
+
+
 class TestAnnotationPolarity:
     """Every annotation sets its own slots to its own value."""
 


### PR DESCRIPTION
Closes #59.

## The bug

A shared *public name* is already refused at class definition, but an explicit `Key("k")` sets the mapping key directly and slipped past it:

```pycon
>>> class R(Magic, mapping=True):
...     a: Annotated[int, Key("k")] = 1
...     b: Annotated[int, Key("k")] = 2
>>> dict(R())
{'k': 2}
>>> len(R())
1
```

`a` was silently unreachable through the view, and `len()` disagreed with the number of fields.

Now:

> `Row` has two fields, `'a'` and `'b'`, and both take `'k'` as their key: only one of them can be reached under `'k'` in the dict-like view, and `len()` would count one field fewer than the class has. A field's key is the one `Key()` gives it, or its public name — and a key stays with the field, so a subclass built with `mapping=True` inherits both. Give one of the two a key of its own, or leave it out of the view with `NotKey`.

The check sits directly after the public-name one, which runs first — so a pair that collides both ways reports the name, the thing the reader has to fix.

## Refused on every class, not only a dict-like one

A key belongs to the *field*, so it is inherited, and any subclass can turn `mapping` on. An explicit `Key("k")` written on a non-mapping base survives inheritance intact and becomes a live collision the moment a subclass says `mapping=True` — at which point the failure surfaces on the subclass and names two fields its author never wrote. That is exactly the surprise the public-name check exists to prevent.

The only thing refusing everywhere rules out is a class where two fields claim one key and nothing reads it, which is a mistake either way.

## Pseudo-fields are excluded, unlike the public-name check

Not because they cannot reach the view, but because including them causes real false positives. `setdefault` gives every field `key = options.mapping`, so on a dict-like class a `ClassVar` gets a defaulted key equal to its own name. Counting it would refuse this, which is fine before and after:

```pycon
>>> class C(Magic, mapping=True):
...     tag: ClassVar[str] = "x"
...     label: Annotated[str, Key("tag")] = "y"
>>> dict(C())
{'tag': 'y'}
```

The public-name check has no such problem, because there a pseudo-field genuinely does share the thing it collides on — an `InitVar` is a constructor parameter, and a pseudo-field shows in `repr`.

## Found on the way, handed to #20 rather than filed

Turning `mapping=True` on in a **subclass** does not give the base's inherited fields a key at all:

```pycon
>>> class Base(Magic):
...     x: int = 1
>>> class Sub(Base, mapping=True):
...     z: int = 3
>>> dict(Sub())
{'z': 3}
```

Same silent-`len()`-disagreement symptom, different mechanism: `key` is resolved once at the class that declares the field and never re-resolved against a subclass's options. That is precisely what the `override=` work on #20 addresses — the `mapping` → `key` row of its option map — so it has gone there as a required test case rather than becoming a separate issue.

761 passed; ruff and codespell clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_