### PR TITLE
Namespace the last four generated locals a field name could shadow

### DIFF
--- a/src/bagof/magic/_constants.py
+++ b/src/bagof/magic/_constants.py
@@ -79,6 +79,17 @@ _ERROR = "__magic_error__"
 # parameter, while it is being built, converted and validated
 def _VALUE(x: str) -> str: return f"__magic_{x}_value__"
 
+# Names given, when generating __init__, to the locals holding the
+# builtins and the factory marker its body is written in terms of. The
+# generated function's parameters are named after the fields, so a field
+# called `object` or `isinstance` would shadow the builtin of that name
+# for the whole body; carrying each under a namespaced name keeps it
+# reachable whatever the fields are called.
+_OBJECT = "__magic_object__"
+_ISINSTANCE = "__magic_isinstance__"
+_EXCEPTION = "__magic_exception__"
+_HAS_FACTORY = "__magic_has_factory__"
+
 # Name given to a method's return type variable when generating it
 def _RETURN_TYPE(x: str) -> str: return f"__magic_{x}_return_type__"
 

--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -163,11 +163,15 @@ from ._constants import (
     _DEFAULT,
     _DISCARD,
     _ERROR,
+    _EXCEPTION,
     _FIELD_ERROR,
     _FIELDS,
     _GENERATED,
+    _HAS_FACTORY,
     _HINTS,
+    _ISINSTANCE,
     _MAGIC,
+    _OBJECT,
     _OPTIONS,
     _POST_INIT_NAME,
     _PRE_INIT_NAME,
@@ -1850,7 +1854,16 @@ def _make_init(
     clsname: str,
 ) -> dict:
 
-    locals = {"object": object, "_HasFactory": _HasFactory}
+    # The body below is written in terms of these; each is carried
+    # under a namespaced name because the parameters of the function
+    # being generated are named after the fields, and a field is free to
+    # be called `object`, `isinstance` or anything else.
+    locals = {
+        _OBJECT: object,
+        _ISINSTANCE: isinstance,
+        _EXCEPTION: Exception,
+        _HAS_FACTORY: _HasFactory,
+    }
     positional_onlys, args, kw_onlys = {}, {}, {}
 
     SELF = "self"
@@ -1971,7 +1984,7 @@ def _make_init(
         return dedent(f"""
         try:
             {call}
-        except Exception as {_ERROR}:
+        except {_EXCEPTION} as {_ERROR}:
             {_FIELD_ERROR}({blamed})
         """)
 
@@ -1984,7 +1997,7 @@ def _make_init(
         name = field.public_name
         call = _guarded(f"{name} = {name}()", field, "build")
         return dedent(f"""
-        if isinstance({name}, _HasFactory):
+        if {_ISINSTANCE}({name}, {_HAS_FACTORY}):
         """) + indent(call, " " * 4)
 
     def _make_body_elem(field: Field) -> str:
@@ -2009,7 +2022,7 @@ def _make_init(
             # NOTE: we by pass the object's __setattr__ to avoid running
             # through conversion and validation multiple times.
             body += dedent(f"""
-            object.__setattr__({SELF}, {field.name!r}, {name})
+            {_OBJECT}.__setattr__({SELF}, {field.name!r}, {name})
             """)
         return body
 
@@ -2023,7 +2036,7 @@ def _make_init(
         locals[default] = field.factory if field.factory else field.default
         if not (field.factory or field.converter or field.validator):
             return dedent(f"""
-            object.__setattr__({SELF}, {field.name!r}, {default})
+            {_OBJECT}.__setattr__({SELF}, {field.name!r}, {default})
             """)
         # Building, converting and validating are taken one at a time,
         # so that whichever of them fails can say what it was doing.
@@ -2047,7 +2060,7 @@ def _make_init(
                 field, "validate", value
             )
         return body + dedent(f"""
-        object.__setattr__({SELF}, {field.name!r}, {value})
+        {_OBJECT}.__setattr__({SELF}, {field.name!r}, {value})
         """)
 
     body = [_make_factory_elem(field) for field in parameters]

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -5415,3 +5415,107 @@ class TestTheFailingFieldIsNamed:
         assert server.spare == 8080
         server.port = "443"
         assert server.port == 443
+
+
+class TestFieldNamesThatShadowGeneratedLocals:
+    """
+    A field may be called anything at all, including the names the
+    generated `__init__` is itself written in terms of.
+    """
+
+    def test_a_field_named_object(self) -> None:
+        class Box(Magic):
+            object: int
+
+        box = Box(3)
+        assert box.object == 3
+        assert repr(box) == "Box(object=3)"
+
+    def test_a_field_named_object_is_stored_on_assignment_too(self) -> None:
+        class Box(Magic, convert=True):
+            object: int
+
+        box = Box(3)
+        box.object = "4"
+        assert box.object == 4
+
+    def test_a_field_named_isinstance(self) -> None:
+        class Box(Magic):
+            isinstance: Factory[list]
+
+        assert Box().isinstance == []
+        assert Box([1, 2]).isinstance == [1, 2]
+
+    def test_a_field_named_exception(self) -> None:
+        def refuse(value: tx.Any) -> int:
+            raise ValueError("I would rather not")
+
+        class Box(Magic):
+            Exception: ConvertTo[int, refuse]
+
+        with pytest.raises(ValueError) as caught:
+            Box(1)
+        assert "Box.Exception" in str(caught.value)
+        assert "I would rather not" in str(caught.value)
+
+    def test_a_field_named_after_the_factory_marker(self) -> None:
+        class Box(Magic):
+            # `alias=False` keeps the leading underscore on the
+            # parameter, which is what puts the name in the way.
+            _HasFactory: Annotated[list, Field(alias=False, factory=list)]
+
+        box = Box()
+        assert box._HasFactory == []
+        assert Box([1])._HasFactory == [1]
+
+    def test_all_of_them_at_once(self) -> None:
+        class Box(Magic):
+            self: int
+            object: int
+            isinstance: Factory[list]
+            Exception: str = "fine"
+
+        box = Box(1, 2)
+        assert box.self == 1
+        assert box.object == 2
+        assert box.isinstance == []
+        assert box.Exception == "fine"
+
+    def test_every_generated_statement_under_a_shadowing_name(self) -> None:
+        def double(value: int) -> int:
+            return value * 2
+
+        def five() -> int:
+            return 5
+
+        def three() -> int:
+            return 3
+
+        def positive(value: int) -> int:
+            if value <= 0:
+                raise ValueError("must be positive")
+            return value
+
+        # A parameter that is built, converted and validated, and a
+        # field that is not a parameter and goes through all three from
+        # its own default -- every statement the builder writes, with
+        # `object` shadowing the builtin the stores are written with.
+        class Box(Magic):
+            object: Annotated[
+                int,
+                Field(factory=five, converter=double, validator=positive),
+            ]
+            spare: NoInit[
+                Annotated[
+                    int,
+                    Field(factory=three, converter=double,
+                          validator=positive),
+                ]
+            ]
+
+        assert repr(Box()) == "Box(object=10, spare=6)"
+        assert repr(Box(4)) == "Box(object=8, spare=6)"
+        with pytest.raises(ValueError) as caught:
+            Box(-1)
+        assert "Box.object" in str(caught.value)
+        assert "must be positive" in str(caught.value)


### PR DESCRIPTION
Closes #72.

## Four, not two

The issue named `object` and `_HasFactory`. Reading every helper that writes source text into the generated `__init__` turned up two more, and one of them was worse than either:

| name | where | what a field of that name did |
|---|---|---|
| `object` | the three `object.__setattr__(...)` stores | `TypeError: expected 2 arguments, got 3` |
| `_HasFactory` | `isinstance(x, _HasFactory)` | `TypeError: isinstance() arg 2 must be a type…` |
| `isinstance` | the same line | `TypeError: _HasFactory.__call__() takes 1 positional argument but 3 were given` |
| `Exception` | `except Exception as …` in the per-field guard | **every** converter, validator and factory failure became `TypeError: catching classes that do not inherit from BaseException is not allowed` |

That last one is the one worth having found. A field named `Exception` did not break its own class — it broke the error handling for *every other field in it*, replacing whatever actually went wrong with a message about `BaseException`:

```
main    E('bad')  ->  TypeError: catching classes that do not inherit from BaseException is not allowed
branch  E('bad')  ->  ValueConversionError: E.Exception: could not convert 'bad' -- ToNumber(<class 'int'>): Invalid value.
```

Every other name the builder emits was already namespaced — `__magic_<field>_type__`, `_converter__`, `_validator__`, `__magic_arguments__`, `__magic_field_error__` and the rest — precisely so a field could not collide with one. These four were left bare. They now follow the same convention, named in `_constants.py` beside their siblings.

## Two things checked and left alone

**`self` is already complete.** `_SELF` (`__magic_self__`) is swapped in whenever any parameter's public name is `"self"`, and the body uses that name for every store and hook call. A field named `self` that is *not* a parameter cannot shadow anything, so the plain `"self"` there is correct. Unchanged, and now covered by a combined test.

**`__setattr__` needed nothing.** It is a real closure rather than generated source, so `object`, `Exception` and `field_error` resolve at module level and no field name reaches them. Confirmed with a test that a field named `object` still converts and stores on assignment.

## Also found, filed not fixed

**#75** — a field whose documentation contains `"""` breaks class creation with a `SyntaxError` in generated source, because the doc block is embedded in a triple-quoted literal unescaped. It reaches defaults too, since the generated numpydoc line embeds `{default!r}`, so any value whose `repr()` contains three quotes will do it. Probably better fixed by assigning `__doc__` after the `exec` than by escaping.

## Tests

One per name; a class carrying all four *plus* a field named `self`; and one that exercises every emitted statement — factory, convert, validate, store, for both a parameter and a `NoInit` own-default — while `object` shadows the builtin, including the failure path so the `except` clause actually runs. All seven fail against `main`.

827 passed on 3.11, 3.12 and 3.13; ruff and codespell clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_