### PR TITLE
Stop embedding the docstring in generated source, and settle three open questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ class Thing(Magic, frozen=True, kw_only=True, slots=True):
 | `unresolved_hints` | `"warn"` | what to do when a type hint still names something undefined the first time a field needs it; or `"raise"`, or `"ignore"` |
 | `factory` | `False` | build every missing default from its type |
 | `mutable_default` | `"factory"` | give each instance its own copy of `x: list = []`; or `"raise"`, or `"allow"` |
-| `mapping` | `False` | behave like a dictionary; a subclass cannot turn it off again |
+| `mapping` | `False` | behave like a dictionary; a subclass inherits the methods and cannot turn them off |
 | `override` | `False` | apply this class's settings to inherited fields too |
 | `reverse` | `False` | list a subclass's own fields before inherited ones |
 | `doc` | `True` | add the field table to the class docstring |

--- a/README.md
+++ b/README.md
@@ -426,6 +426,22 @@ the class setting: on a `kw_only=True` class, `x: Positional[int]` can be
 passed by position anyway. What an annotation says nothing about follows
 the class as usual.
 
+Several of them go on one field by nesting, and when two disagree the outer
+one has the last word.
+
+```pycon
+>>> class ByName(Magic):
+...     x: Kw[NotKw[int]] = 0
+...
+>>> ByName(x=1)
+ByName(x=1)
+>>> class ByPosition(Magic):
+...     x: NotKw[Kw[int]] = 0
+...
+>>> ByPosition(1)
+ByPosition(x=1)
+```
+
 `Init` and `NoInit` say *whether* a field is an argument at all; `Kw`,
 `Positional` and the two `...Only` pairs say *how* it may be passed. A
 field is an argument unless something says otherwise, so `Init[T]` is

--- a/README.md
+++ b/README.md
@@ -423,7 +423,9 @@ Each of these can be used bare (`x: Frozen[int]`) or with a value
 
 Each one sets exactly what its name mentions, and what it sets wins over
 the class setting: on a `kw_only=True` class, `x: Positional[int]` can be
-passed by position anyway. What an annotation says nothing about follows
+passed by position anyway, while `x: NotKw[int]` forbids the one way in
+that was left and so has no parameter at all — it takes its default,
+exactly like `NoInit[int]`. What an annotation says nothing about follows
 the class as usual.
 
 Several of them go on one field by nesting, and when two disagree the outer

--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -1871,12 +1871,23 @@ _hash_action = {(False, False, False, False): None,
                 }
 
 
+def _is_class_attribute(field: Field) -> bool:
+    # A `ClassVar` is a pseudo-field that asked not to be passed either
+    # way -- that is what the annotation lowers to. A pseudo-field that
+    # merely *ends up* with no parameter is not one: an `InitVar` that
+    # may not be passed by name, on a class where nothing may be passed
+    # by position, is an `InitVar` whose two settings cancelled out, and
+    # nothing is ever stored on the class for it.
+    declared = field.declared if field.declared is not MISSING else {}
+    return declared.get("kw") is False and declared.get("positional") is False
+
+
 def _make_doc_class(fields: dict[str, Field]) -> str:
     attrdocs, classattrdocs = [], []
     for name, field in fields.items():
         if not field.var:
             attrdocs.append(_make_doc_elem(field, name))
-        elif not field.init:
+        elif not field.init and _is_class_attribute(field):
             classattrdocs.append(_make_doc_elem(field, name))
     attrdocs = "\n".join(attrdocs)
     classattrdocs = "\n".join(classattrdocs)

--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -70,8 +70,9 @@ unresolved_hints : str, default="warn"
     What to do when a type hint still names something undefined the
     first time a field needs it: "warn", "raise" or "ignore"
 mapping : bool, default=False
-    Implement the `Mapping` protocol; a subclass cannot turn it off.
-    Only a field that is holding a value is a key
+    Implement the `Mapping` protocol; a subclass inherits the dict-like
+    methods and cannot turn them off. Only a field that is holding a
+    value is a key
 override : bool | str | list, default=False
     Decide the settings of an inherited field again from this class;
     a name, or a list of names, decides only those
