### PR TITLE
Add override=, so a subclass can re-decide what its base baked in

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,23 @@ User(id=1, name='ada')
 ```
 
 A subclass that wants something different just says so — `class Draft(Record,
-frozen=False)`.
+frozen=False)`. That reaches the fields the subclass declares itself; add
+`override=True` for it to reach the inherited ones as well:
+
+```python
+class Draft(Record, frozen=False, override=True):
+    note: str = ""
+```
+
+```pycon
+>>> draft = Draft(id=1)
+>>> draft.id = 2
+>>> draft
+Draft(id=2, note='')
+```
+
+A field that asked for something in its own annotation — `Frozen[int]`,
+`KwOnly[int]` — keeps it either way.
 
 ### Per-field behaviour lives in the annotation
 
@@ -472,6 +488,7 @@ class Thing(Magic, frozen=True, kw_only=True, slots=True):
 | `factory` | `False` | build every missing default from its type |
 | `mutable_default` | `"factory"` | give each instance its own copy of `x: list = []`; or `"raise"`, or `"allow"` |
 | `mapping` | `False` | behave like a dictionary; a subclass cannot turn it off again |
+| `override` | `False` | apply this class's settings to inherited fields too |
 | `reverse` | `False` | list a subclass's own fields before inherited ones |
 | `doc` | `True` | add the field table to the class docstring |
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -152,6 +152,11 @@ class User(Record):
 User(name='ada', age=36)
 ```
 
+A subclass that changes a setting changes it for the fields it declares
+itself. Add `override=True` and it changes for the inherited fields too —
+except where a field asked for something in its own annotation, which always
+wins.
+
 ### Per-field behaviour is part of the annotation
 
 The others put it in a `field()` call on the right-hand side, which pushes the

--- a/src/bagof/magic/_fields.py
+++ b/src/bagof/magic/_fields.py
@@ -48,6 +48,31 @@ from ._utils import SlotsBase, _get_origin, slots
 T = tx.TypeVar("T")
 
 
+#: The class settings a field takes an answer from when it does not give
+#: one itself, and the field attributes each of them decides.
+#:
+#: The two are not one for one -- `kw_only` and `positional_only` both
+#: decide the same pair -- so the mapping is written out rather than
+#: guessed. It lists exactly what `Field.setdefault` reads from
+#: `Options`: `eq`, `order`, `hash` and `mapping` are not here, because
+#: a field works those out from itself rather than from its class, and
+#: there would be nothing to resolve again.
+_OVERRIDABLE = {
+    "convert": ("converter",),
+    "factory": ("factory",),
+    "frozen": ("frozen",),
+    "kw_only": ("kw", "positional"),
+    "positional_only": ("kw", "positional"),
+    "repr": ("repr",),
+    "validate": ("validator",),
+}
+
+#: Every field attribute a class setting decides, in a stable order.
+_RESOLVED_ATTRS = tuple(dict.fromkeys(
+    attr for attrs in _OVERRIDABLE.values() for attr in attrs
+))
+
+
 @slots(
     'name',             # Field name
     'type',             # Field type (or type hint)
@@ -76,6 +101,8 @@ T = tx.TypeVar("T")
     'key',
     # Alternative names for this field in the generated methods.
     'alias',
+    # What the field itself asked for, before the class filled in the rest.
+    'declared',
 )
 class Field(SlotsBase):
     """A field in a `Magic`."""
@@ -160,6 +187,13 @@ class Field(SlotsBase):
             external API.
             By default, names that start with an underscore will have
             the underscore stripped in the alias.
+        declared : dict, optional
+            What this field asked for by itself, before a class filled
+            in everything it left unsaid. It is recorded the first time
+            the field is resolved against a class, and is what the
+            `override` class setting restores from when a subclass
+            resolves the field again against its own settings. There is
+            no reason to pass it by hand.
 
         Other Parameters
         ----------------
@@ -277,6 +311,54 @@ class Field(SlotsBase):
         field.update(Field(name=name, type=type, default=default))
         return field
 
+    def copy(self) -> tx.Self:
+        # A field is mutated in place while its class is built, and so
+        # is the record of what it declared: a copy must share neither
+        # with the field it was copied from. `update` copies slots by
+        # reference and would share the record; nothing hands it a
+        # resolved field today, but a caller that does has to copy the
+        # record the way this does.
+        new = super().copy()
+        if new.declared is not MISSING:
+            new.declared = dict(new.declared)
+        return new
+
+    def __repr__(self) -> str:
+        # Everything but the record of what was declared, which is
+        # bookkeeping for `override` and would double the length of
+        # every field's repr.
+        shown = (
+            slot for slot in self._slots()
+            if slot != "declared"
+            and getattr(self, slot, MISSING) is not MISSING
+        )
+        params = ", ".join(
+            f"{slot}={getattr(self, slot)!r}" for slot in shown
+        )
+        return f"{type(self).__name__}({params})"
+
+    def _redeclare(self, **values) -> None:
+        # Record a value as if this field had asked for it itself, so
+        # that re-resolving against another class's options leaves it
+        # alone.
+        for attr, value in values.items():
+            setattr(self, attr, value)
+            if self.declared is not MISSING and attr in self.declared:
+                self.declared[attr] = value
+
+    def _reresolve(
+        self,
+        options: Options,
+        attrs: tx.Sequence[str],
+        hints: tx.Optional[Hints] = None,
+    ) -> None:
+        # Forget what a class filled in for `attrs`, and work those out
+        # again from `options`. Whatever the field asked for itself is
+        # restored unchanged, so it survives.
+        for attr in attrs:
+            setattr(self, attr, self.declared[attr])
+        self.setdefault(options, hints)
+
     def setdefault(
         self, options: Options, hints: tx.Optional[Hints] = None
     ) -> None:
@@ -287,6 +369,15 @@ class Field(SlotsBase):
         # with by name -- a class that names itself, a type imported for
         # type checking only -- when the converter, validator or factory
         # built here is first used.
+        #
+        # What the field asked for is kept as it was, so that a subclass
+        # can fill the rest in again from its own options -- that is the
+        # `override` class option, and `_reresolve` above is the other
+        # half of it.
+        if self.declared is MISSING:
+            self.declared = {
+                attr: getattr(self, attr) for attr in _RESOLVED_ATTRS
+            }
         if options.kw_only and options.positional_only:
             raise ValueError(
                 "Cannot set both kw_only and positional_only to True"

--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -72,6 +72,9 @@ unresolved_hints : str, default="warn"
 mapping : bool, default=False
     Implement the `Mapping` protocol; a subclass cannot turn it off.
     Only a field that is holding a value is a key
+override : bool | str | list, default=False
+    Decide the settings of an inherited field again from this class;
+    a name, or a list of names, decides only those
 reverse : bool, default=False
     Use the reverse MRO order to determine field order
 doc : bool | str, default=True
@@ -179,7 +182,7 @@ from ._constants import (
     _HasFactory,
 )
 from ._fields import *  # noqa: F401, F403
-from ._fields import Field, _stored
+from ._fields import _OVERRIDABLE, Field, _stored
 from ._fields import __all__ as __all_fields__
 from ._options import *  # noqa: F401, F403
 from ._options import Options
@@ -255,6 +258,63 @@ def _inherit_attrs(
         inherited = getattr(other, attr, MISSING)
         if inherited is not MISSING:
             setattr(field, attr, inherited)
+
+
+def _override_attrs(override: tx.Any, clsname: str) -> tx.Tuple[str, ...]:
+    # The field attributes an inherited field works out again from this
+    # class's settings.
+    #
+    # `override` names settings; a field stores their answers under
+    # names of its own, so `_OVERRIDABLE` maps between the two.
+    if override is True:
+        names = tuple(_OVERRIDABLE)
+    elif not override:
+        return ()
+    elif isinstance(override, str):
+        names = (override,)
+    elif isinstance(override, tx.Iterable):
+        names = tuple(override)
+    else:
+        raise ValueError(
+            f"{clsname} passes override={override!r}, which is neither a "
+            f"setting name nor a list of them. Pass override=True for "
+            f"every setting a subclass can decide again, the name of one "
+            f"of them, or a list of names."
+        )
+
+    attrs = []
+    for name in names:
+        if name not in _OVERRIDABLE:
+            raise ValueError(
+                f"{clsname} asks to override {name!r}, which is not one of "
+                f"the settings a field takes from its class: "
+                f"{', '.join(sorted(_OVERRIDABLE))}. Those are the ones "
+                f"decided per field; the rest are about the class as a "
+                f"whole, and a subclass already decides them for itself."
+            )
+        for attr in _OVERRIDABLE[name]:
+            if attr not in attrs:
+                attrs.append(attr)
+    return tuple(attrs)
+
+
+def _wrap_show_attrs(field: Field) -> None:
+    # `repr` and `key` each answer two questions -- whether the field
+    # takes part, and under which name -- so once resolved they are held
+    # as a `SHOW_ATTR` rather than as a plain value.
+    # (This is hacky and ugly -- should be reworked)
+    if field.key is HIDE_IF_NONE:
+        field.key = HIDE_IF_NONE(field.public_name)
+    if not isinstance(field.key, SHOW_ATTR):
+        field.key = SHOW_ATTR(field.key)
+
+    if field.repr is HIDE_IF_NONE:
+        if field.var:
+            field.repr = SHOW_ATTR(False)
+        else:
+            field.repr = HIDE_IF_NONE(field.public_name)
+    if not isinstance(field.repr, SHOW_ATTR):
+        field.repr = SHOW_ATTR(field.repr)
 
 
 def _add_fields(
@@ -1043,7 +1103,9 @@ def _handle_mutable_default(field: Field, action: str) -> bool:
     # A shallow copy, so each instance gets its own container while
     # what the container holds stays shared -- the same thing a factory
     # written as `lambda: copy(default)` would give.
-    field.factory = partial(copy.copy, default)
+    # Recorded as the field's own, so that a subclass resolving the
+    # field again against its own settings does not undo it.
+    field._redeclare(factory=partial(copy.copy, default))
     field.default = MISSING
     return True
 
@@ -1306,6 +1368,26 @@ def __pre_new__(
     hints = Hints(globals, {}, clsname, options.unresolved_hints)
     namespace[_HINTS] = hints
 
+    # An inherited field was resolved against the settings of the class
+    # that declared it, and keeps those answers. `override` names the
+    # settings this class decides again for every field it inherits --
+    # only where the field itself said nothing, since what a field asked
+    # for is restored unchanged. A field this class redeclares is built
+    # from its annotation below and replaces the inherited one, so it
+    # never goes through here.
+    #
+    # A converter, validator or factory rebuilt here looks a type named
+    # in text up where *this* class is written, which is where the class
+    # asking for the conversion can be read. A base in another module
+    # that annotated a field by name is the one case that reaches for a
+    # name this module may not have, and `unresolved_hints` says what
+    # happens then.
+    override = _override_attrs(options.override, clsname)
+    if override:
+        for field in fields.values():
+            field._reresolve(options, override, hints)
+            _wrap_show_attrs(field)
+
     # Annotations that are defined in this class (not in base
     # classes).  If __annotations__ isn't present, then this class
     # adds no new   We use this to compute fields that are
@@ -1373,20 +1455,7 @@ def __pre_new__(
         if options.slots and not field.var:
             namespace.pop(field.name, None)
 
-        # Use Key/Repr wrappers
-        # (This is hacky and ugly -- should be reworked)
-        if field.key is HIDE_IF_NONE:
-            field.key = HIDE_IF_NONE(field.public_name)
-        if not isinstance(field.key, SHOW_ATTR):
-            field.key = SHOW_ATTR(field.key)
-
-        if field.repr is HIDE_IF_NONE:
-            if field.var:
-                field.repr = SHOW_ATTR(False)
-            else:
-                field.repr = HIDE_IF_NONE(field.public_name)
-        if not isinstance(field.repr, SHOW_ATTR):
-            field.repr = SHOW_ATTR(field.repr)
+        _wrap_show_attrs(field)
 
         cls_fields.append(field)
 
@@ -2453,6 +2522,18 @@ class MetaMagic(ABCMeta):
         keys an instance has is a question about that instance: the
         length can differ between two instances of one class, and can
         change over an instance's life.
+    override : bool | str | list, default=False
+        Decide the settings of an inherited field again from this
+        class. A field is resolved against the settings of the class
+        that declares it and keeps those answers, so by default
+        `frozen=False` on a subclass only reaches the fields that
+        subclass declares itself; `override=True` applies this class's
+        settings to the fields it inherits as well. What a field asked
+        for in its own annotation always wins, whichever way this is
+        set. Give the name of a setting, or a list of names, to decide
+        only those again: frozen, kw_only, positional_only, convert,
+        validate, factory and repr are the ones a field takes from its
+        class.
     reverse : bool, default=False
         Use the reverse MRO order to determine field order.
         This only affects the relative order of the fields of one class
@@ -2552,6 +2633,18 @@ class Magic(metaclass=MetaMagic):
         keys an instance has is a question about that instance: the
         length can differ between two instances of one class, and can
         change over an instance's life.
+    override : bool | str | list, default=False
+        Decide the settings of an inherited field again from this
+        class. A field is resolved against the settings of the class
+        that declares it and keeps those answers, so by default
+        `frozen=False` on a subclass only reaches the fields that
+        subclass declares itself; `override=True` applies this class's
+        settings to the fields it inherits as well. What a field asked
+        for in its own annotation always wins, whichever way this is
+        set. Give the name of a setting, or a list of names, to decide
+        only those again: frozen, kw_only, positional_only, convert,
+        validate, factory and repr are the ones a field takes from its
+        class.
     reverse : bool, default=False
         Use the reverse MRO order to determine field order.
         This only affects the relative order of the fields of one class

--- a/src/bagof/magic/_options.py
+++ b/src/bagof/magic/_options.py
@@ -25,6 +25,8 @@ from ._utils import SlotsBase, slots
     'validate',         # Use field type as validator if none is provided
     'unresolved_hints',  # What to do about a type hint that never resolves
     'mapping',          # Generate Mapping methods for dict-like behavior
+    # Resolve an inherited field's settings again from this class
+    'override',
     'reverse',          # Use the reverse MRO order when listing fields
     'doc',              # Generate class docstring from field docstrings
 )
@@ -63,6 +65,7 @@ class Options(SlotsBase):
         validate=False,
         unresolved_hints="warn",
         mapping=False,
+        override=False,
         reverse=False,
         doc=True,
     )

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1,7 +1,9 @@
 """Unit tests for the bagof.magic module."""
 import copy
+import inspect
 import operator
 import pickle
+import re
 from inspect import Parameter, signature
 from typing import ClassVar as TypingClassVar
 from typing import Optional, Union
@@ -12,6 +14,7 @@ from bagof.validators.exceptions import ValidationError
 from typing_extensions import Annotated
 
 import bagof.magic._api as _api
+import bagof.magic._fields as _fields
 import bagof.magic._magic as m
 from bagof.magic import (
     HIDE_IF_NONE,
@@ -2595,6 +2598,390 @@ class TestFieldInheritance:
 
         assert _api.fields(Derived)[0].doc == "base doc"
 
+
+# ======================================================================
+# override
+# ======================================================================
+
+
+class TestOverride:
+    """A subclass deciding an inherited field's settings again."""
+
+    def test_the_worked_example(self) -> None:
+        class Record(Magic, frozen=True):
+            x: int
+            y: Frozen[int]
+
+        class Draft(Record, frozen=False, override=True):
+            z: int
+
+        d = Draft(1, 2, 3)
+        # x never asked to be frozen, so Draft's answer applies.
+        d.x = 9
+        assert d.x == 9
+        # y asked for it in writing, so it keeps it.
+        with pytest.raises(AttributeError, match="Cannot set frozen"):
+            d.y = 9
+        d.z = 9
+        assert d.z == 9
+
+    def test_saying_nothing_keeps_the_base_answer(self) -> None:
+        class Record(Magic, frozen=True):
+            x: int
+
+        class Draft(Record, frozen=False):
+            z: int
+
+        d = Draft(1, 2)
+        d.z = 9
+        with pytest.raises(AttributeError, match="Cannot set frozen"):
+            d.x = 9
+
+    def test_the_base_is_left_alone(self) -> None:
+        class Record(Magic, frozen=True):
+            x: int
+
+        class Draft(Record, frozen=False, override=True):
+            pass
+
+        Draft(1).x = 9
+        with pytest.raises(AttributeError, match="Cannot set frozen"):
+            Record(1).x = 9
+
+    # ------------------------------------------------------------------
+    # Every setting a field takes from its class
+    # ------------------------------------------------------------------
+
+    def test_frozen_is_decided_again(self) -> None:
+        class Base(Magic):
+            x: int = 1
+
+        class Sub(Base, frozen=True, override=True):
+            pass
+
+        with pytest.raises(AttributeError, match="Cannot set frozen"):
+            Sub().x = 2
+
+    def test_kw_only_is_decided_again(self) -> None:
+        class Base(Magic):
+            x: int = 1
+
+        class Sub(Base, kw_only=True, override=True):
+            pass
+
+        assert Sub(x=2).x == 2
+        with pytest.raises(TypeError):
+            Sub(2)
+
+    def test_positional_only_is_decided_again(self) -> None:
+        class Base(Magic):
+            x: int = 1
+
+        class Sub(Base, positional_only=True, override=True):
+            pass
+
+        assert Sub(2).x == 2
+        with pytest.raises(TypeError):
+            Sub(x=2)
+
+    def test_convert_is_decided_again(self) -> None:
+        class Base(Magic):
+            x: int = 1
+
+        class Kept(Base):
+            pass
+
+        class Sub(Base, convert=True, override=True):
+            pass
+
+        assert Kept("42").x == "42"
+        assert Sub("42").x == 42
+
+    def test_validate_is_decided_again(self) -> None:
+        class Base(Magic):
+            x: int = 1
+
+        class Kept(Base):
+            pass
+
+        class Sub(Base, validate=True, override=True):
+            pass
+
+        assert Kept("nope").x == "nope"
+        with pytest.raises(ValidationError):
+            Sub("nope")
+
+    def test_a_rebuilt_converter_is_told_where_to_look(self) -> None:
+        # A type written as a name is looked up when the field is first
+        # used, and the class asking for the conversion says where and
+        # what to do when it is not there.
+        class Base(Magic):
+            parent: "Nowhere" = None  # noqa: F821
+
+        class Sub(
+            Base, convert=True, override=True, unresolved_hints="raise"
+        ):
+            pass
+
+        with pytest.raises(NameError, match="Sub.parent"):
+            Sub("anything")
+
+    def test_factory_is_decided_again(self) -> None:
+        class Base(Magic):
+            x: list
+
+        class Sub(Base, factory=True, override=True):
+            pass
+
+        assert Sub().x == []
+        # Still a factory: one list per instance, not one shared list.
+        assert Sub().x is not Sub().x
+
+    def test_repr_is_decided_again(self) -> None:
+        class Base(Magic):
+            x: Optional[int] = None
+
+        class Kept(Base):
+            pass
+
+        class Sub(Base, repr=HIDE_IF_NONE, override=True):
+            pass
+
+        assert repr(Kept()) == "Kept(x=None)"
+        assert repr(Sub()) == "Sub()"
+        assert repr(Sub(3)) == "Sub(x=3)"
+
+    def test_a_subclass_still_cannot_stop_being_dict_like(self) -> None:
+        class Base(Magic, mapping=True):
+            x: int = 1
+
+        with pytest.raises(TypeError, match="a subclass cannot take it"):
+            class Sub(Base, mapping=False, override=True):
+                pass
+
+    # ------------------------------------------------------------------
+    # What it is allowed to say
+    # ------------------------------------------------------------------
+
+    def test_one_setting_by_name(self) -> None:
+        class Base(Magic):
+            x: int = 1
+
+        class Sub(Base, frozen=True, kw_only=True, override="frozen"):
+            pass
+
+        # frozen was asked for by name; kw_only was not, so `x` stays
+        # positional.
+        with pytest.raises(AttributeError, match="Cannot set frozen"):
+            Sub(2).x = 3
+
+    def test_several_settings_by_name(self) -> None:
+        class Base(Magic):
+            x: int = 1
+
+        class Sub(
+            Base, frozen=True, kw_only=True, override=("frozen", "kw_only")
+        ):
+            pass
+
+        with pytest.raises(TypeError):
+            Sub(2)
+        with pytest.raises(AttributeError, match="Cannot set frozen"):
+            Sub(x=2).x = 3
+
+    @pytest.mark.parametrize("setting", ["eq", "order", "hash", "mapping"])
+    def test_a_setting_a_field_never_takes_from_its_class(
+        self, setting: str
+    ) -> None:
+        # These four are about the class as a whole -- whether a method
+        # is generated, whether there is a dict-like view. A field
+        # answers them from itself, so there is nothing to decide again
+        # and asking says so rather than doing nothing.
+        with pytest.raises(ValueError, match="not one of the settings"):
+            class Sub(Magic, override=setting):
+                x: int = 1
+
+    def test_something_that_names_nothing(self) -> None:
+        with pytest.raises(ValueError, match="neither a setting name"):
+            class Sub(Magic, override=3):
+                x: int = 1
+
+    def test_off_by_name(self) -> None:
+        class Base(Magic, frozen=True):
+            x: int = 1
+
+        class Sub(Base, frozen=False, override=()):
+            pass
+
+        with pytest.raises(AttributeError, match="Cannot set frozen"):
+            Sub().x = 2
+
+    # ------------------------------------------------------------------
+    # What survives it
+    # ------------------------------------------------------------------
+
+    def test_an_annotation_survives_in_both_directions(self) -> None:
+        class Base(Magic, frozen=True):
+            loose: NotFrozen[int] = 1
+
+        class Sub(Base, frozen=True, override=True):
+            pass
+
+        sub = Sub()
+        sub.loose = 2
+        assert sub.loose == 2
+
+    def test_an_annotated_keyword_stays_keyword_only(self) -> None:
+        class Base(Magic, kw_only=True):
+            x: KwOnly[int] = 1
+
+        class Sub(Base, kw_only=False, override=True):
+            pass
+
+        with pytest.raises(TypeError):
+            Sub(2)
+        assert Sub(x=2).x == 2
+
+    def test_a_promoted_mutable_default_survives(self) -> None:
+        # `x: list = []` becomes a factory when the base is built; that
+        # is the field's own from then on, whatever the subclass says
+        # about factories.
+        class Base(Magic):
+            x: list = []
+
+        class Sub(Base, override=True):
+            pass
+
+        assert Sub().x == []
+        assert Sub().x is not Sub().x
+
+    def test_a_doc_still_reaches_the_field_that_replaces_it(self) -> None:
+        class Base(Magic, frozen=True):
+            x: Annotated[int, Doc("base doc")] = 1
+
+        class Sub(Base, frozen=False, override=True):
+            x: int = 2
+
+        assert _api.fields(Sub)[0].doc == "base doc"
+
+    def test_a_redeclared_field_is_built_fresh(self) -> None:
+        # A field the subclass declares again is resolved against the
+        # subclass's settings like any other, with no `override` needed.
+        class Base(Magic, frozen=True):
+            x: int = 1
+
+        class Sub(Base, frozen=False):
+            x: int = 2
+
+        sub = Sub()
+        sub.x = 3
+        assert sub.x == 3
+
+    # ------------------------------------------------------------------
+    # Inheriting the setting itself
+    # ------------------------------------------------------------------
+
+    def test_a_base_can_turn_it_on_for_a_family(self) -> None:
+        class Base(Magic, frozen=True, override=True):
+            x: int = 1
+
+        class Sub(Base, frozen=False):
+            pass
+
+        Sub().x = 2
+
+    def test_a_middle_class_turns_it_on_for_what_follows(self) -> None:
+        class Top(Magic, frozen=True):
+            x: int = 1
+
+        class Middle(Top, frozen=False, override=True):
+            y: int = 2
+
+        class Bottom(Middle):
+            z: int = 3
+
+        with pytest.raises(AttributeError, match="Cannot set frozen"):
+            Top().x = 9
+        middle = Middle()
+        middle.x = 9
+        bottom = Bottom()
+        bottom.x = 9
+        bottom.y = 9
+        bottom.z = 9
+        assert (bottom.x, bottom.y, bottom.z) == (9, 9, 9)
+
+
+class TestDeclaredValues:
+    """The record of what a field asked for, which `override` reads."""
+
+    def test_it_is_taken_before_anything_is_filled_in(self) -> None:
+        field = Field.from_hint("x", Frozen[int])
+        assert field.declared is MISSING
+        field.setdefault(Options.make_default())
+        assert field.declared["frozen"] is True
+        assert field.declared["converter"] is MISSING
+
+    def test_it_is_taken_once(self) -> None:
+        field = Field.from_hint("x", int)
+        field.setdefault(Options(**dict(Options._DEFAULTS, frozen=True)))
+        assert field.frozen is True
+        field.setdefault(Options.make_default())
+        # Already answered, so a second pass changes nothing.
+        assert field.frozen is True
+        assert field.declared["frozen"] is MISSING
+
+    def test_a_copy_shares_nothing_with_its_original(self) -> None:
+        class Base(Magic, frozen=True):
+            x: int = 1
+
+        class Sub(Base, frozen=False, override=True):
+            pass
+
+        base_field = _api.fields(Base)[0]
+        sub_field = _api.fields(Sub)[0]
+        assert sub_field.declared is not base_field.declared
+        assert base_field.frozen is True
+        assert sub_field.frozen is False
+
+    def test_a_field_that_declared_nothing_copies_cleanly(self) -> None:
+        field = Field(name="x")
+        assert field.copy().declared is MISSING
+
+    def test_it_stays_out_of_the_repr(self) -> None:
+        field = Field.from_hint("x", int)
+        field.setdefault(Options.make_default())
+        assert "declared" not in repr(field)
+        assert "name='x'" in repr(field)
+
+    def test_recording_a_value_on_an_unresolved_field(self) -> None:
+        field = Field(name="x")
+        field._redeclare(factory=list)
+        assert field.factory is list
+        assert field.declared is MISSING
+
+
+class TestOverridableSettings:
+    """Which settings a field takes from its class, checked not assumed."""
+
+    def test_they_are_exactly_the_ones_a_field_reads(self) -> None:
+        # Twice a setting has been listed here that a field never takes
+        # from its class, and re-resolving it would have done nothing at
+        # all. `mapping` was the second: it stopped reaching a field the
+        # day `key` began defaulting to `not var`. So the list is read
+        # off the code that does the resolving rather than kept by hand.
+        read = re.findall(
+            r"options\.(\w+)", inspect.getsource(Field.setdefault)
+        )
+        assert set(_fields._OVERRIDABLE) == set(read)
+
+    def test_they_are_class_settings(self) -> None:
+        assert set(_fields._OVERRIDABLE) <= set(Options._DEFAULTS)
+
+    def test_they_name_field_attributes(self) -> None:
+        slots = set(Field._slots())
+        for setting, attrs in _fields._OVERRIDABLE.items():
+            assert set(attrs) <= slots, setting
+        assert set(_fields._RESOLVED_ATTRS) <= slots
 
 # ======================================================================
 # _FuncBuilder


### PR DESCRIPTION
Closes #20. The design is the one settled on that issue.

## The problem

A class setting is baked into each field when the field is created, so changing it on a subclass only reaches the fields that subclass declares itself:

```pycon
>>> class Record(Magic, frozen=True):
...     x: int
>>> class Draft(Record, frozen=False):
...     z: int
>>> Draft(1, 2).x = 9
AttributeError: Cannot set frozen field 'x'
```

## Two layers on the field

A `Field` stored only its *resolved* values, so once `setdefault` had run, "frozen because the class said so" and "frozen because the field said so" were indistinguishable and there was nothing left to re-resolve. It now keeps what was **declared** — exactly what the annotation said, `MISSING` for anything it did not — as a snapshot taken the first time `setdefault` runs. Re-resolving is: restore the snapshot, run `setdefault` against the new class's options.

An explicit per-field annotation survives either way, because it was never `MISSING`. That is the point — `override` only ever reaches values nobody wrote down:

```
class Record(Magic, frozen=True):
    x: int                # said nothing about frozen
    y: Frozen[int]        # said it in writing

