### PR TITLE
Name the class and the field when a converter, validator or factory fails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,8 @@ src/bagof/magic/
                 #   `__magic_*__` attribute names
   _utils.py     # SlotsBase, rebuild_cls, the `slots` decorator
   _resolve.py   # adapters to bagof-converters / -validators / -factories
+  _errors.py    # field_error -- names the class and the field when a
+                #   converter, a validator or a factory raises
 tests/
   test_magic.py                 # the builder, option by option
   test_docstrings.py            # every `pycon` block in a docstring or page
@@ -73,6 +75,14 @@ Tests that exercise internals import them from the module that defines them
 - **`_FuncBuilder` compiles `__init__`** from generated source text, because a
   real signature (defaults, positional-only markers, keyword-only markers) can
   only be produced by `exec`. Everything else is a closure.
+- **Every call to a converter, a validator or a factory is guarded**, in the
+  generated `__init__` and in `__setattr__` alike, and its failure goes
+  through `field_error` in `_errors.py` — which raises the same error again
+  (same class, so an existing `except` still catches) with the class, the
+  field and the value in front of the original text, and the original as its
+  cause. The guard is per call rather than one around the whole body: a
+  single one could only name the field by guessing which call raised, and a
+  `try` costs nothing while nothing fails.
 - **Options are inherited by merging down the MRO** (`Options.update` per base,
   in reverse MRO order), so a derived class only overrides what it states.
 

--- a/src/bagof/magic/_constants.py
+++ b/src/bagof/magic/_constants.py
@@ -65,6 +65,16 @@ def _VALIDATOR(x: str) -> str: return f"__magic_{x}_validator__"
 # __init__, for the object handed to the init hooks
 _ARGUMENTS = "__magic_arguments__"
 
+# Names given, when generating __init__, to the local holding the helper
+# that names the class and the field when a converter, a validator or a
+# factory raises, and to the exception it is handed
+_FIELD_ERROR = "__magic_field_error__"
+_ERROR = "__magic_error__"
+
+# Name given to the local holding the value of a field that is not a
+# parameter, while it is being built, converted and validated
+def _VALUE(x: str) -> str: return f"__magic_{x}_value__"
+
 # Name given to a method's return type variable when generating it
 def _RETURN_TYPE(x: str) -> str: return f"__magic_{x}_return_type__"
 

--- a/src/bagof/magic/_errors.py
+++ b/src/bagof/magic/_errors.py
@@ -1,0 +1,85 @@
+"""
+Naming the class and the field when a converter, a validator or a
+factory fails.
+
+A converter, a validator and a factory each know what they were asked to
+do, and nothing about where they were asked to do it: on its own, a
+failure reads ``ToNumber(<class 'int'>): Invalid value.``, which does not
+say which field of which class was being filled in. Every call to one of
+them hands its failure to `field_error`, which raises the same error
+again -- same class, so an ``except`` written for it still catches -- with
+the class, the field and the offending value in front of the original
+text, and the original as its cause.
+"""
+
+from __future__ import annotations
+
+__all__ = ["field_error"]
+
+# dependencies
+import typing_extensions as tx
+
+# internals
+from ._constants import MISSING, MaybeMissing
+
+# What was being done to the field, in the reader's terms. The key is
+# what the call site was doing, not which of the three it called: a
+# factory builds a value, a converter converts one, a validator turns
+# one down.
+_WHAT = {
+    "build": "could not build a value",
+    "convert": "could not convert {value!r}",
+    "validate": "{value!r} is not a valid value",
+}
+
+
+def field_error(
+    owner: str,
+    name: str,
+    action: str,
+    error: Exception,
+    value: MaybeMissing[tx.Any] = MISSING,
+) -> tx.NoReturn:
+    """
+    Raise `error` again, saying which field of which class it is about.
+
+    Parameters
+    ----------
+    owner : str
+        Name of the class the field belongs to.
+    name : str
+        Name of the field.
+    action : str
+        What was being done: "build", "convert" or "validate".
+    error : Exception
+        What was raised while doing it.
+    value : Any, optional
+        The value that was being converted or validated. A factory is
+        given no value, and names none.
+    """
+    what = _WHAT[action].format(value=value)
+    message = f"{owner}.{name}: {what} -- {error}"
+    again = _rebuilt(error, message)
+    if again is None:
+        # Nothing can be said about where this one comes from without
+        # changing what it is, and its class is what a caller catches.
+        raise error
+    raise again from error
+
+
+def _rebuilt(error: Exception, message: str) -> tx.Optional[Exception]:
+    """The same error, of the same class, saying `message` instead."""
+    try:
+        again = type(error)(message)
+    except Exception:
+        # An exception class whose constructor asks for more than a
+        # message cannot be built from one.
+        return None
+    # Whatever the original was carrying comes across, so that code
+    # reading an attribute off the error it caught still finds it.
+    again.__dict__.update(error.__dict__)
+    if hasattr(again, "message"):
+        # A `bagof` error keeps its own plain text under `message` and
+        # decorates it for display; the plain text is now the fuller one.
+        again.message = message
+    return again

