### PR TITLE
Add convert_defaults and validate_defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,29 @@ class Service(Magic, convert=True, unresolved_hints="raise"):
 The third choice, `"ignore"`, says nothing at all — for a hint you know
 will not resolve and do not want to hear about again.
 
+### Leaving the defaults alone
+
+A default is converted and validated like anything else, so a class is as
+strict about the values it was written with as about the ones it is handed.
+Sometimes only the incoming values need the attention:
+
+```python
+class Node(Magic, convert=True, convert_defaults=False):
+    name: str
+    parent: "Node" = None
+```
+
+```pycon
+>>> Node("root")
+Node(name='root', parent=None)
+```
+
+`parent: Optional["Node"]` is the precise spelling and needs nothing turned
+off. But when the defaults in a class are already exactly what you meant,
+`convert_defaults=False` and `validate_defaults=False` say to take them as
+written. Anything a caller passes is still converted and validated, as is
+anything assigned afterwards.
+
 ---
 
 ## Also included
@@ -484,6 +507,8 @@ class Thing(Magic, frozen=True, kw_only=True, slots=True):
 | `weakref_slot` | `False` | allow weak references under `slots` |
 | `convert` | `False` | convert every field from its type |
 | `validate` | `False` | check every field against its type |
+| `convert_defaults` | `True` | convert a value that came from a default, too |
+| `validate_defaults` | `True` | check a value that came from a default, too |
 | `unresolved_hints` | `"warn"` | what to do when a type hint still names something undefined the first time a field needs it; or `"raise"`, or `"ignore"` |
 | `factory` | `False` | build every missing default from its type |
 | `mutable_default` | `"factory"` | give each instance its own copy of `x: list = []`; or `"raise"`, or `"allow"` |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -31,6 +31,7 @@ question of what you want the type hints to *do*.
 | Conversion from your own callable | no | yes | yes | **yes** |
 | Validation from the type hint | no | no | yes | **yes** |
 | Validation from your own callable | no | yes | yes | **yes** |
+| Defaults converted and validated | no | yes | opt-in | **yes, or opt out** |
 | Defaults built by a factory | yes | yes | yes | **yes** |
 | Mutable defaults caught | raises | raises | copies | **copies, or raises** |
 | | | | | |

--- a/src/bagof/magic/_constants.py
+++ b/src/bagof/magic/_constants.py
@@ -79,6 +79,12 @@ _ERROR = "__magic_error__"
 # parameter, while it is being built, converted and validated
 def _VALUE(x: str) -> str: return f"__magic_{x}_value__"
 
+# Name given to the local that remembers whether a parameter arrived
+# holding its own default rather than a value the caller passed. Only
+# generated for a field whose class asked for defaults to skip
+# conversion or validation.
+def _IS_DEFAULT(x: str) -> str: return f"__magic_{x}_is_default__"
+
 # Names given, when generating __init__, to the locals holding the
 # builtins and the factory marker its body is written in terms of. The
 # generated function's parameters are named after the fields, so a field
@@ -139,6 +145,26 @@ class _HasFactory:
 
     def __call__(self) -> tx.Any:
         return self.factory()
+
+
+class _HasDefault:
+    """A parameter default that can be told apart from a value.
+
+    A class that asks for its defaults not to be converted or validated
+    needs to know which of the two arrived. The value a field defaults
+    to is wrapped in one of these and unwrapped again at the top of
+    `__init__`, so the test is `is` against a marker no caller can hold
+    rather than a guess about the value.
+
+    It reads as the value it stands for, so a signature built from it
+    shows the default the class was written with.
+    """
+
+    def __init__(self, value: tx.Any) -> None:
+        self.value = value
+
+    def __repr__(self) -> str:
+        return repr(self.value)
 
 
 class SHOW_ATTR:

--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -66,6 +66,10 @@ convert : bool, default=False
     Use field type as converter if none is provided
 validate : bool, default=False
     Use field type as validator if none is provided
