### PR TITLE
Fill a base's type parameters in on the fields that inherit them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,8 @@ src/bagof/magic/
   _resolve.py   # adapters to bagof-converters / -validators / -factories,
                 #   and the deferred resolution of a hint that is still
                 #   a name when the class is built
+  _generics.py  # what a base's type parameters stand for, and filling
+                #   them in on the hints that mention them
   _errors.py    # field_error -- names the class and the field when a
                 #   converter, a validator or a factory raises
 tests/
@@ -197,6 +199,52 @@ Evaluating the text later does not reopen the "an annotation is never
 called" rule. `_readable` refuses text with a call in it, so `x:
 _record()` is reported rather than run at first use, exactly as it is at
 class creation.
+
+### Filling in a base's type parameters
+
+`class IntBox(Box[int])` says that `Box`'s `T` stands for `int` here, so
+the inherited field `item: T` has to become `item: int` -- otherwise both
+resolvers get a bare `TypeVar` to work from, let every value through, and
+a class that asked for `validate=True` checks nothing.
+
+Two things make that work, and neither takes a hint apart by hand:
+
+- **What each base fills in is read off `__orig_bases__`**, the bases as
+  they were written, which is the same attribute `_mro` needs and the only
+  place `Box[int]` survives -- by the time the metaclass runs, the bases
+  themselves are plain `Box`. `type_arguments` zips a base's
+  `__parameters__` against `tx.get_args` of the alias, and keys the answer
+  by the base, so two parameterised bases fill in their own variables and
+  not each other's.
+- **The substitution itself is `typing`'s.** A hint that mentions a type
+  variable lists it in `__parameters__` and can be subscripted to fill it
+  in -- `List[T][int]` is `List[int]` -- which is exactly what writing
+  `Box[int]` does. Going through that rather than walking the hint and
+  rebuilding it keeps every shape working the same way on 3.8 through
+  3.13: nested (`Dict[str, T]`), carrying metadata (`Annotated[T,
+  Field(alias="why")]`, whose metadata survives), a callable signature,
+  and a base that fills one parameter of two. The two spellings a walk
+  would need -- `copy_with` and `__args__` -- disagree with `get_args`
+  about `Callable` and about `Annotated`, and differ by version; this one
+  does not exist in two forms.
+
+A generic class named on its own (a bare `Box` as a field's type) lists
+its parameters too, and is deliberately **not** filled in: it stands for
+`Box` with anything in it. That is why `substitute` also asks for an
+origin before doing anything.
+
+Which of a field's converter, validator and factory came from its type is
+recorded on the field as `derived` when `setdefault` resolves them, and
+`Field._rebuild` builds those again from the new type. One that was handed
+over ready made (`ConvertTo(some_callable)`) is not in `derived` and is
+left exactly as it is: filling in a type variable says nothing about it.
+The snapshot holds the *names* of the three, not the type they came from,
+so there is no second copy of the type to keep in step with the first.
+
+Out of scope, and said so in `README.md` and `docs/comparison.md`:
+`Box[int]("1")`. That is a `typing` alias rather than a class, so there is
+no class being built and nowhere to hang a filled-in field table;
+catching it means intercepting `__call__` on the alias.
 
 ## Conventions specific to this repo (do not regress)
 

--- a/README.md
+++ b/README.md
@@ -325,7 +325,8 @@ Circle(radius=6.0)
 ```
 
 **Generic classes.** A `Magic` class can take a type parameter like any
-other:
+other, and a subclass that says what it stands for gets fields of that
+type:
 
 ```python
 from typing import Generic, TypeVar
@@ -333,21 +334,31 @@ from bagof.magic import Magic
 
 T = TypeVar("T")
 
-class Box(Magic, Generic[T]):
+class Box(Magic, Generic[T], convert=True):
     item: T
+
+class IntBox(Box[int]):
+    pass
 ```
 
 ```pycon
->>> Box(1)
-Box(item=1)
->>> Box[str]("hello")
-Box(item='hello')
+>>> Box("1")
+Box(item='1')
+>>> IntBox("1")
+IntBox(item=1)
 ```
 