@@ -1348,14 +1349,13 @@ def __pre_new__(
             mapping_base = b
     if mapping_base is not None and not options.mapping:
         raise TypeError(
-            f"{clsname} gets its dict-like behaviour from "
-            f"{mapping_base.__name__}, and a subclass cannot take it "
-            f"away: {clsname} would still answer yes to an isinstance "
-            f"check against Mapping, while the dict-like methods it "
-            f"inherited would report {mapping_base.__name__}'s fields "
-            f"instead of its own. Either leave mapping alone here, or "
-            f"turn it off on {mapping_base.__name__} and ask for it only "
-            f"on the subclasses that want it."
+            f"{clsname} gets its dict-like methods from "
+            f"{mapping_base.__name__}, and turning mapping off here does "
+            f"not take them away: {clsname} would inherit them and answer "
+            f"with {mapping_base.__name__}'s fields instead of its own. "
+            f"Either leave mapping alone here, or turn it off on "
+            f"{mapping_base.__name__} and ask for it only on the "
+            f"subclasses that want it."
         )
 
     if options.mutable_default not in _MUTABLE_DEFAULT_ACTIONS:
@@ -2633,10 +2633,11 @@ class MetaMagic(ABCMeta):
         there is no value to hand back.
     mapping : bool, default=False
         Implement the `Mapping` protocol. A subclass cannot turn it off
-        again. Only a field that is holding a value is a key, so which
-        keys an instance has is a question about that instance: the
-        length can differ between two instances of one class, and can
-        change over an instance's life.
+        again: it would inherit these methods, and they answer with the
+        fields of the class they were generated for. Only a field that
+        is holding a value is a key, so which keys an instance has is a
+        question about that instance: the length can differ between two
+        instances of one class, and can change over an instance's life.
     override : bool | str | list, default=False
         Decide the settings of an inherited field again from this
         class. A field is resolved against the settings of the class
@@ -2744,10 +2745,11 @@ class Magic(metaclass=MetaMagic):
         there is no value to hand back.
     mapping : bool, default=False
         Implement the `Mapping` protocol. A subclass cannot turn it off
-        again. Only a field that is holding a value is a key, so which
-        keys an instance has is a question about that instance: the
-        length can differ between two instances of one class, and can
-        change over an instance's life.
+        again: it would inherit these methods, and they answer with the
+        fields of the class they were generated for. Only a field that
+        is holding a value is a key, so which keys an instance has is a
+        question about that instance: the length can differ between two
+        instances of one class, and can change over an instance's life.
     override : bool | str | list, default=False
         Decide the settings of an inherited field again from this
         class. A field is resolved against the settings of the class

--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -1696,6 +1696,7 @@ class _FuncBuilder:
         self.methods = {}  # name -> function
         self.globals = globals
         self.locals = {}
+        self.docs = {}  # name -> docstring
         self.overwrite_errors = {}
         self.unconditional_adds = {}
 
@@ -1724,12 +1725,32 @@ class _FuncBuilder:
             return_annotation = ''
 
         args = ','.join(args or [])
-        body = '\n'.join(body or ['pass'])
-        doc = '\n'.join(['"""'] + (doc or []) + ['"""'])
+        body = '\n'.join(body or [])
+        # A function whose every statement is empty -- one for a class
+        # with nothing to assign -- still needs a body of its own now
+        # that the documentation is no longer standing in for one.
+        if not body.strip():
+            body = 'pass'
+
+        # The documentation is attached to the finished function rather
+        # than written into the source: a field's documentation, or the
+        # `repr()` of a default, is arbitrary text, and text holding a
+        # quote or a backslash would end or escape its way out of a
+        # literal in the generated source.
+        #
+        # It is laid out as a docstring written there would have been --
+        # opening newline, every line indented to the body of a function
+        # nested one level inside the builder's own -- so that `help()`
+        # and the API reference render exactly what they rendered when it
+        # was a literal.
+        if doc:
+            margin = " " * 8
+            self.docs[name] = "\n{}\n{}".format(
+                indent("\n".join(doc), margin), margin
+            )
 
         src = "\n".join([
             f"def {name}({args}){return_annotation}:",
-            indent(doc, " " * 4),
             indent(body, " " * 4),
         ])
         if decorator:
@@ -1775,6 +1796,10 @@ class _FuncBuilder:
         qualname = namespace.get("__qualname__", None)
         for name, fn in zip(self.methods, fns):
             fn.__qualname__ = f"{qualname}.{fn.__name__}"
+            # `python -OO` asks for docstrings to be dropped, and one
+            # written by hand would be gone already.
+            if name in self.docs and sys.flags.optimize < 2:
+                fn.__doc__ = self.docs[name]
             if self.unconditional_adds.get(name, False):
                 namespace[name] = fn
             elif name not in namespace:

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -3298,6 +3298,52 @@ class TestDocGeneration:
         assert "hi" in doc
 
 
+class TestGeneratedDocstring:
+    """The constructor's documentation is arbitrary text."""
+
+    def test_doc_holding_triple_quotes(self) -> None:
+        ends_a_docstring = 'ends a docstring: """ and then some'
+
+        class C(Magic):
+            x: Annotated[int, Doc(ends_a_docstring)]
+
+        assert ends_a_docstring in C.__magic_init__.__doc__
+        assert C(1).x == 1
+
+    def test_default_whose_repr_holds_triple_quotes(self) -> None:
+        class C(Magic):
+            x: str = 'holds """ inside'
+
+        assert 'holds """ inside' in C.__magic_init__.__doc__
+        assert C().x == 'holds """ inside'
+
+    def test_default_whose_repr_holds_a_backslash(self) -> None:
+        class C(Magic):
+            x: str = "a\\b\nc"
+
+        # What the documentation shows is the `repr()`, so the escapes are
+        # spelled out rather than acted on.
+        assert r"default='a\\b\nc'" in C.__magic_init__.__doc__
+        assert C().x == "a\\b\nc"
+
+    def test_an_ordinary_docstring_is_unchanged(self) -> None:
+        class C(Magic):
+            x: int
+            y: Annotated[str, Doc("why not")] = "hi"
+            z: Optional[float] = None
+
+        assert C.__magic_init__.__doc__ == (
+            "\n"
+            "        Parameters\n"
+            "        ----------\n"
+            "        x : int\n"
+            "        y : str, default='hi'\n"
+            "            why not\n"
+            "        z : float, optional\n"
+            "        "
+        )
+
+
 # ======================================================================
 # Slots inheritance corner cases
 # ======================================================================

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1593,7 +1593,7 @@ class TestMapping:
         class Base(Magic, mapping=True):
             a: int
 
-        with pytest.raises(TypeError, match="cannot take it away"):
+        with pytest.raises(TypeError, match="does not take them away"):
             class Child(Base, mapping=False):
                 b: int
 
@@ -1634,6 +1634,21 @@ class TestMapping:
             b: int
 
         assert dict(Child(1, 2)) == {"a": 1, "b": 2}
+
+    def test_mapping_false_is_fine_under_a_real_mapping_base(self) -> None:
+        # The ban is about the dict-like methods a Magic base generates,
+        # not about what the class is: a class that inherits a real
+        # Mapping and asks for no dict-like methods of its own is fine,
+        # and is a Mapping all the same.
+        from collections.abc import Mapping
+
+        class RealMap(Mapping):
+            pass
+
+        class Child(Magic, RealMap, mapping=False):
+            b: int
+
+        assert issubclass(Child, Mapping)
 
     def test_mapping_false_is_fine_without_a_dict_like_base(self) -> None:
         class Base(Magic):
@@ -2761,7 +2776,7 @@ class TestOverride:
         class Base(Magic, mapping=True):
             x: int = 1
 
-        with pytest.raises(TypeError, match="a subclass cannot take it"):
+        with pytest.raises(TypeError, match="does not take them away"):
             class Sub(Base, mapping=False, override=True):
                 pass
 

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -554,6 +554,8 @@ class TestParameterAnnotations:
         assert C().x == 7
         with pytest.raises(TypeError):
             C(7)
+        with pytest.raises(TypeError):
+            C(x=7)
 
     def test_no_init_still_takes_its_default(self) -> None:
         class C(Magic):

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -3289,6 +3289,30 @@ class TestDocGeneration:
         assert "Class Attributes" in doc
         assert "a classvar" in doc
 
+    def test_doc_a_pseudo_field_with_no_parameter_is_not_a_class_attribute(
+        self,
+    ) -> None:
+        # `NotKw` on a class that takes keywords only leaves the field
+        # with no parameter, which does not turn an `InitVar` into a
+        # class attribute -- nothing is stored on the class for it.
+        class C(Magic, kw_only=True):
+            x: InitVar[NotKw[int]] = 0
+            y: int = 1
+
+        doc = C.__doc__
+        assert "Class Attributes" not in doc
+        assert "x :" not in doc
+        assert "y : int, default=1" in doc
+
+    def test_doc_a_pseudo_field_that_is_never_an_argument_is_one(self) -> None:
+        # A pseudo-field that forbids both ways of passing it is what
+        # `ClassVar` is, however it is spelled.
+        class C(Magic):
+            x: InitVar[NoInit[int]] = 0
+
+        assert "Class Attributes" in C.__doc__
+        assert "x : int, default=0" in C.__doc__
+
     def test_make_doc_elem_annotated_type(self) -> None:
         # `field.type` being a bare Annotated is only reachable by building
         # a Field directly (the public API always strips Annotated).


### PR DESCRIPTION
Closes #75, #65, #61 and #46. Four commits, one per item.

## #75 — a docstring or default containing `"""` broke class creation

```pycon
>>> class Box(Magic):
...     x: Doc[int, 'ends a docstring: """ and then some'] = 1
SyntaxError: unterminated triple-quoted string literal
```

It reached **defaults** too, since the numpydoc line embeds `{default!r}` — any value whose `repr()` contains three quotes did it.

Fixed by not writing the documentation into the generated source at all: it is stored and assigned to `fn.__doc__` after the `exec`, guarded by `sys.flags.optimize < 2` so `-OO` still strips it exactly as the compiler did. That removes the class of bug rather than the instance.

Two things fell out that are worth naming:

**The docstring literal was silently serving as the function body** for a class with nothing to assign — remove it and you get an empty suite. `body` now falls back to `pass`. That would have been a baffling `SyntaxError` to meet later.

**The layout is preserved exactly** — leading newline, eight-space margin — so `help()` and the API reference get byte-identical text. Verified by diffing five representative classes' `__doc__` against `main`, including blank lines inside a multi-line field doc, and `-OO` gives `None` on both.

## #65 — nested annotations: last-wins stays, documented

`Kw[ClassVar[int]]` and `ClassVar[Kw[int]]` differ because the outer annotation has the last word. That is one rule, it is how `Annotated` metadata already works here, and nobody writes these on purpose — so it stays, with a sentence and a checked example in the README's annotation section.

**But one real bug came out with it.** `_make_doc_class` decided "Class Attributes" by `not field.init`, which a pseudo-field can reach without being a `ClassVar` — so `InitVar[NotKw[int]]` on a `kw_only=True` class was documented as a class attribute, which it is not.

The fix reframes the test as *did the field ask to be un-passable*, rather than *did it end up un-passable* — because `ClassVar` **is** `Var + NoInit`, lowering to `kw=False, positional=False, var=True`. So it reads that off `field.declared`, the record `override=` already keeps. A field that is neither stored nor passable is documented in **neither** section, on the grounds that the two sections are instance attributes and class attributes and it is neither: nothing is kept on the class for it, and `C.x` only answers at all because of the ordinary default-left-in-the-namespace artefact that a `Factory` field would not have.

## #61 — two settings that cancel out: left alone, documented

`x: NotKw[int]` on a `kw_only=True` class forbids the one way in the class left open, so the field has no parameter and takes its default like `NoInit[int]`. An error would make the same two settings legal or not depending on a class option possibly written on a base several levels up, and the signature already says exactly what happened.

Documented in the same README paragraph as the rule it follows from. The behaviour was already pinned, but only for passing positionally — the test now also asserts `C(x=7)` raises, which is the half the class setting would otherwise have allowed.

## #46 — the `mapping=False` message overclaimed

Nothing about what is refused changed. The message said the subclass "would still answer yes to an isinstance check against Mapping" — but the same end state is reachable by inheriting a real `collections.abc.Mapping`, which is allowed. The ban is about what *Magic* generates, so the message now says only that:

> `Child` gets its dict-like methods from `Base`, and turning `mapping` off here does not take them away: `Child` would inherit them and answer with `Base`'s fields instead of its own.

The option's own documentation made a softer version of the same overclaim in four places — module docstring, both class docstrings, README table — all now name the inherited methods. A new test builds the case the old wording ruled out in words.

## Noticed, not changed

`_handle_mutable_default` uses the same `field.var and not field.init` shorthand for "is a `ClassVar`". Harmless there — a cancelled-out `InitVar` has no per-instance default to promote — but it is the same conflation, and worth knowing if that check ever grows.

858 passed on 3.11, 3.12 and 3.13; ruff and codespell clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_