class Draft(Record, frozen=False, override=True):
    z: int

d.x = 9   ok
d.y = 9   raises (Cannot set frozen field 'y')
d.z = 9   ok
```

Without `override`, `x` stays frozen — today's behaviour, and the default.

`override` takes `True`, a setting name, or a sequence of them, and is itself inherited, so a base can turn it on for a family.

## The map is now checked rather than written

My hand-written list of which settings a field takes from its class was wrong **twice**: `eq`, `order` and `hash` are never read by `setdefault` (it sets `eq = True`, `order = self.eq`, `hash = None` unconditionally — there is a comment there recording that conflating the two was a past bug), and `mapping` left the list when #71 fixed `key` at the root.

So it is no longer kept by hand. A test reads `inspect.getsource(Field.setdefault)`, pulls every `options.<name>` out of it, and asserts set equality with `_OVERRIDABLE`. It fails in **both** directions — a setting that stops reaching a field, which is exactly what `mapping` just did, and one that starts. Two cheaper siblings assert the keys are real class settings and the values are real `Field` slots.

What is left: `frozen`, `kw_only`, `positional_only`, `convert`, `validate`, `factory`, and `repr` — the last still conditional, since only a `SHOW_ATTR`/`HIDE_IF_NONE` sentinel reaches a field. Anything else raises:

> `Bad` asks to override `'eq'`, which is not one of the settings a field takes from its class: convert, factory, frozen, kw_only, positional_only, repr, validate.

## A landmine found on the way

`_handle_mutable_default` promotes `x: list = []` to a factory *after* `setdefault` and clears the default. Naive re-resolution restored `factory` to `MISSING` with the default already gone — silently turning an inherited field with a default into a **required argument**. It is fixed by recording the promotion as declared, and there is a test that fails without it.

Also noted at `Field.copy`: `SlotsBase.update` copies slots by reference and would share a `declared` dict. Not reachable today, but it is the same hazard `copy()` had.

## One limitation, deliberately taken

The `Hints` used when a converter is rebuilt is the **inheriting** class's, so a name is looked up where the subclass is written. If a base in another module annotated a field by name and the subclass turns `convert` on with `override`, that name may not be in the subclass's module — it then takes the documented `unresolved_hints` path (warn by default, naming the class and field) rather than resolving. Making it exact needs per-field provenance for hints, which is a design question rather than a detail. Commented at the call site.

## Also

A redeclared field builds a fresh `Field` from its annotation, so `override` never touches it — only fields inherited unchanged. Tested.

820 passed on 3.11, 3.12 and 3.13; `src` and every test file at 100% bar the pre-existing version branch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_