-The parameter is not filled in on the fields, though: a subclass written as
-`class IntBox(Box[int])` still sees `item` as `T`, so conversion and
-validation have nothing to go on there. Annotate the field with a real type
-in the subclass if you need those.
+`item` is `T` on `Box`, which is no type to convert to and nothing to
+validate against, and `int` on `IntBox` -- which is why one of them turns
+the string into a number and the other does not. It works the same way
+when the parameter is buried in the annotation (`List[T]`, `Optional[T]`,
+`Dict[str, T]`), and a class that fills in one parameter of two leaves the
+other standing for its own subclasses to fill in.
+
+Writing the parameter where the object is built -- `Box[int]("1")` -- is a
+different thing. That is a `typing` alias rather than a class, so it builds
+a plain `Box` and `item` stays as it was; give the subclass a name when you
+want the fields to follow.
 
 **Documentation that writes itself.** Describe a field and it shows up in the
 class docstring and in the generated `__init__`:

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -47,7 +47,7 @@ question of what you want the type hints to *do*.
 | Copy with changes | `replace` | `evolve` | `model_copy` | **`replace`** |
 | Convert to a plain `dict` | `asdict` | `asdict` | `model_dump` | **`asdict`**, *without recursing* |
 | JSON schema | no | no | yes | no |
-| Generic classes | yes | yes | yes | **yes**, *[without substitution][generics]* |
+| Generic classes | yes | yes | yes | **yes**, *[named subclass only][generics]* |
 | Runtime dependency | none | `attrs` | `pydantic-core` (compiled) | the `bagof` packages |
 
 ## The same class, four ways
@@ -236,11 +236,13 @@ Being honest about the gaps, with links to where they are being worked on:
   stored, so a field holding another object gives you that object rather
   than a dict of its fields. The others walk the whole tree, copying
   lists and dicts as they go.
-- **Type parameters in a generic class.** `class Box(Magic, Generic[T])`
-  works, but a subclass that fills the parameter in — `class IntBox(Box[int])`
-  — leaves the field's type as `T`, so conversion and validation have nothing
-  to work from and let any value through. [Tracked here][generics]. Pydantic
-  substitutes the parameter; `dataclasses` and `attrs` do not either.
+- **A type parameter filled in where the object is built.** A subclass
+  fills one in — `class IntBox(Box[int])` gives `item` the type `int`, and
+  converts and validates against it — but the same thing written at the
+  point of use, `Box[int]("1")`, does not: that is a `typing` alias rather
+  than a class, so it builds a plain `Box` whose `item` is still `T`.
+  [Tracked here][generics]. Pydantic fills that one in too; `dataclasses`
+  and `attrs` fill in neither.
 - **Editor and type-checker support.** The others are understood by mypy and
   pyright today, so your editor completes the constructor and catches a wrong
   argument type. `magic` is not, yet — [tracked here][typing]. The route is

--- a/src/bagof/magic/_fields.py
+++ b/src/bagof/magic/_fields.py
@@ -69,6 +69,9 @@ T = tx.TypeVar("T")
     'converter',
     # A function that validates the input value for this field.
     'validator',
+    # Which of `converter`, `validator` and `factory` were worked out
+    # from `type` rather than given.
+    'derived',
     # Whether this field is a pseudo-field (InitVar or ClassVar).
     'var',
     'doc',              # Docstring for this field.
@@ -137,6 +140,12 @@ class Field(SlotsBase):
             If should be pass-through when the value is valid, and raise
             an exception when it is not.
             If `True`, a validator will be generated based on the field type.
+        derived : tuple of str, optional
+            Which of `converter`, `validator` and `factory` were worked
+            out from the field's type rather than handed over ready
+            made. A subclass that fills in a type variable builds those
+            again from the type it filled in, and leaves the ones you
+            passed alone.
         var : bool, default=False
             Whether this field is a pseudo-field (InitVar or ClassVar).
             Pseudo-fields are not set by the generated `__init__` method,
@@ -353,18 +362,36 @@ class Field(SlotsBase):
             self.frozen = options.frozen
         if self.converter is MISSING:
             self.converter = options.convert
-        if self.converter is True:
-            self.converter = _make_converter(self.type, hints, self.name)
         if self.validator is MISSING:
             self.validator = options.validate
-        if self.validator is True:
-            self.validator = _make_validator(self.type, hints, self.name)
         if self.factory is MISSING:
             self.factory = options.factory