--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -159,6 +159,8 @@ from ._constants import (
     _CONVERTER,
     _DEFAULT,
     _DISCARD,
+    _ERROR,
+    _FIELD_ERROR,
     _FIELDS,
     _GENERATED,
     _MAGIC,
@@ -169,11 +171,13 @@ from ._constants import (
     _SELF,
     _TYPE,
     _VALIDATOR,
+    _VALUE,
     HIDE_IF_NONE,
     MISSING,
     SHOW_ATTR,
     _HasFactory,
 )
+from ._errors import field_error
 from ._fields import *  # noqa: F401, F403
 from ._fields import Field, _stored
 from ._fields import __all__ as __all_fields__
@@ -1377,7 +1381,7 @@ def __pre_new__(
     # Build __init__. The builder writes source, so binding the public
     # name has to wait until `insert_fns` has compiled it (below).
     try:
-        init_kwargs = _make_init(fields, prepost)
+        init_kwargs = _make_init(fields, prepost, clsname)
     except _BadSignature as error:
         if init_name:
             raise
@@ -1772,7 +1776,9 @@ def _make_doc_elem(field: Field, name: tx.Optional[str] = None) -> str:
 
 
 def _make_init(
-    fields: dict[str, Field], prepost: tx.Mapping[str, bool]
+    fields: dict[str, Field],
+    prepost: tx.Mapping[str, bool],
+    clsname: str,
 ) -> dict:
 
     locals = {"object": object, "_HasFactory": _HasFactory}
@@ -1873,6 +1879,33 @@ def _make_init(
         )
         return f"{SELF}.{func}({_ARGUMENTS}({{{values}}}))"
 
+    def _guarded(
+        call: str,
+        field: Field,
+        action: str,
+        value: tx.Optional[str] = None
+    ) -> str:
+        # A converter, a validator and a factory each say what went
+        # wrong and nothing about where, so the class and the field are
+        # put in front of the failure on its way out. The field is named
+        # the way it is written in the class, which is also the way
+        # `__setattr__` names it -- an aliased field's parameter goes by
+        # another name, but the value it fills in is this one.
+        #
+        # Only the call itself is guarded: nothing else that goes wrong
+        # nearby should be described as this field's fault.
+        locals[_FIELD_ERROR] = field_error
+        blamed = [repr(clsname), repr(field.name), repr(action), _ERROR]
+        if value is not None:
+            blamed.append(value)
+        blamed = ", ".join(blamed)
+        return dedent(f"""
+        try:
+            {call}
+        except Exception as {_ERROR}:
+            {_FIELD_ERROR}({blamed})
+        """)
+
     def _make_factory_elem(field: Field) -> str:
         # A defaulted-by-factory parameter arrives holding the factory
         # rather than a value. Every one of them is resolved before the
@@ -1880,10 +1913,10 @@ def _make_init(
         if not field.factory:
             return ""
         name = field.public_name
+        call = _guarded(f"{name} = {name}()", field, "build")
         return dedent(f"""
         if isinstance({name}, _HasFactory):
-            {name} = {name}()
-        """)
+        """) + indent(call, " " * 4)
 
     def _make_body_elem(field: Field) -> str:
         # The body reads the *parameter*, which is named after the
@@ -1893,14 +1926,16 @@ def _make_init(
         body = ""
         if field.converter:
             locals[_CONVERTER(name)] = field.converter
-            body += dedent(f"""
-            {name} = {_CONVERTER(name)}({name})
-            """)
+            body += _guarded(
+                f"{name} = {_CONVERTER(name)}({name})",
+                field, "convert", name
+            )
         if field.validator:
             locals[_VALIDATOR(name)] = field.validator
-            body += dedent(f"""
-            {name} = {_VALIDATOR(name)}({name})
-            """)
+            body += _guarded(
+                f"{name} = {_VALIDATOR(name)}({name})",
+                field, "validate", name
+            )
         if not field.var:
             # NOTE: we by pass the object's __setattr__ to avoid running
             # through conversion and validation multiple times.
@@ -1917,14 +1952,32 @@ def _make_init(
         # public name.
         default = _DEFAULT(field.name)
         locals[default] = field.factory if field.factory else field.default
-        value = f"{default}()" if field.factory else default
+        if not (field.factory or field.converter or field.validator):
+            return dedent(f"""
+            object.__setattr__({SELF}, {field.name!r}, {default})
+            """)
+        # Building, converting and validating are taken one at a time,
+        # so that whichever of them fails can say what it was doing.
+        value = _VALUE(field.name)
+        if field.factory:
+            body = _guarded(f"{value} = {default}()", field, "build")
+        else:
+            body = dedent(f"""
+            {value} = {default}
+            """)
         if field.converter:
             locals[_CONVERTER(field.name)] = field.converter
-            value = f"{_CONVERTER(field.name)}({value})"
+            body += _guarded(
+                f"{value} = {_CONVERTER(field.name)}({value})",
+                field, "convert", value
+            )
         if field.validator:
             locals[_VALIDATOR(field.name)] = field.validator
-            value = f"{_VALIDATOR(field.name)}({value})"
-        return dedent(f"""
+            body += _guarded(
+                f"{value} = {_VALIDATOR(field.name)}({value})",
+                field, "validate", value
+            )
+        return body + dedent(f"""
         object.__setattr__({SELF}, {field.name!r}, {value})
         """)
 
@@ -2074,10 +2127,23 @@ def _make_assign(cls: type) -> type:
         if field and not field.var:
             if field.frozen:
                 raise AttributeError(f"Cannot set frozen field {name!r}")
+            # A converter and a validator say what went wrong and
+            # nothing about where, so the class and the field are put in
+            # front of the failure on its way out.
             if field.converter:
-                value = field.converter(value)
+                try:
+                    value = field.converter(value)
+                except Exception as error:
+                    field_error(
+                        type(self).__name__, name, "convert", error, value
+                    )
             if field.validator:
-                value = field.validator(value)
+                try:
+                    value = field.validator(value)
+                except Exception as error:
+                    field_error(
+                        type(self).__name__, name, "validate", error, value
+                    )
         elif getattr(type(self), _OPTIONS).frozen:
             raise AttributeError(
                 f"Cannot set attribute {name!r} on frozen class"

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -8,6 +8,10 @@ from typing import Optional, Union
 
 import pytest
 import typing_extensions as tx
+from bagof.converters.exceptions import (
+    ConversionError,
+    ValueConversionError,
+)
 from bagof.validators.exceptions import ValidationError
 from typing_extensions import Annotated
 
@@ -5124,3 +5128,186 @@ class TestQuotedAnnotations:
 
         parameters = signature(Server.__init__).parameters
         assert parameters["debug"].kind is Parameter.KEYWORD_ONLY
+
+
+# ======================================================================
+# Which field a failure is about
+# ======================================================================
+# A converter, a validator and a factory each say what went wrong and
+# nothing about where. These are about the class and the field being
+# named too, without losing what went wrong.
+
+
+class TestTheFailingFieldIsNamed:
+
+    def test_conversion_names_the_class_and_the_field(self) -> None:
+        class Server(Magic, convert=True):
+            port: int
+
+        with pytest.raises(ConversionError) as caught:
+            Server("not a number")
+        assert "Server.port" in str(caught.value)
+        assert "'not a number'" in str(caught.value)
+
+    def test_validation_names_the_class_and_the_field(self) -> None:
+        class Server(Magic, validate=True):
+            port: int
+
+        with pytest.raises(ValidationError) as caught:
+            Server("nope")
+        assert "Server.port" in str(caught.value)
+        assert "'nope'" in str(caught.value)
+
+    def test_the_field_that_failed_is_the_one_named(self) -> None:
+        class Ports(Magic, convert=True):
+            first: int
+            second: int
+
+        with pytest.raises(ConversionError) as caught:
+            Ports(1, "not a number")
+        assert "Ports.second" in str(caught.value)
+        assert "Ports.first" not in str(caught.value)
+
+    def test_a_nested_class_names_every_field_on_the_way(self) -> None:
+        class Inner(Magic, convert=True):
+            name: str
+
+        class Outer(Magic, convert=True):
+            thing: Inner = None
+
+        with pytest.raises(ConversionError) as caught:
+            Outer()
+        assert "Outer.thing" in str(caught.value)
+        assert "Inner.name" in str(caught.value)
+
+    def test_a_factory_failure_names_the_field(self) -> None:
+        def boom() -> int:
+            raise ValueError("nothing to build it from")
+
+        class Server(Magic):
+            port: Factory[int, boom]
+
+        with pytest.raises(ValueError) as caught:
+            Server()
+        assert "Server.port: could not build a value" in str(caught.value)
+        assert "nothing to build it from" in str(caught.value)
+
+    def test_a_factory_failure_names_a_field_that_is_not_a_parameter(
+        self
+    ) -> None:
+        def boom() -> int:
+            raise ValueError("nothing to build it from")
+
+        class Server(Magic):
+            port: NoInit[Factory[int, boom]]
+
+        with pytest.raises(ValueError) as caught:
+            Server()
+        assert "Server.port: could not build a value" in str(caught.value)
+
+    def test_a_conversion_on_assignment_names_the_field(self) -> None:
+        class Server(Magic, convert=True):
+            port: int
+
+        server = Server(80)
+        with pytest.raises(ConversionError) as caught:
+            server.port = "not a number"
+        assert "Server.port" in str(caught.value)
+
+    def test_a_validation_on_assignment_names_the_field(self) -> None:
+        class Server(Magic, validate=True):
+            port: int
+
+        server = Server(80)
+        with pytest.raises(ValidationError) as caught:
+            server.port = "nope"
+        assert "Server.port" in str(caught.value)
+
+    def test_the_error_is_still_the_one_that_was_raised(self) -> None:
+        class Server(Magic, convert=True):
+            port: int
+
+        # The class is what a caller catches, so it is unchanged: the
+        # narrowest `except` written before still catches.
+        with pytest.raises(ValueConversionError) as caught:
+            Server("not a number")
+        assert type(caught.value) is type(caught.value.__cause__)
+        assert isinstance(caught.value, ValueError)
+
+    def test_what_the_error_was_carrying_comes_across(self) -> None:
+        class Server(Magic, convert=True):
+            port: int
+
+        with pytest.raises(ConversionError) as caught:
+            Server("not a number")
+        assert caught.value.value == "not a number"
+
+    def test_the_original_is_kept_whole_as_the_cause(self) -> None:
+        class Server(Magic, convert=True):
+            port: int
+
+        with pytest.raises(ConversionError) as caught:
+            Server("not a number")
+        original = caught.value.__cause__
+        assert isinstance(original, ConversionError)
+        # Every word of it is still there, at the end of the fuller one.
+        assert str(caught.value).endswith(str(original))
+
+    def test_an_ordinary_error_is_named_too(self) -> None:
+        def refuse(value: tx.Any) -> int:
+            raise ValueError("I would rather not")
+
+        class Server(Magic):
+            port: ConvertTo[int, refuse]
+
+        with pytest.raises(ValueError) as caught:
+            Server(80)
+        assert "Server.port" in str(caught.value)
+        assert "I would rather not" in str(caught.value)
+        assert isinstance(caught.value.__cause__, ValueError)
+
+    def test_an_error_that_needs_more_than_a_message_is_left_alone(
+        self
+    ) -> None:
+        class Fussy(Exception):
+            def __init__(self, what: str, why: str) -> None:
+                super().__init__(what, why)
+
+        raised = []
+
+        def refuse(value: tx.Any) -> int:
+            error = Fussy("no", "not that either")
+            raised.append(error)
+            raise error
+
+        class Server(Magic):
+            port: ConvertTo[int, refuse]
+
+        # Nothing can be added to this one without changing its class,
+        # and its class is what a caller catches, so it comes through
+        # exactly as it was raised.
+        with pytest.raises(Fussy) as caught:
+            Server(80)
+        assert caught.value is raised[0]
+        assert caught.value.args == ("no", "not that either")
+
+    def test_nothing_generated_is_mentioned(self) -> None:
+        class Server(Magic, convert=True, validate=True):
+            port: int
+
+        with pytest.raises(ConversionError) as caught:
+            Server("not a number")
+        assert "__magic" not in str(caught.value)
+
+    def test_a_value_that_is_fine_is_left_alone(self) -> None:
+        class Server(Magic, convert=True, validate=True):
+            port: int
+            name: str = "localhost"
+            spare: NoInit[int] = 8080
+
+        server = Server("80")
+        assert server.port == 80
+        assert server.name == "localhost"
+        assert server.spare == 8080
+        server.port = "443"
+        assert server.port == 443


### PR DESCRIPTION
Closes #70.

## The bug

No conversion or validation failure said which field it was. On a class with ten fields you were told a number conversion failed somewhere; if two fields shared a type the message was identical whichever broke.

Before and after:

```
ValueConversionError: ToNumber(<class 'int'>): Invalid value.
C.port: could not convert 'not a number' -- ToNumber(<class 'int'>): Invalid value.

TypeValidationError: IsNumber(<class 'int'>): Not a valid instance.
V.port: 'nope' is not a valid value -- IsNumber(<class 'int'>): Not a valid instance.
```

The nested case is the one that was hardest to act on — you wrote `thing: Inner` and were told about `str`. Each class now adds its own field on the way out, so the whole path is there:

```
Outer.thing: could not convert None -- Inner.name: could not convert None -- ToString(): Value of type <class 'NoneType'> is not a string or bytes.
```

And with two fields of one type, only the bad one is named:

```
T.b: could not convert 'bad' -- ToNumber(<class 'int'>): Invalid value.
```

## Four call sites, not two

I said the generated `__init__` and `__setattr__`. There were four:

- the converter and validator on a parameter;
- resolving a `_HasFactory` default in `__init__`;
- a field that is **not** a parameter — factory, converter and validator. That one composed a single nested expression (`validator(converter(default()))`), so it is now one statement per step, each able to say what it was doing. It keeps the old single-statement form when nothing there can fail;
- `__setattr__`.

## The two decisions

**Chain rather than replace.** The original is the `__cause__` and its text is quoted in the new message, so the *what* survives and the wrapper adds the *where*. One extra traceback frame.

**Keep the exception class**, so `except ValueConversionError:` still catches. This turned out to need more than `type(error)(message)`: the sibling exceptions take structured arguments (`this`, `value` through `bagof.core.magic.MagicError`), which that would have dropped. The rebuilt error is given the fuller message and then everything the original carried, so code reading `.value` off a caught error still finds it:

```
type kept: True | cause kept: True | .value still readable: not a number
```

An exception whose constructor needs more than a message cannot be rebuilt from one — tested with a two-required-argument exception, and that case is re-raised **exactly as it was** rather than swapped for a different class.

The field is named as written in the class (`C.port`), not the parameter name an alias would give it, matching `__setattr__` and the repo's other attribute-shaped messages. No generated local ever appears, which is convention 5 and is asserted by a test.

## Factories fitted

Both paths — a parameter's factory default and a non-parameter field's own — so `factory=True` on an unbuildable type now reads `C.x: could not build a value -- Factory(<class 'Weird'>): …`.

## Found on the way, filed not fixed

**#72** — a field named `object` breaks class construction, on `main` too:

```pycon
>>> class C(Magic):
...     object: int = 1
>>> C(1)
TypeError: expected 2 arguments, got 3
```

The generated `__init__` closes over locals literally named `object` and `_HasFactory` and stores each field with `object.__setattr__(...)`, so a parameter of that name shadows the builtin. Every other name the builder puts in that scope is namespaced precisely so a field cannot collide; these two were left bare. The new locals here use `__magic_*__` and do not add to it.

**Cosmetic:** a *pickled* wrapped error round-trips through `MagicError.__reduce__`, which re-decorates it, so the converter repr appears twice. Only visible after a pickle round-trip, and it follows from carrying `this`/`value` across for attribute compatibility.

779 passed on 3.11, 3.12 and 3.13; ruff and codespell clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_