+convert_defaults : bool, default=True
+    Convert a value that came from a field's own default
+validate_defaults : bool, default=True
+    Validate a value that came from a field's own default
 unresolved_hints : str, default="warn"
     What to do when a type hint still names something undefined the
     first time a field needs it: "warn", "raise" or "ignore"
@@ -172,6 +176,7 @@ from ._constants import (
     _GENERATED,
     _HAS_FACTORY,
     _HINTS,
+    _IS_DEFAULT,
     _ISINSTANCE,
     _MAGIC,
     _OBJECT,
@@ -186,6 +191,7 @@ from ._constants import (
     HIDE_IF_NONE,
     MISSING,
     SHOW_ATTR,
+    _HasDefault,
     _HasFactory,
 )
 from ._errors import field_error
@@ -1523,7 +1529,7 @@ def __pre_new__(
     # Build __init__. The builder writes source, so binding the public
     # name has to wait until `insert_fns` has compiled it (below).
     try:
-        init_kwargs = _make_init(fields, prepost, clsname)
+        init_kwargs = _make_init(fields, prepost, clsname, options)
     except _BadSignature as error:
         if init_name:
             raise
@@ -1669,6 +1675,7 @@ def __pre_new__(
         magic_init.__code__ = magic_init.__code__.replace(
             co_name=magic_init.__name__
         )
+        _show_real_defaults(magic_init)
         if init_name and init_name not in namespace:
             namespace[init_name] = magic_init
             generated[init_name] = "init"
@@ -1686,6 +1693,27 @@ def __pre_new__(
         namespace[docname] = doc
 
     return clsname, bases, namespace
+
+
+def _show_real_defaults(func: tx.Callable) -> None:
+    """Give back the signature a marked default stands in for.
+
+    A field whose default skips conversion or validation carries that
+    default behind a marker, which is what the compiled function ends up
+    with. Anyone reading the signature -- `help`, an editor, a caller
+    -- should see the value the class was written with, so the marked
+    parameters are put back before the function goes anywhere.
+    """
+    marked = list(func.__defaults__ or ())
+    marked += list((func.__kwdefaults__ or {}).values())
+    if not any(isinstance(default, _HasDefault) for default in marked):
+        return
+    known = signature(func)
+    func.__signature__ = known.replace(parameters=[
+        parameter.replace(default=parameter.default.value)
+        if isinstance(parameter.default, _HasDefault) else parameter
+        for parameter in known.parameters.values()
+    ])
 
 
 class _FuncBuilder:
@@ -1921,6 +1949,7 @@ def _make_init(
     fields: dict[str, Field],
     prepost: tx.Mapping[str, bool],
     clsname: str,
+    options: Options,
 ) -> dict:
 
     # The body below is written in terms of these; each is carried
@@ -1964,11 +1993,35 @@ def _make_init(
         if field.public_name == "self":
             SELF = _SELF
 
+    def _skipped(field: Field) -> tx.Tuple[bool, bool]:
+        # Which of the field's two steps a value coming from its own
+        # default does not go through. A class converts and validates
+        # its defaults unless it says otherwise, so both are usually
+        # False and nothing below changes.
+        return (
+            bool(field.converter) and not options.convert_defaults,
+            bool(field.validator) and not options.validate_defaults,
+        )
+
+    def _splits(field: Field) -> bool:
+        # Whether this field has to tell a default apart from a value
+        # the caller passed. It only does when it has a default to
+        # arrive holding and a step for that default to skip.
+        if field.default is MISSING and not field.factory:
+            return False
+        return any(_skipped(field))
+
     def _make_signature_elem(field: Field) -> tx.Tuple[str, str]:
         name = field.public_name
         default = field.default
         if field.factory:
             default = _HasFactory(field.factory)
+        elif _splits(field):
+            # The parameter carries a marker instead of the value, so
+            # that the body can tell "not passed" from a caller who
+            # passed the same thing. The marker never leaves the top of
+            # `__init__`, and the signature people read shows the value.
+            default = _HasDefault(default)
         locals[_TYPE(name)] = field.type
         if default is MISSING:
             signature = f"{name}: {_TYPE(name)}"
@@ -2057,35 +2110,71 @@ def _make_init(
             {_FIELD_ERROR}({blamed})
         """)
 
-    def _make_factory_elem(field: Field) -> str:
-        # A defaulted-by-factory parameter arrives holding the factory
-        # rather than a value. Every one of them is resolved before the
-        # first hook runs, so that `__pre_init__` sees real values.
-        if not field.factory:
-            return ""
+    def _make_unpack_elem(field: Field) -> str:
+        # A parameter that was not passed arrives holding its own
+        # default: the factory to call, or -- for a field whose default
+        # skips a step -- the value behind a marker. Both are unpacked
+        # before the first hook runs, so that `__pre_init__` sees real
+        # values, and a field that has to tell the two apart remembers
+        # which one arrived for the body below.
         name = field.public_name
+        splits = _splits(field)
+        if not field.factory:
+            if not splits:
+                return ""
+            # `is` against the one marker this parameter defaults to: a
+            # caller has no way to hold that object, so nothing they
+            # pass can be mistaken for the default.
+            return dedent(f"""
+            {_IS_DEFAULT(name)} = {name} is {_DEFAULT(name)}
+            if {_IS_DEFAULT(name)}:
+                {name} = {_DEFAULT(name)}.value
+            """)
         call = _guarded(f"{name} = {name}()", field, "build")
+        test = f"{_ISINSTANCE}({name}, {_HAS_FACTORY})"
+        if splits:
+            return dedent(f"""
+            {_IS_DEFAULT(name)} = {test}
+            if {_IS_DEFAULT(name)}:
+            """) + indent(call, " " * 4)
         return dedent(f"""
-        if {_ISINSTANCE}({name}, {_HAS_FACTORY}):
+        if {test}:
         """) + indent(call, " " * 4)
+
+    def _only_when_passed(step: str, field: Field) -> str:
+        # A step the class asked to skip for its defaults still runs for
+        # a value the caller passed.
+        return dedent(f"""
+        if not {_IS_DEFAULT(field.public_name)}:
+        """) + indent(step, " " * 4)
 
     def _make_body_elem(field: Field) -> str:
         # The body reads the *parameter*, which is named after the
         # field's public name, and writes the *field*, which keeps its
         # own name.
         name = field.public_name
+        skip_convert, skip_validate = _skipped(field)
+        splits = _splits(field)
         body = ""
         if field.converter:
             locals[_CONVERTER(name)] = field.converter
-            body += _guarded(
+            step = _guarded(
                 f"{name} = {_CONVERTER(name)}({name})",
                 field, "convert", name
             )
+            body += (
+                _only_when_passed(step, field)
+                if splits and skip_convert else step
+            )
         if field.validator:
             locals[_VALIDATOR(name)] = field.validator
-            body += _guarded(
+            step = _guarded(
                 f"{name} = {_VALIDATOR(name)}({name})",
                 field, "validate", name
+            )
+            body += (
+                _only_when_passed(step, field)
+                if splits and skip_validate else step
             )
         if not field.var:
             # NOTE: we by pass the object's __setattr__ to avoid running
@@ -2097,13 +2186,17 @@ def _make_init(
 
     def _make_own_default_elem(field: Field) -> str:
         # The value comes from the field itself rather than from a
-        # parameter, and goes through the same converter and validator a
-        # parameter would. The locals are keyed by the field name, which
-        # no parameter uses: a parameter is named after the field's
-        # public name.
+        # parameter, so it is a default whatever else happens: whichever
+        # of converting and validating the class skips for its defaults
+        # is skipped here outright. The locals are keyed by the field
+        # name, which no parameter uses: a parameter is named after the
+        # field's public name.
+        skip_convert, skip_validate = _skipped(field)
+        converter = None if skip_convert else field.converter
+        validator = None if skip_validate else field.validator
         default = _DEFAULT(field.name)
         locals[default] = field.factory if field.factory else field.default
-        if not (field.factory or field.converter or field.validator):
+        if not (field.factory or converter or validator):
             return dedent(f"""
             {_OBJECT}.__setattr__({SELF}, {field.name!r}, {default})
             """)
@@ -2116,14 +2209,14 @@ def _make_init(
             body = dedent(f"""
             {value} = {default}
             """)
-        if field.converter:
-            locals[_CONVERTER(field.name)] = field.converter
+        if converter:
+            locals[_CONVERTER(field.name)] = converter
             body += _guarded(
                 f"{value} = {_CONVERTER(field.name)}({value})",
                 field, "convert", value
             )
-        if field.validator:
-            locals[_VALIDATOR(field.name)] = field.validator
+        if validator:
+            locals[_VALIDATOR(field.name)] = validator
             body += _guarded(
                 f"{value} = {_VALIDATOR(field.name)}({value})",
                 field, "validate", value
@@ -2132,7 +2225,7 @@ def _make_init(
         {_OBJECT}.__setattr__({SELF}, {field.name!r}, {value})
         """)
 
-    body = [_make_factory_elem(field) for field in parameters]
+    body = [_make_unpack_elem(field) for field in parameters]
     if _PRE_INIT_NAME in prepost:
         body.append(_make_prepost_call(_PRE_INIT_NAME))
     body += [_make_body_elem(field) for field in parameters]
@@ -2588,6 +2681,16 @@ class MetaMagic(ABCMeta):
         Use field type as converter if none is provided.
     validate : bool, default=False
         Use field type as validator if none is provided.
+    convert_defaults : bool, default=True
+        Convert a value that came from a field's own default, the same
+        way a value passed to the constructor is converted. Set it to
+        False to leave the defaults written in the class alone and
+        convert only what a caller passes.
+    validate_defaults : bool, default=True
+        Validate a value that came from a field's own default, the same
+        way a value passed to the constructor is validated. Set it to
+        False to leave the defaults written in the class alone and
+        check only what a caller passes.
     unresolved_hints : str, default="warn"
         What to do when a field is annotated with a type that is still
         not defined the first time the field needs it. "warn" says so
@@ -2699,6 +2802,16 @@ class Magic(metaclass=MetaMagic):
         Use field type as converter if none is provided.
     validate : bool, default=False
         Use field type as validator if none is provided.
+    convert_defaults : bool, default=True
+        Convert a value that came from a field's own default, the same
+        way a value passed to the constructor is converted. Set it to
+        False to leave the defaults written in the class alone and
+        convert only what a caller passes.
+    validate_defaults : bool, default=True
+        Validate a value that came from a field's own default, the same
+        way a value passed to the constructor is validated. Set it to
+        False to leave the defaults written in the class alone and
+        check only what a caller passes.
     unresolved_hints : str, default="warn"
         What to do when a field is annotated with a type that is still
         not defined the first time the field needs it. "warn" says so

--- a/src/bagof/magic/_options.py
+++ b/src/bagof/magic/_options.py
@@ -23,6 +23,8 @@ from ._utils import SlotsBase, slots
     'mutable_default',  # What to do with a mutable default (x: list = [])
     'convert',          # Use field type as converter if none is provided
     'validate',         # Use field type as validator if none is provided
+    'convert_defaults',   # Convert a value that came from a default
+    'validate_defaults',  # Validate a value that came from a default
     'unresolved_hints',  # What to do about a type hint that never resolves
     'mapping',          # Generate Mapping methods for dict-like behavior
     # Resolve an inherited field's settings again from this class
@@ -63,6 +65,8 @@ class Options(SlotsBase):
         mutable_default="factory",
         convert=False,
         validate=False,
+        convert_defaults=True,
+        validate_defaults=True,
         unresolved_hints="warn",
         mapping=False,
         override=False,

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1327,6 +1327,252 @@ class TestValidate:
 
 
 # ======================================================================
+# convert_defaults / validate_defaults
+# ======================================================================
+
+
+def _double(value: int) -> int:
+    return value * 2
+
+
+def _positive(value: int) -> int:
+    if value <= 0:
+        raise ValueError("must be positive")
+    return value
+
+
+class TestDefaultsAreConvertedAndValidated:
+    """Whether a value that came from a default goes through the field's
+    converter and validator, or is taken as it was written."""
+
+    def test_a_default_is_converted(self) -> None:
+        class Config(Magic, convert=True):
+            port: int = "8080"
+
+        assert Config().port == 8080
+
+    def test_a_default_is_validated(self) -> None:
+        class Config(Magic, validate=True):
+            port: int = "8080"
+
+        with pytest.raises(ValidationError):
+            Config()
+
+    def test_a_class_that_says_nothing_carries_its_default_plainly(
+        self
+    ) -> None:
+        # Nothing is wrapped and no signature is stood in for unless a
+        # class asks for one of the two settings.
+        class Config(Magic, convert=True):
+            port: int = "8080"
+
+        assert Config.__init__.__defaults__ == ("8080",)
+        assert not hasattr(Config.__init__, "__signature__")
+
+    def test_convert_defaults_false_leaves_a_plain_default(self) -> None:
+        class Config(Magic, convert=True, convert_defaults=False):
+            port: int = "8080"
+
+        assert Config().port == "8080"
+        assert Config("9000").port == 9000
+
+    def test_convert_defaults_false_leaves_a_factory_default(self) -> None:
+        class Config(Magic, convert=True, convert_defaults=False):
+            port: Annotated[int, Field(factory=lambda: "8080")]
+
+        assert Config().port == "8080"
+        assert Config("9000").port == 9000
+
+    def test_validate_defaults_false_leaves_a_plain_default(self) -> None:
+        class Config(Magic, validate=True, validate_defaults=False):
+            port: int = "8080"
+
+        assert Config().port == "8080"
+        assert Config(9000).port == 9000
+        with pytest.raises(ValidationError):
+            Config("9000")
+
+    def test_validate_defaults_false_leaves_a_factory_default(self) -> None:
+        class Config(Magic, validate=True, validate_defaults=False):
+            port: Annotated[int, Field(factory=lambda: "8080")]
+
+        assert Config().port == "8080"
+        with pytest.raises(ValidationError):
+            Config("9000")
+
+    def test_the_same_value_is_taken_two_ways(self) -> None:
+        # The one case a guess about the value could not get right: what
+        # the class defaults to is exactly what the caller passes.
+        class Reading(Magic, validate_defaults=False):
+            level: Annotated[int, Field(validator=_positive)] = -1
+
+        assert Reading().level == -1
+        with pytest.raises(ValueError):
+            Reading(-1)
+
+    def test_only_the_skipped_step_is_skipped(self) -> None:
+        class Reading(Magic, validate_defaults=False):
+            level: Annotated[
+                int, Field(converter=_double, validator=_positive)
+            ] = -1
+
+        # Converted, as the class did not turn that off, and then not
+        # handed to the validator that would have refused it.
+        assert Reading().level == -2
+        assert Reading(3).level == 6
+
+    @pytest.mark.parametrize("convert_defaults", [True, False])
+    @pytest.mark.parametrize("validate_defaults", [True, False])
+    def test_a_passed_value_always_goes_through_both(
+        self, convert_defaults: bool, validate_defaults: bool
+    ) -> None:
+        class Reading(
+            Magic,
+            convert_defaults=convert_defaults,
+            validate_defaults=validate_defaults,
+        ):
+            level: Annotated[
+                int, Field(converter=_double, validator=_positive)
+            ] = 1
+
+        assert Reading(3).level == 6
+        with pytest.raises(ValueError):
+            Reading(-1)
+        assert Reading().level == (2 if convert_defaults else 1)
+
+    def test_assignment_afterwards_is_always_converted_and_validated(
+        self
+    ) -> None:
+        class Reading(
+            Magic, convert_defaults=False, validate_defaults=False
+        ):
+            level: Annotated[
+                int, Field(converter=_double, validator=_positive)
+            ] = -1
+
+        reading = Reading()
+        assert reading.level == -1
+        reading.level = 3
+        assert reading.level == 6
+        with pytest.raises(ValueError):
+            reading.level = -1
+
+    def test_a_field_with_no_parameter_follows_the_setting(self) -> None:
+        class Lenient(Magic, convert_defaults=False):
+            origin: NoInit[Annotated[int, Field(converter=_double)]] = 3
+
+        class Strict(Magic):
+            origin: NoInit[Annotated[int, Field(converter=_double)]] = 3
+
+        assert (Lenient().origin, Strict().origin) == (3, 6)
+
+    def test_a_field_with_no_parameter_and_a_factory(self) -> None:
+        class Lenient(Magic, convert_defaults=False):
+            origin: NoInit[
+                Annotated[int, Field(converter=_double, factory=lambda: 3)]
+            ]
+
+        class Strict(Magic):
+            origin: NoInit[
+                Annotated[int, Field(converter=_double, factory=lambda: 3)]
+            ]
+
+        assert (Lenient().origin, Strict().origin) == (3, 6)
+
+    def test_an_init_var_default_follows_the_setting(self) -> None:
+        class Scaled(Magic, convert_defaults=False):
+            x: int = 0
+            scale: InitVar[Annotated[int, Field(converter=_double)]] = 3
+
+            def __post_init__(self, arguments: Arguments) -> None:
+                self.x = arguments.scale
+
+        assert (Scaled().x, Scaled(0, 5).x) == (3, 10)
+
+    def test_a_hook_is_handed_the_default_itself(self) -> None:
+        seen = []
+
+        class Reading(Magic, convert_defaults=False):
+            level: Annotated[int, Field(converter=_double)] = 3
+
+            def __pre_init__(self, arguments: Arguments) -> None:
+                seen.append(arguments.level)
+
+        Reading()
+        Reading(5)
+        assert seen == [3, 5]
+
+    def test_a_class_that_refers_to_itself(self) -> None:
+        # `parent: Optional[Node]` needs nothing turned off; this is for
+        # the class whose defaults are already what its author meant.
+        class Node(Magic, convert=True, convert_defaults=False):
+            name: str
+            parent: "Node" = None
+
+        root = Node("root")
+        assert root.parent is None
+        assert Node("leaf", root).parent is root
+
+    def test_both_settings_are_inherited(self) -> None:
+        class Base(
+            Magic,
+            convert=True,
+            convert_defaults=False,
+            validate_defaults=False,
+        ):
+            port: int = "8080"
+
+        class Child(Base):
+            host: str = 1234
+
+        # The setting reaches the field the subclass declares itself as
+        # well as the one it inherits, and neither stops a caller's
+        # value being converted.
+        child = Child()
+        assert (child.port, child.host) == ("8080", 1234)
+        assert Child("9000", "here").port == 9000
+
+    def test_a_subclass_can_ask_for_its_defaults_back(self) -> None:
+        class Base(Magic, convert=True, convert_defaults=False):
+            port: int = "8080"
+
+        class Strict(Base, convert_defaults=True):
+            pass
+
+        assert (Base().port, Strict().port) == ("8080", 8080)
+
+    def test_the_signature_shows_the_default_it_was_written_with(
+        self
+    ) -> None:
+        class Strict(Magic, convert=True):
+            port: int = "8080"
+            name: KwOnly[str] = 1234
+
+        class Lenient(Magic, convert=True, convert_defaults=False):
+            port: int = "8080"
+            name: KwOnly[str] = 1234
+
+        assert str(signature(Lenient)) == str(signature(Strict))
+        parameters = signature(Lenient).parameters
+        assert parameters["port"].default == "8080"
+        assert parameters["name"].default == 1234
+
+    def test_a_marked_default_reads_as_the_value(self) -> None:
+        class Config(Magic, convert=True, convert_defaults=False):
+            port: int = "8080"
+
+        assert repr(Config.__init__.__defaults__) == "('8080',)"
+
+    def test_they_are_not_settings_a_field_takes(self) -> None:
+        # A field resolves nothing from them: they decide what the
+        # generated `__init__` does with a default, not which converter
+        # or validator the field ends up with. So `override=` has
+        # nothing to resolve again.
+        assert "convert_defaults" not in _fields._OVERRIDABLE
+        assert "validate_defaults" not in _fields._OVERRIDABLE
+
+
+# ======================================================================
 # Var / InitVar / ClassVar
 # ======================================================================
 


### PR DESCRIPTION
Closes #68.

Both default to `True`, so nothing changes unless asked. Turning one off makes the class's own defaults exempt from the pipeline, while a value the caller passes is treated exactly as before:

```pycon
>>> class Node(Magic, convert=True):
...     name: str
...     parent: Node = None
>>> Node("root")
TypeConversionError: ...            # None is not a Node

>>> class Node(Magic, convert=True, convert_defaults=False):
...     name: str
...     parent: Node = None
>>> Node("root")
Node(name='root', parent=None)
```

`Optional[Node]` remains the more correct spelling and still works; this is for someone who meant what they wrote and does not want their defaults touched.

## Why `True` rather than pydantic's `False`

`convert` and `validate` are off by default, so turning one on is already an explicit act by the class author, made with their own defaults in front of them — the same act as writing `converter=int` beside `default="7"` in attrs. Pydantic can afford to skip because its coercion is on by virtue of being a `BaseModel`, so a default it never asked about is a different case.

## The three decisions

**Factory results count as defaults.** attrs runs converters on factory output, and the motivating argument applies identically — the author wrote the factory too. It also made the implementation cheaper: `_HasFactory` already marks an un-passed factory parameter, so the same test doubles as the "this is a default" flag.

**Neither setting is in `_OVERRIDABLE`, and neither reaches a `Field`.** They decide what the generated `__init__` *does* with a default, not which converter a field resolves to, so there is nothing for `override=` to re-resolve. `Field.setdefault` never reads them, so the test that scans its source for the map stays green without an entry. Inheritance still works because `Options` merges down the MRO and every class regenerates its own `__init__`.

**A marker holding the real value, not a comparison.** Telling a default from a passed value at the point of conversion needed a sentinel, because the default *is* the parameter's default. Comparing the value is wrong: for `level: Field(validator=positive) = -1`, `C()` must keep `-1` while `C(-1)` must raise — only identity against the one object the parameter defaults to gets that right, and no caller can hold it. Unwrapping happens before `__pre_init__`, so hooks see real values.

## The signature stays honest

This was the constraint I cared most about, and it holds two ways: the marker's `repr` is the value's repr, and after compilation the real defaults are put back into `__init__.__signature__`.

```
signature same as a class that does not opt out: True   (self, level = -1)
default object: -1
```

A class that opts out is indistinguishable from one that does not. A class that says nothing gets no marker and no `__signature__` at all — its generated source is byte-identical to before, which is asserted.

`__setattr__` is untouched and tested: on an opted-out class, `-1` survives as the default but `reading.level = -1` still raises. An assignment is never a default.

## Found on the way, filed not fixed

**#79** — `replace()` converts values that have already been converted, because it passes the stored values back through `__init__`:

```pycon
>>> class D(Magic):
...     x: Annotated[int, Field(converter=double)] = 3
>>> D(), replace(D()), replace(replace(D()))
(D(x=6), D(x=12), D(x=24))
```

`replace(d)` with no changes does not return an equal object. It reproduces on `main` with no new option set — type-derived converters are mostly idempotent, which is why it has not been noticed — but it interacts with this change, since on an opted-out class `replace()` converts a value construction deliberately left alone.

885 passed on 3.11, 3.12 and 3.13; test files at 100%.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_