-        if self.factory is True:
-            # Resolve the default factory from the field's type hint, the
-            # same way converters/validators are resolved from their bag.
-            self.factory = _make_factory(self.type, hints, self.name)
+        # `True` means "work it out from the type" -- for the factory as
+        # much as for the other two, which is why all three go through
+        # the same step. Which ones were worked out that way is worth
+        # remembering: a subclass that fills in a type variable has to
+        # build those again from the type it filled in, and must leave
+        # a converter, validator or factory that was handed over ready
+        # made exactly as it is.
+        self.derived = tuple(
+            attr for attr in _FROM_TYPE if getattr(self, attr) is True
+        )
+        self._rebuild(hints)
+
+    def _rebuild(self, hints: tx.Optional[Hints] = None) -> None:
+        # Work out again, from the field's type, whatever was worked out
+        # from it the first time round.
+        for attr in self.derived or ():
+            setattr(self, attr, _FROM_TYPE[attr](self.type, hints, self.name))
+
+
+#: How each of the three is built, for a field that asked for it to be
+#: worked out from its type.
+_FROM_TYPE = {
+    "converter": _make_converter,
+    "validator": _make_validator,
+    "factory": _make_factory,
+}
 
 
 def _stored(obj: tx.Any, field: Field) -> tx.Tuple[bool, tx.Any]:

--- a/src/bagof/magic/_generics.py
+++ b/src/bagof/magic/_generics.py
@@ -1,0 +1,76 @@
+"""
+Filling in the type parameters a base class was written with.
+
+A class written as ``class IntBox(Box[int])`` says that ``Box``'s type
+variable ``T`` stands for ``int`` here. Python keeps the bases as they
+were written in ``__orig_bases__``, so what each variable stands for can
+be read back off, and a field ``Box`` declared as ``item: T`` becomes
+``item: int`` on the subclass -- with a converter, a validator and a
+default factory built from the type that was filled in.
+
+The substitution itself is left to ``typing``. Every hint that mentions a
+type variable lists it in ``__parameters__`` and can be subscripted to
+fill it in, which is exactly what writing ``Box[int]`` does. Going
+through that rather than taking a hint apart and putting it back
+together keeps every shape working the same way: a nested hint
+(``List[T]``, ``Dict[str, T]``), one carrying metadata
+(``Annotated[T, Field(alias="why")]``, whose metadata is kept), a
+callable signature (``Callable[[T], T]``), and a base that fills one
+parameter of two (``Pair[int, S]``, which leaves ``S`` standing).
+"""
+
+from __future__ import annotations
+
+__all__ = ["substitute", "type_arguments"]
+
+import typing_extensions as tx
+
+
+def type_arguments(namespace: dict) -> tx.Dict[type, tx.Dict[tx.Any, tx.Any]]:
+    """
+    What each base fills its type variables in with, keyed by that base.
+
+    `namespace` is the class body being built. A base written without
+    brackets, and one written with its own variables passed straight
+    through (`Generic[T]`), fills nothing in and is left out.
+    """
+    arguments = {}
+    for base in namespace.get("__orig_bases__", ()):
+        origin = tx.get_origin(base)
+        if origin is None:
+            continue
+        parameters = getattr(origin, "__parameters__", ())
+        values = tx.get_args(base)
+        if len(values) != len(parameters):
+            # A base subscripted with the wrong number of arguments is
+            # Python's to complain about, not this module's.
+            continue
+        filled = {
+            parameter: value
+            for parameter, value in zip(parameters, values)
+            if value is not parameter
+        }
+        if filled:
+            arguments[origin] = filled
+    return arguments
+
+
+def substitute(hint: tx.Any, arguments: tx.Dict[tx.Any, tx.Any]) -> tx.Any:
+    """
+    `hint` with the type variables named in `arguments` filled in.
+
+    The hint is handed back unchanged, and not merely equal to itself,
+    when it mentions none of them.
+    """
+    if isinstance(hint, tx.TypeVar):
+        return arguments.get(hint, hint)
+    parameters = getattr(hint, "__parameters__", ())
+    if not parameters or tx.get_origin(hint) is None:
+        # No variables to fill in -- or a generic class named on its own,
+        # like a bare `Box`, which lists its parameters but stands for
+        # `Box` with anything in it and is not this class's to narrow.
+        return hint
+    values = tuple(arguments.get(p, p) for p in parameters)
+    if all(value is p for value, p in zip(values, parameters)):
+        return hint
+    return hint[values if len(values) > 1 else values[0]]

--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -185,6 +185,8 @@ from ._errors import field_error
 from ._fields import *  # noqa: F401, F403
 from ._fields import Field, _stored
 from ._fields import __all__ as __all_fields__
+from ._generics import substitute as _substitute
+from ._generics import type_arguments as _type_arguments
 from ._options import *  # noqa: F401, F403
 from ._options import Options
 from ._options import __all__ as __all_options__
@@ -259,6 +261,26 @@ def _inherit_attrs(
         inherited = getattr(other, attr, MISSING)
         if inherited is not MISSING:
             setattr(field, attr, inherited)
+
+
+def _fill_in_type(
+    field: Field,
+    arguments: tx.Dict[tx.Any, tx.Any],
+    hints: Hints,
+) -> None:
+    # Replace the type variables in a field's type with what the class
+    # being built says they stand for, and work out again whatever was
+    # worked out from that type. A converter, validator or factory the
+    # field was given rather than asked for is left alone: filling in a
+    # type variable says nothing about it.
+    #
+    # The field is one this class owns -- `_add_fields` copies on the way
+    # in -- so it is changed in place.
+    filled = _substitute(field.type, arguments)
+    if filled is field.type:
+        return
+    field.type = filled
+    field._rebuild(hints)
 
 
 def _add_fields(
@@ -1250,7 +1272,25 @@ def __pre_new__(
     # Find our base classes in reverse MRO order, so that order is
     # obtained from MRO, but value is obtained from most derived class.
     mro = _mro(bases, namespace)
-    for b in reversed(mro):
+
+    # What this class fills in for the type variables its bases were
+    # written with: `class IntBox(Box[int])` says that `Box`'s `T` is
+    # `int` here. Kept per base, so that two parameterised bases fill in
+    # their own variables and not each other's.
+    arguments = _type_arguments(namespace)
+
+    # Which of those applies to each inherited field, once every base has
+    # had its say. A field a later base also declares is that base's, so
+    # the last word on the field is the last word on its type variables
+    # too -- including "none", when that base fills nothing in.
+    inherited_arguments = {}
+
+    # `mro[0]` is the throwaway class built above to work out the
+    # inheritance order. It has no fields of its own -- it only inherits
+    # the most derived base's, which the loop reads off that base
+    # anyway -- and nothing was written as one of *its* type variables,
+    # so reading it would only undo what that base said.
+    for b in reversed(mro[1:]):
         # Only process classes that have been processed by our
         # decorator.  That is, they have a _FIELDS attribute.
         base_fields = getattr(b, _FIELDS, None)
@@ -1263,6 +1303,9 @@ def __pre_new__(
                 replace=True,
                 reverse=options.reverse
             )
+            if arguments:
+                for field_name in base_fields:
+                    inherited_arguments[field_name] = arguments.get(b)
 
     # Save final options for this class.
     options.update(Options(**kwargs))
@@ -1309,6 +1352,14 @@ def __pre_new__(
     # namespace once it exists, by `__post_new__`.
     hints = Hints(globals, {}, clsname, options.unresolved_hints)
     namespace[_HINTS] = hints
+
+    # Fill the type variables in on the fields that came from a base
+    # written with them. A field this class declares again is built from
+    # its own annotation further down and replaces the one filled in
+    # here, so only what really is inherited is touched.
+    for field_name, base_arguments in inherited_arguments.items():
+        if base_arguments:
+            _fill_in_type(fields[field_name], base_arguments, hints)
 
     # Annotations that are defined in this class (not in base
     # classes).  If __annotations__ isn't present, then this class

--- a/tests/test_annotations_as_strings.py
+++ b/tests/test_annotations_as_strings.py
@@ -42,6 +42,7 @@ from bagof.magic import (
     NoRepr,
     Options,
     Validate,
+    fields_dict,
 )
 
 if TYPE_CHECKING:
@@ -616,3 +617,37 @@ class TestHintsThatNeverResolve:
 
         with pytest.warns(UserWarning, match="^port: the name `NeverDefined`"):
             assert field.converter("8") == "8"
+
+
+# ======================================================================
+# Type parameters
+# ======================================================================
+
+
+_T = tx.TypeVar("_T")
+
+
+class TextBox(Magic, tx.Generic[_T], convert=True):
+    item: _T
+    items: tx.List[_T]
+
+
+class TestTypeParametersWrittenAsText:
+    """A generic class in a module whose annotations are strings."""
+
+    def test_a_type_parameter_is_read_back_as_itself(self) -> None:
+        # Not carried by name: `_T` is defined in this module, so the
+        # text resolves to the very type variable the class was written
+        # with -- which is what a subclass then fills in.
+        fields = fields_dict(TextBox)
+        assert fields["item"].type is _T
+        assert fields["items"].type == tx.List[_T]
+
+    def test_a_subclass_fills_it_in(self) -> None:
+        class IntBox(TextBox[int]):
+            pass
+
+        fields = fields_dict(IntBox)
+        assert fields["item"].type is int
+        assert fields["items"].type == tx.List[int]
+        assert IntBox("1", ["2"]) == IntBox(1, [2])

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -4761,6 +4761,245 @@ class TestGenericClasses:
 
 
 # ======================================================================
+# Filling a type parameter in
+# ======================================================================
+
+
+_S = tx.TypeVar("_S")
+
+
+class ConvertingBox(Magic, tx.Generic[_T], convert=True):
+    item: _T
+
+
+class ValidatingBox(Magic, tx.Generic[_T], validate=True):
+    item: _T
+
+
+class GenericPair(Magic, tx.Generic[_T, _S], convert=True):
+    left: _T
+    right: _S
+
+
+class ConvertingPlain(Magic, convert=True):
+    a: int
+
+
+class PlainChild(ConvertingPlain):
+    b: str
+
+
+class TestFillingATypeParameterIn:
+    """A subclass that says what a base's type parameter stands for."""
+
+    def test_the_field_takes_the_type_that_was_filled_in(self) -> None:
+        class IntBox(GenericBox[int]):
+            pass
+
+        assert _api.fields_dict(IntBox)["item"].type is int
+
+    def test_the_value_is_converted_to_it(self) -> None:
+        class IntBox(ConvertingBox[int]):
+            pass
+
+        assert IntBox("1").item == 1
+
+    def test_the_value_is_validated_against_it(self) -> None:
+        class IntBox(ValidatingBox[int]):
+            pass
+
+        assert IntBox(1).item == 1
+        with pytest.raises(ValidationError):
+            IntBox("one")
+
+    def test_the_base_is_left_as_it_was(self) -> None:
+        # The subclass fills the parameter in for itself only.
+        class IntBox(ConvertingBox[int]):
+            pass
+
+        assert _api.fields_dict(ConvertingBox)["item"].type is _T
+        assert ConvertingBox("1").item == "1"
+
+    def test_a_default_factory_is_built_from_it(self) -> None:
+        class Box(Magic, tx.Generic[_T]):
+            item: Factory[_T]
+
+        class IntBox(Box[int]):
+            pass
+
+        assert IntBox().item == 0
+
+    # -- hints the parameter is buried in ------------------------------
+
+    def test_a_parameter_inside_a_list(self) -> None:
+        class Box(Magic, tx.Generic[_T], convert=True):
+            items: tx.List[_T]
+
+        class IntBox(Box[int]):
+            pass
+
+        assert _api.fields_dict(IntBox)["items"].type == tx.List[int]
+        assert IntBox(["1", "2"]).items == [1, 2]
+
+    def test_a_parameter_inside_an_optional(self) -> None:
+        class Box(Magic, tx.Generic[_T], convert=True):
+            item: Optional[_T] = None
+
+        class IntBox(Box[int]):
+            pass
+
+        assert _api.fields_dict(IntBox)["item"].type == Optional[int]
+        assert (IntBox("1").item, IntBox().item) == (1, None)
+
+    def test_a_parameter_inside_a_dict(self) -> None:
+        class Box(Magic, tx.Generic[_T], convert=True):
+            items: tx.Dict[str, _T]
+
+        class IntBox(Box[int]):
+            pass
+
+        assert IntBox({"a": "1"}).items == {"a": 1}
+
+    def test_an_annotated_parameter_keeps_its_metadata(self) -> None:
+        class Box(Magic, tx.Generic[_T], convert=True):
+            item: Annotated[_T, Field(alias="why")]
+
+        class IntBox(Box[int]):
+            pass
+
+        assert _api.fields_dict(IntBox)["why"].type is int
+        assert IntBox(why="1").item == 1
+
+    # -- more than one parameter ---------------------------------------
+
+    def test_both_parameters_are_filled_in(self) -> None:
+        class Pair(GenericPair[int, str]):
+            pass
+
+        assert Pair("1", "two") == Pair(1, "two")
+
+    def test_one_parameter_filled_in_and_one_left_standing(self) -> None:
+        class HalfPair(GenericPair[int, _S], tx.Generic[_S]):
+            pass
+
+        fields = _api.fields_dict(HalfPair)
+        assert (fields["left"].type, fields["right"].type) == (int, _S)
+        # The one left standing behaves as it did: no type to work from,
+        # so the value goes through as it is.
+        assert HalfPair("1", "two") == HalfPair(1, "two")
+
+    def test_a_hint_with_no_parameter_of_its_own_is_left_alone(
+        self
+    ) -> None:
+        class Pair(Magic, tx.Generic[_T, _S]):
+            left: _T
+            rights: tx.List[_S]
+            label: str = "?"
+
+        class HalfPair(Pair[int, _S], tx.Generic[_S]):
+            pass
+
+        fields = _api.fields_dict(HalfPair)
+        assert fields["left"].type is int
+        assert fields["label"].type is str
+        # Not merely equal to the hint it started as: the very same one.
+        assert fields["rights"].type is _api.fields_dict(Pair)["rights"].type
+
+    def test_a_parameter_passed_straight_through_fills_nothing_in(
+        self
+    ) -> None:
+        class Relabelled(ConvertingBox[_T], tx.Generic[_T]):
+            pass
+
+        assert _api.fields_dict(Relabelled)["item"].type is _T
+
+    # -- along a chain of classes --------------------------------------
+
+    def test_a_chain_of_three_classes(self) -> None:
+        class Middle(ConvertingBox[int]):
+            pass
+
+        class Leaf(Middle):
+            pass
+
+        assert _api.fields_dict(Leaf)["item"].type is int
+        assert Leaf("1").item == 1
+
+    def test_a_generic_class_in_the_middle_of_the_chain(self) -> None:
+        class Middle(ConvertingBox[_T], tx.Generic[_T]):
+            pass
+
+        class Leaf(Middle[int]):
+            pass
+
+        assert Leaf("1").item == 1
+
+    # -- what must not change ------------------------------------------
+
+    def test_a_field_the_subclass_declares_again_keeps_its_own_type(
+        self
+    ) -> None:
+        class Redeclared(ConvertingBox[int]):
+            item: str
+
+        assert _api.fields_dict(Redeclared)["item"].type is str
+        assert Redeclared("one").item == "one"
+
+    def test_a_converter_that_was_given_rather_than_worked_out(
+        self
+    ) -> None:
+        class Box(Magic, tx.Generic[_T], convert=True):
+            item: ConvertTo[_T, str.upper]
+
+        class IntBox(Box[int]):
+            pass
+
+        assert _api.fields_dict(IntBox)["item"].type is int
+        assert IntBox("hi").item == "HI"
+
+    def test_a_plain_subclass_of_a_plain_class_is_untouched(self) -> None:
+        # Not merely equivalent: the very same converter, so nothing was
+        # built again behind the scenes.
+        inherited = _api.fields_dict(PlainChild)["a"]
+        declared = _api.fields_dict(ConvertingPlain)["a"]
+        assert inherited.type is declared.type
+        assert inherited.converter is declared.converter
+
+    def test_a_filled_in_field_really_does_get_a_new_converter(self) -> None:
+        # The other half of the test above: an identity check only says
+        # something if it can fail.
+        class IntBox(ConvertingBox[int]):
+            pass
+
+        assert (
+            _api.fields_dict(IntBox)["item"].converter
+            is not _api.fields_dict(ConvertingBox)["item"].converter
+        )
+
+    def test_which_of_the_three_came_from_the_type(self) -> None:
+        class Box(Magic, tx.Generic[_T], convert=True):
+            given: ConvertTo[_T, str.upper]
+            worked_out: _T
+
+        fields = _api.fields_dict(Box)
+        assert fields["given"].derived == ()
+        assert fields["worked_out"].derived == ("converter",)
+
+    def test_a_type_still_written_as_a_name_is_filled_in_too(self) -> None:
+        class Box(Magic, tx.Generic[_T], convert=True):
+            item: _T
+
+        class LaterBox(Box["_Later"]):
+            pass
+
+        assert LaterBox(3).item == _Later(3)
+
+
+class _Later(Magic):
+    value: int
+
+
+# ======================================================================
 # replace / asdict / astuple / fields_dict / is_magic
 # ======================================================================
 


### PR DESCRIPTION
Closes #50.

## The bug

A generic class could be defined (#49) but parameterising one did nothing to its fields — so conversion and validation silently did not happen:

```pycon
>>> class Box(Magic, Generic[T], convert=True, validate=True):
...     item: T
>>> class IntBox(Box[int]): pass
>>> IntBox("one").item
'one'                        # not converted, not rejected
```

Now:

```
substituted type: <class 'int'>
converts        : 1
rejects         : IntBox.item: could not convert 'one' -- ToNumber(<class 'int'>): Invalid value.
list[T] -> typing.List[int]   Optional[T] -> typing.Optional[int]
partial : <class 'int'> / ~S
```

## Substitution by subscription, not by walking

Every hint that mentions a type variable lists it in `__parameters__` and can be subscripted to fill it in — `List[T][int]` *is* `List[int]`, which is literally what writing `Box[int]` does. So `typing`'s own machinery does the recursion, and there is no second spelling of it to keep correct.

Probed on all three available interpreters before committing to it: `List[T]`, `Dict[str, T]`, `Optional[T]`, `Annotated[T, meta]` with its metadata intact, `Callable[[int, T], T]`, `Tuple[T, ...]`, nesting, PEP 585 `list[T]`, and partial fills — identical on 3.11, 3.12 and 3.13, with `ParamSpec` and `TypeVarTuple` passing through without raising.

The walk-and-rebuild alternative needs `copy_with`/`__args__`, and those disagree with `get_args` about `Callable` (`([int, T], T)` versus `(int, T, T)`) and about `Annotated`, differently by version.

Two guards matter, and the second is the interesting one:

- a bare `TypeVar` has no `__parameters__`, so it is handled first by a dict lookup;
- a bare generic class (`x: Box`) *does* list `__parameters__` but means "a `Box` of anything", so it is skipped — and the skip is `get_origin(hint) is None`, **not** `isinstance(hint, type)`, because on 3.9 and 3.10 `isinstance(list[int], type)` is `True`, which would have silently disabled PEP 585 hints on exactly those two versions.

Only a converter, validator or factory that was *derived from the type* is rebuilt. An explicit `ConvertTo(some_callable)` is left exactly as it was — filling in a type variable says nothing about it. A new `derived` slot on `Field` records which of the three were type-derived.

## A pre-existing bug found on the way

`__pre_new__`'s base loop iterated `reversed(mro)` **including `mro[0]`** — the throwaway class the MRO helper builds, which inherits `_FIELDS` through `getattr`. So every class build processed its most-derived base's fields a second time. Harmless before, because the work was idempotent; fatal here, because processed last it reset each field's type arguments to "none" and substitution silently did nothing.

The loop is now `reversed(mro[1:])`, matching the `mapping` check just below it, which already skipped `mro[0]` for the same reason.

## It composes with `override=`

`override` landed while this was being built, and the two both add a pass over inherited fields. Substitution goes first, so a converter worked out again by `override` is worked out from the **filled-in** type:

```pycon
>>> class Loose(Box[int], convert=True): pass
>>> class Strict(Box[int], convert=True, override=True): pass
>>> Loose("1").item, Strict("1").item
('1', 1)
```

`Loose` inherits a field already settled without a converter; `Strict` decides `convert` again, against `int`. A test pins that, since it is a property of the two together that neither branch could have covered alone.

## Out of scope, and said so in the docs

`Box[int]("1")` — the subscripted form itself. `Box[int]` is a `typing._GenericAlias`, not a class, so it constructs a plain `Box` and there is nowhere to hang a substituted field table. Handling it means intercepting `__call__` on the alias, which is a much larger piece of work. The README and the comparison row now say what is true rather than "not yet".

## Not verified, and one more found

3.8, 3.9, 3.10 and 3.14 are not installed here; CI covers 3.8 and current. A multi-parameter conflict (`class C(A[int], B[str])` where `A` and `B` share one `TypeVar` object) is handled by keying the arguments per base, but that was reasoned rather than tested.

**A separate bug, already filed as bagofseeds/bagof-factories#37**: a factory built from a bare unbounded `TypeVar` recurses until `RecursionError`. Substitution now *fixes* it for a filled-in subclass (`IntBox().item == 0`) while the generic base still raises.

844 passed on 3.11, 3.12 and 3.13; `_generics.py` and `_fields.py` at 100%.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_