### PR TITLE
Polymorphic construction: Chord(mode="minor") returns a MinorChord

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,8 @@ src/bagof/magic/
                 #   them in on the hints that mention them
   _errors.py    # field_error -- names the class and the field when a
                 #   converter, a validator or a factory raises
+  _polymorph.py # the registry, the constraint shapes and the dispatch
+                #   behind the `polymorphic` option
 tests/
   test_magic.py                 # the builder, option by option
   test_docstrings.py            # every `pycon` block in a docstring or page
@@ -430,6 +432,13 @@ those are the two ends where things differ; a change that passes on one
 interpreter can fail to *import* on another. `ast.Ellipsis` disappearing
 in 3.14 took out every test in the suite at collection time, and no
 amount of local testing on a single version would have shown it.
+
+**Clear `__pycache__` between mutation-testing runs.** Editing a file in
+place to check that a test catches the change is a good habit, but
+Python validates a `.pyc` by size and mtime — so an edit that leaves the
+file the same size, made and reverted inside one second, is invisible
+and the stale bytecode runs instead. A swap of two adjacent lines is
+exactly that shape, and it makes a caught mutation look uncaught.
 
 Whatever interpreters are to hand will do, pointed at the sources
 directly rather than at an install:

--- a/README.md
+++ b/README.md
@@ -529,12 +529,14 @@ exist are untouched.
 
 ### The two settings
 
-`polymorphic="strict"` refuses to build the class itself when it has
-subclasses registered and none of them matches, and names the ones it
-considered — which is how a subclass in a module nobody imported shows up as
-the missing import it is, rather than as a dispatch that quietly did nothing.
-A subclass with no registrations of its own is built normally, so the setting
-is safe to inherit down a whole hierarchy.
+`polymorphic="strict"` refuses to build the class itself, and names the
+subclasses it considered — which is how one in a module nobody imported shows
+up as the missing import it is, rather than as a dispatch that quietly did
+nothing. It says so even when *nothing* has registered yet, since that is the
+same mistake one step earlier. A class that is itself registered somewhere is
+exempt: being built is the whole point of having registered, so a leaf with no
+subclasses of its own is built normally and the setting is safe to inherit
+down a whole hierarchy.
 
 `pin_discriminant` decides what the matched field becomes on the subclass.
 `"pin"`, the default, gives it that value as its default — it stays in the
@@ -555,6 +557,18 @@ class SusChord(Chord, on={"mode": "sus"}, pin_discriminant="classvar"):
 >>> SusChord(root="B")
 SusChord(root='B', variant='natural')
 ```
+
+!!! warning "`classvar` and round trips"
+    Under `"classvar"` the discriminant is no longer one of the instance's
+    fields, so `asdict` leaves it out — and a dictionary without it cannot be
+    dispatched back to the same subclass. Use `"pin"` whenever the values
+    have to survive a round trip through a config file or a database.
+
+Writing the class attribute out yourself instead — `mode: ClassVar[str] =
+"minor"` — is refused, and the error says why: the base passes `mode` on to
+whatever it builds, so a subclass whose constructor does not take it could
+only be reached by a call that then fails. `pin_discriminant="classvar"` is
+that spelling, done in a way that keeps both calls working.
 
 Pickling and copying rebuild through the class an instance already has, so
 neither of them goes back through the dispatch.

--- a/README.md
+++ b/README.md
@@ -378,6 +378,162 @@ delay : float, default=0.5
 
 ---
 
+## Building the right subclass
+
+A class can hand back one of its subclasses, chosen from the arguments it was
+given. Say which subclass stands for what, and call the base:
+
+```python
+class Chord(Magic, polymorphic=True):
+    root: str
+    mode: str = "major"
+    variant: str = "natural"
+
+class MinorChord(Chord, on={"mode": "minor"}):
+    def thirds(self) -> int:
+        return 3
+```
+
+```pycon
+>>> Chord(root="A", mode="minor")
+MinorChord(root='A', mode='minor', variant='natural')
+>>> Chord(root="C")
+Chord(root='C', mode='major', variant='natural')
+```
+
+A default counts as a value the caller wrote out, so `Chord(root="C")` and
+`Chord(root="C", mode="major")` always give you the same class.
+
+`MinorChord` does not have to write `mode` out again either: matching on one
+exact value gives the field that value as its default, so the subclass can be
+built on its own with only what is left.
+
+```pycon
+>>> MinorChord(root="A")
+MinorChord(root='A', mode='minor', variant='natural')
+```
+
+### Saying what a subclass stands for
+
+A constraint is a value to equal, a set to belong to, a pattern to match, a
+type to fit, or a question to answer:
+
+| Written as | Matches when |
+| --- | --- |
+| `"minor"` | the argument equals it |
+| `{"minor", "aeolian"}` | the argument is one of them |
+| `re.compile(r"m(in)?")` | the pattern matches the whole argument |
+| `int`, `Literal["a", "b"]` | the argument fits the type |
+| `lambda v: v > 3` | the call answers yes |
+| `...` | the argument was given at all |
+
+A subclass is in the running when *every* constraint it wrote matches.
+
+### Which subclass wins
+
+More conditions beats fewer, and a narrower condition beats a wider one. In
+order: how many fields the subclass constrains, then how precise those
+constraints are (an exact value, then a set, then a pattern, then a type),
+then how far down the hierarchy the subclass sits.
+
+Nothing else is looked at — in particular not the order the subclasses were
+written or imported, which is what makes these systems answer differently on
+a different day. Two subclasses that no rule separates raise
+`AmbiguousPolymorphError` instead, and `priority=` settles it. It is also how
+you spell "when nothing else fits", since a subclass that constrains nothing
+matches everything:
+
+```python
+class Note(Magic, polymorphic=True):
+    name: str
+
+class Sharp(Note, on={"name": lambda name: name.endswith("#")}):
+    pass
+
+class Natural(Note, on={}, priority=-1):
+    pass
+```
+
+```pycon
+>>> Note("C#")
+Sharp(name='C#')
+>>> Note("C")
+Natural(name='C')
+```
+
+### Narrowing more than once
+
+A subclass of a subclass registers with its parent, so each step narrows the
+choice by one:
+
+```python
+class HarmonicMinor(MinorChord, on={"variant": "harmonic"}):
+    pass
+```
+
+```pycon
+>>> Chord(root="A", mode="minor", variant="harmonic")
+HarmonicMinor(root='A', mode='minor', variant='harmonic')
+```
+
+Reaching `HarmonicMinor` means satisfying `MinorChord` first. Ask for
+`variant="harmonic"` without a `mode` and the first step matches nothing, so
+that is where it stops:
+
+```pycon
+>>> Chord(root="A", variant="harmonic")
+Chord(root='A', mode='major', variant='harmonic')
+```
+
+### Registering a class you did not write
+
+```pycon
+>>> class Diminished(Chord):
+...     pass
+...
+>>> Chord.register_polymorph(Diminished, mode="dim")
+<class '...Diminished'>
+>>> Chord(root="B", mode="dim")
+Diminished(root='B', mode='dim', variant='natural')
+```
+
+Registering later only changes what is built later; instances that already
+exist are untouched.
+
+### The two settings
+
+`polymorphic="strict"` refuses to build the class itself when it has
+subclasses registered and none of them matches, and names the ones it
+considered — which is how a subclass in a module nobody imported shows up as
+the missing import it is, rather than as a dispatch that quietly did nothing.
+A subclass with no registrations of its own is built normally, so the setting
+is safe to inherit down a whole hierarchy.
+
+`pin_discriminant` decides what the matched field becomes on the subclass.
+`"pin"`, the default, gives it that value as its default — it stays in the
+repr, in `==`, and in anything that walks the fields. `"classvar"` makes it a
+class attribute instead, stored once rather than once per instance; the
+constructor still accepts it and throws it away, so both
+`Chord(root="A", mode="sus")` and `SusChord(root="A", mode="sus")` keep
+working. `"keep"` leaves the field exactly as the subclass wrote it.
+
+```python
+class SusChord(Chord, on={"mode": "sus"}, pin_discriminant="classvar"):
+    pass
+```
+
+```pycon
+>>> SusChord.mode
+'sus'
+>>> SusChord(root="B")
+SusChord(root='B', variant='natural')
+```
+
+Pickling and copying rebuild through the class an instance already has, so
+neither of them goes back through the dispatch.
+
+---
+
 ## The annotations
 
 Each of these can be used bare (`x: Frozen[int]`) or with a value
@@ -472,6 +628,8 @@ class Thing(Magic, frozen=True, kw_only=True, slots=True):
 | `factory` | `False` | build every missing default from its type |
 | `mutable_default` | `"factory"` | give each instance its own copy of `x: list = []`; or `"raise"`, or `"allow"` |
 | `mapping` | `False` | behave like a dictionary; a subclass cannot turn it off again |
+| `polymorphic` | `False` | build one of this class's subclasses, chosen from the arguments; or `"strict"`, which refuses to build this class when none of them matches |
+| `pin_discriminant` | `"pin"` | what a subclass does with the field it matches on; or `"classvar"`, or `"keep"` |
 | `reverse` | `False` | list a subclass's own fields before inherited ones |
 | `doc` | `True` | add the field table to the class docstring |
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -16,3 +16,6 @@ icon: fontawesome/brands/python
         - replace
         - is_magic
         - HIDE_IF_NONE
+        - PolymorphError
+        - NoPolymorphError
+        - AmbiguousPolymorphError

--- a/src/bagof/magic/_constants.py
+++ b/src/bagof/magic/_constants.py
@@ -36,6 +36,23 @@ _PRE_INIT_NAME = "__pre_init__"
 # if it exists.
 _POST_INIT_NAME = "__post_init__"
 
+# The name of an attribute on the class that stores which of its
+# subclasses it builds, for which arguments (see `_polymorph.py`). Only
+# a class that has some is given one, so a class that has none costs one
+# failed dict lookup per instantiation.
+_POLYMORPHS = '__magic_polymorphs__'
+
+# The name of an attribute on the class that stores the registration the
+# class statement asked for -- the class it registers with, what it
+# stands for, and how strong a claim that is.
+_REGISTRATION = '__magic_registration__'
+
+# The name of an attribute on the class that stores which of its fields
+# were given a default because the class registered for one exact value
+# of them. Inherited: a field pinned by a base is still pinned further
+# down, and `__init__` has to be built the same way there.
+_PINNED = '__magic_pinned__'
+
 # Name we give to classes that are only created temporarily to build the
 # MRO and then discarded.
 _DISCARD = "__magic_discard__"
@@ -74,6 +91,13 @@ _ARGUMENTS = "__magic_arguments__"
 # factory raises, and to the exception it is handed
 _FIELD_ERROR = "__magic_field_error__"
 _ERROR = "__magic_error__"
+
+# Name given, when generating __init__, to the local holding the sentinel
+# that stands for "this argument was not passed". It fills in for a
+# parameter that has no default and follows one that does -- which
+# Python's own syntax cannot spell -- and the body turns it back into
+# the usual "missing a required argument".
+_REQUIRED_ARG = "__magic_required__"
 
 # Name given to the local holding the value of a field that is not a
 # parameter, while it is being built, converted and validated

--- a/src/bagof/magic/_constants.py
+++ b/src/bagof/magic/_constants.py
@@ -38,9 +38,14 @@ _POST_INIT_NAME = "__post_init__"
 
 # The name of an attribute on the class that stores which of its
 # subclasses it builds, for which arguments (see `_polymorph.py`). Only
-# a class that has some is given one, so a class that has none costs one
-# failed dict lookup per instantiation.
+# a class that dispatches ever looks for it: choosing a subclass happens
+# in a metaclass `__call__`, and only a class written `polymorphic=...`
+# is given a metaclass that has one.
 _POLYMORPHS = '__magic_polymorphs__'
+
+# The name of an attribute on a *metaclass*, marking one that already
+# dispatches, so deriving another from it is recognised as unnecessary.
+_DISPATCHING = '__magic_dispatching__'
 
 # The name of an attribute on the class that stores the registration the
 # class statement asked for -- the class it registers with, what it

--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -72,6 +72,18 @@ unresolved_hints : str, default="warn"
 mapping : bool, default=False
     Implement the `Mapping` protocol; a subclass cannot turn it off.
     Only a field that is holding a value is a key
+polymorphic : bool | str, default=False
+    Build one of this class's subclasses instead of this class,
+    chosen from the arguments it was given. A subclass says which
+    arguments it stands for with `on=` on its own class statement.
+    With "strict", a call matching none of them is refused rather
+    than building this class.
+pin_discriminant : {"pin", "classvar", "keep"}, default="pin"
+    What a subclass does with a field it matches on exactly. "pin"
+    gives the field that value as its default, so it still shows in
+    the repr and survives a round trip; "classvar" makes it a class
+    attribute that is not stored per instance, still accepted by the
+    constructor and discarded; "keep" leaves the field alone.
 reverse : bool, default=False
     Use the reverse MRO order to determine field order
 doc : bool | str, default=True
@@ -145,7 +157,7 @@ import warnings
 from abc import ABCMeta
 from collections import abc as _abc
 from functools import partial
-from inspect import Parameter, signature
+from inspect import Parameter, Signature, signature
 from textwrap import dedent, indent
 from types import MemberDescriptorType
 
@@ -169,8 +181,12 @@ from ._constants import (
     _HINTS,
     _MAGIC,
     _OPTIONS,
+    _PINNED,
+    _POLYMORPHS,
     _POST_INIT_NAME,
     _PRE_INIT_NAME,
+    _REGISTRATION,
+    _REQUIRED_ARG,
     _RETURN_TYPE,
     _SELF,
     _TYPE,
@@ -178,6 +194,7 @@ from ._constants import (
     _VALUE,
     HIDE_IF_NONE,
     MISSING,
+    REQUIRED,
     SHOW_ATTR,
     _HasFactory,
 )
@@ -188,6 +205,13 @@ from ._fields import __all__ as __all_fields__
 from ._options import *  # noqa: F401, F403
 from ._options import Options
 from ._options import __all__ as __all_options__
+from ._polymorph import *  # noqa: F401, F403
+from ._polymorph import __all__ as __all_polymorph__
+from ._polymorph import check as _check_invariant
+from ._polymorph import invariant as _keep_invariant
+from ._polymorph import register as _register_polymorph
+from ._polymorph import select as _select_polymorph
+from ._polymorph import specifications as _specifications
 from ._resolve import POLICIES as _HINT_POLICIES
 from ._resolve import Hints
 from ._utils import _get_origin, rebuild_cls
@@ -195,6 +219,7 @@ from ._utils import _get_origin, rebuild_cls
 __all__ += __all_arguments__
 __all__ += __all_fields__
 __all__ += __all_options__
+__all__ += __all_polymorph__
 
 
 # ----------------------------------------------------------------------
@@ -217,6 +242,17 @@ def __post_new__(cls: type) -> type:
     hints = cls.__dict__.get(_HINTS)
     if hints is not None:
         hints.namespace[cls.__name__] = cls
+
+    # The class exists now, so it can be registered with the one that
+    # will build it. Under "strict" it also keeps its own registration,
+    # to refuse a direct call that contradicts it.
+    registration = cls.__dict__.get(_REGISTRATION)
+    if registration is not None:
+        polymorphic_base, specs, priority = registration
+        strict = getattr(polymorphic_base, _OPTIONS).polymorphic == "strict"
+        _register_polymorph(polymorphic_base, cls, specs, priority, strict)
+        if getattr(cls, _OPTIONS).polymorphic == "strict":
+            _keep_invariant(cls, specs)
 
     fields = getattr(cls, _FIELDS, {})
     fields = {name: field for name, field in fields.items() if not field.var}
@@ -986,6 +1022,65 @@ _MUTABLE_TYPES = (list, dict, set, bytearray)
 # The accepted values of the `mutable_default` class option.
 _MUTABLE_DEFAULT_ACTIONS = ("factory", "raise", "allow")
 
+# The accepted values of the `polymorphic` class option. "strict" means
+# "if I have registrations and none of them match, refuse to build" --
+# not "never build me": every subclass of a polymorphic class is
+# polymorphic too, so the other reading would leave the leaves of a
+# hierarchy unbuildable.
+_POLYMORPHIC = (False, True, "strict")
+
+# The accepted values of the `pin_discriminant` class option.
+_PIN_ACTIONS = ("pin", "classvar", "keep")
+
+
+def _polymorphic_base(mro: tx.Tuple[type, ...]) -> tx.Optional[type]:
+    # The nearest class up the chain that builds its subclasses. A
+    # subclass registers with that one rather than with the root, so
+    # each level narrows the choice by one step.
+    for base in mro:
+        if getattr(getattr(base, _OPTIONS, None), "polymorphic", False):
+            return base
+    return None
+
+
+def _pin_discriminants(
+    fields: dict,
+    namespace: dict,
+    declared: tx.Container[str],
+    specs: tx.Sequence,
+    action: str,
+) -> tx.Set[str]:
+    # A subclass registered for one exact value already says what that
+    # field holds, so it does not have to say it twice: the field is
+    # given that value as its default ("pin"), or becomes a class
+    # attribute that is not stored per instance ("classvar"). A field
+    # the subclass writes out itself is left exactly as written.
+    #
+    # Under "classvar" the field stays a parameter of `__init__` and its
+    # value is thrown away, so both `Chord(mode="minor", root="A")` --
+    # which passes the argument straight through -- and
+    # `MinorChord(mode="minor", root="A")` keep working.
+    pinned = set()
+    for spec in specs:
+        if spec.value is MISSING:
+            # More than one value would satisfy this constraint, so
+            # there is nothing to pin the field to.
+            continue
+        field = fields[spec.name]
+        if field.name in declared:
+            continue
+        field.default = spec.value
+        field.factory = False
+        if action == "classvar":
+            field.var = True
+            field.repr = SHOW_ATTR(False)
+            field.key = SHOW_ATTR(False)
+            field.eq = field.order = False
+            field.hash = False
+            namespace[field.name] = spec.value
+        pinned.add(field.name)
+    return pinned
+
 
 def _is_mutable(value: tx.Any) -> bool:
     # Besides the obvious builtins, anything unhashable counts: a class
@@ -1204,6 +1299,19 @@ def __pre_new__(
         # without including the class itself.
         return clsname, bases, namespace
 
+    # `on=` and `priority=` describe this one class rather than setting
+    # an option, so they are taken out before the options are read --
+    # nothing inherits them.
+    on = kwargs.pop("on", MISSING)
+    priority = kwargs.pop("priority", MISSING)
+    if priority is not MISSING and on is MISSING:
+        raise TypeError(
+            f"{clsname} sets priority= without on=, and priority only "
+            f"decides between subclasses that match the same arguments. "
+            f"Say what {clsname} stands for as well -- "
+            f"`class {clsname}(..., on={{'mode': 'minor'}}, priority=1)`."
+        )
+
     # `_FIELDS` in the namespace means this class has been through here
     # before. A direct lookup, so a base class having it does not count.
     if _FIELDS in namespace:
@@ -1296,6 +1404,18 @@ def __pre_new__(
         raise ValueError(
             f"mutable_default must be 'factory', 'raise' or 'allow', "
             f"not {options.mutable_default!r}"
+        )
+
+    if options.polymorphic not in _POLYMORPHIC:
+        raise ValueError(
+            f"polymorphic must be False, True or 'strict', "
+            f"not {options.polymorphic!r}"
+        )
+
+    if options.pin_discriminant not in _PIN_ACTIONS:
+        raise ValueError(
+            f"pin_discriminant must be 'pin', 'classvar' or 'keep', "
+            f"not {options.pin_discriminant!r}"
         )
 
     if options.unresolved_hints not in _HINT_POLICIES:
@@ -1397,6 +1517,48 @@ def __pre_new__(
     # Insert fields from this class, in correct order.
     _add_fields(fields, cls_fields, replace=True, reverse=options.reverse)
 
+    # Which fields carry a default only because a registration pinned
+    # them -- here or further up. `_make_init` has to know, because a
+    # pinned default can leave a parameter without one behind it.
+    pinned = set()
+    for base in mro[1:]:
+        pinned.update(getattr(base, _PINNED, ()))
+
+    # What this class stands for, if it said. The constraints are read
+    # against the class it registers with -- so a misspelled field name
+    # is refused here, where it was written, rather than the first time
+    # something is built. The registration itself waits until the class
+    # exists; `__post_new__` does it.
+    if on is not MISSING:
+        polymorphic_base = _polymorphic_base(mro[1:])
+        if polymorphic_base is None:
+            raise TypeError(
+                f"{clsname} says with on= which arguments it stands for, "
+                f"but none of the classes it inherits from builds its "
+                f"subclasses. Add polymorphic=True to the one that "
+                f"should -- `class Chord(Magic, polymorphic=True)`."
+            )
+        specs = _specifications(polymorphic_base, clsname, on)
+        namespace[_REGISTRATION] = (
+            polymorphic_base,
+            specs,
+            0 if priority is MISSING else priority,
+        )
+        if options.pin_discriminant != "keep":
+            pinned.update(_pin_discriminants(
+                fields, namespace, cls_annotations, specs,
+                options.pin_discriminant,
+            ))
+
+    # A subclass that declares the field again, with no default of its
+    # own, has taken the pin away.
+    pinned = {
+        name for name in pinned
+        if name in fields and fields[name].default is not MISSING
+    }
+    if pinned:
+        namespace[_PINNED] = frozenset(pinned)
+
     # Do we have any Field members that don't also have annotations?
     for attr_name, value in namespace.items():
         if isinstance(value, Field) and attr_name not in cls_annotations:
@@ -1450,7 +1612,10 @@ def __pre_new__(
     # Build __init__. The builder writes source, so binding the public
     # name has to wait until `insert_fns` has compiled it (below).
     try:
-        init_kwargs = _make_init(fields, prepost, clsname)
+        init_kwargs = _make_init(
+            fields, prepost, clsname,
+            {fields[name].public_name for name in pinned},
+        )
     except _BadSignature as error:
         if init_name:
             raise
@@ -1848,6 +2013,7 @@ def _make_init(
     fields: dict[str, Field],
     prepost: tx.Mapping[str, bool],
     clsname: str,
+    pinned: tx.Container[str] = (),
 ) -> dict:
 
     locals = {"object": object, "_HasFactory": _HasFactory}
@@ -1882,11 +2048,29 @@ def _make_init(
         if field.public_name == "self":
             SELF = _SELF
 
+    # Pinning a field gives it a default, which can leave a parameter
+    # without one behind it -- `MinorChord(mode="minor", root)`, which
+    # Python's syntax has no way to write. Those parameters are given a
+    # sentinel default instead, and the body turns a sentinel that is
+    # still there back into the usual "missing a required argument". A
+    # class that pins nothing is untouched: two hand-written fields in
+    # that order are still refused, with the error that says so.
+    required = set()
+    if pinned:
+        after_pin = False
+        for field in list(positional_onlys.values()) + list(args.values()):
+            if field.public_name in pinned:
+                after_pin = True
+            elif after_pin and field.default is MISSING and not field.factory:
+                required.add(field.public_name)
+
     def _make_signature_elem(field: Field) -> tx.Tuple[str, str]:
         name = field.public_name
         default = field.default
         if field.factory:
             default = _HasFactory(field.factory)
+        elif name in required:
+            default = REQUIRED
         locals[_TYPE(name)] = field.type
         if default is MISSING:
             signature = f"{name}: {_TYPE(name)}"
@@ -2050,7 +2234,18 @@ def _make_init(
         object.__setattr__({SELF}, {field.name!r}, {value})
         """)
 
-    body = [_make_factory_elem(field) for field in parameters]
+    def _make_required_elem(name: str) -> str:
+        # `REQUIRED` is the package's own sentinel and nothing else
+        # hands it out, so a parameter still holding it was not passed.
+        locals[_REQUIRED_ARG] = REQUIRED
+        message = f"{clsname}() missing a required argument: {name!r}"
+        return dedent(f"""
+        if {name} is {_REQUIRED_ARG}:
+            raise TypeError({message!r})
+        """)
+
+    body = [_make_required_elem(name) for name in sorted(required)]
+    body += [_make_factory_elem(field) for field in parameters]
     if _PRE_INIT_NAME in prepost:
         body.append(_make_prepost_call(_PRE_INIT_NAME))
     body += [_make_body_elem(field) for field in parameters]
@@ -2519,6 +2714,18 @@ class MetaMagic(ABCMeta):
         keys an instance has is a question about that instance: the
         length can differ between two instances of one class, and can
         change over an instance's life.
+    polymorphic : bool | str, default=False
+        Build one of this class's subclasses instead of this class,
+        chosen from the arguments it was given. A subclass says which
+        arguments it stands for with `on=` on its own class statement.
+        With "strict", a call matching none of them is refused rather
+        than building this class.
+    pin_discriminant : {"pin", "classvar", "keep"}, default="pin"
+        What a subclass does with a field it matches on exactly. "pin"
+        gives the field that value as its default, so it still shows in
+        the repr and survives a round trip; "classvar" makes it a class
+        attribute that is not stored per instance, still accepted by the
+        constructor and discarded; "keep" leaves the field alone.
     reverse : bool, default=False
         Use the reverse MRO order to determine field order.
         This only affects the relative order of the fields of one class
@@ -2545,6 +2752,89 @@ class MetaMagic(ABCMeta):
         cls = super().__new__(metacls, name, bases, namespace)
         cls = __post_new__(cls)
         return cls
+
+    @property
+    def __signature__(cls) -> Signature:
+        # `inspect.signature(SomeClass)` reads the metaclass `__call__`
+        # when there is one, and would report `(*args, **kwargs)` for
+        # every Magic class. What a reader is asking for is how the
+        # class is built, so answer with the constructor's own
+        # signature, without the `self` it is written with.
+        found = signature(cls.__init__)
+        parameters = list(found.parameters.values())
+        return found.replace(parameters=parameters[1:])
+
+    def __call__(cls, *args, **kwargs) -> tx.Any:
+        # A class no subclass has registered with has nothing here, so
+        # the ordinary case pays one failed dictionary lookup. The
+        # lookup is a direct one: a subclass answers for the subclasses
+        # registered with *it*, and never for its parent's.
+        found = cls.__dict__.get(_POLYMORPHS)
+        if found is None:
+            return super().__call__(*args, **kwargs)
+        if found.invariant is not None:
+            _check_invariant(cls, found, args, kwargs)
+        if not found.entries:
+            return super().__call__(*args, **kwargs)
+        target = _select_polymorph(cls, found, args, kwargs)
+        if target is None:
+            return super().__call__(*args, **kwargs)
+        # The subclass is built the same way it would be if it had been
+        # named directly, so a subclass of *it* gets its turn too.
+        return target(*args, **kwargs)
+
+    def register_polymorph(
+        cls,
+        target: type,
+        on: tx.Optional[tx.Mapping[str, tx.Any]] = None,
+        priority: int = 0,
+        **constraints: tx.Any,
+    ) -> type:
+        """
+        Build `target` instead of this class, for these argument values.
+
+        This is the same thing as `class Sub(Base, on={...})`, said
+        after the fact -- for a class you did not write, or one whose
+        constraints are only known at run time. Registering later only
+        affects what is built later; instances that already exist are
+        untouched.
+
+        Parameters
+        ----------
+        target : type
+            The subclass to build. It must be a subclass of this class,
+            and not this class itself.
+        on : dict, optional
+            What `target` stands for: field names against the values
+            they must take. The same shapes as the `on=` class keyword.
+        priority : int, default=0
+            Which subclass wins when two match equally well. Higher
+            wins, and it is looked at before anything else.
+        **constraints
+            A friendlier spelling of `on`, for the usual case:
+            `Chord.register_polymorph(Diminished, mode="diminished")`.
+            Use `on=` for a field named `on`, `target` or `priority`.
+
+        Returns
+        -------
+        target : type
+            What was registered, so this can be used as a decorator.
+        """
+        options = getattr(cls, _OPTIONS, None)
+        if options is None or not options.polymorphic:
+            raise TypeError(
+                f"{cls.__name__} does not build its subclasses, so nothing "
+                f"can be registered with it. Add polymorphic=True to it -- "
+                f"`class {cls.__name__}(Magic, polymorphic=True)`."
+            )
+        wanted = dict(on or {})
+        wanted.update(constraints)
+        specs = _specifications(cls, getattr(target, "__name__", target),
+                                wanted)
+        _register_polymorph(
+            cls, target, specs, priority, options.polymorphic == "strict"
+        )
+        return target
 
 
 class Magic(metaclass=MetaMagic):
@@ -2618,6 +2908,18 @@ class Magic(metaclass=MetaMagic):
         keys an instance has is a question about that instance: the
         length can differ between two instances of one class, and can
         change over an instance's life.
+    polymorphic : bool | str, default=False
+        Build one of this class's subclasses instead of this class,
+        chosen from the arguments it was given. A subclass says which
+        arguments it stands for with `on=` on its own class statement.
+        With "strict", a call matching none of them is refused rather
+        than building this class.
+    pin_discriminant : {"pin", "classvar", "keep"}, default="pin"
+        What a subclass does with a field it matches on exactly. "pin"
+        gives the field that value as its default, so it still shows in
+        the repr and survives a round trip; "classvar" makes it a class
+        attribute that is not stored per instance, still accepted by the
+        constructor and discarded; "keep" leaves the field alone.
     reverse : bool, default=False
         Use the reverse MRO order to determine field order.
         This only affects the relative order of the fields of one class

--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -3212,7 +3212,10 @@ class MetaMagic(ABCMeta):
         for base in cls.__mro__:
             for name in ("__init__", "__new__"):
                 if name in base.__dict__:
-                    found = signature(base.__dict__[name])
+                    # Through `getattr`, not the class dict: `__new__`
+                    # is stored as a `staticmethod`, which is only
+                    # callable in its own right from Python 3.10.
+                    found = signature(getattr(base, name))
                     # Not `replace`, which checks the result: a pinned
                     # discriminant makes a signature Python's own
                     # syntax cannot write, and it is already true.

--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -177,6 +177,7 @@ from ._constants import (
     _CONVERTER,
     _DEFAULT,
     _DISCARD,
+    _DISPATCHING,
     _ERROR,
     _EXCEPTION,
     _FIELD_ERROR,
@@ -216,8 +217,8 @@ from ._options import Options
 from ._options import __all__ as __all_options__
 from ._polymorph import *  # noqa: F401, F403
 from ._polymorph import __all__ as __all_polymorph__
+from ._polymorph import arm as _arm_polymorph
 from ._polymorph import check as _check_invariant
-from ._polymorph import invariant as _keep_invariant
 from ._polymorph import register as _register_polymorph
 from ._polymorph import select as _select_polymorph
 from ._polymorph import specifications as _specifications
@@ -253,15 +254,18 @@ def __post_new__(cls: type) -> type:
         hints.namespace[cls.__name__] = cls
 
     # The class exists now, so it can be registered with the one that
-    # will build it. Under "strict" it also keeps its own registration,
-    # to refuse a direct call that contradicts it.
+    # will build it.
     registration = cls.__dict__.get(_REGISTRATION)
     if registration is not None:
         polymorphic_base, specs, priority = registration
-        strict = getattr(polymorphic_base, _OPTIONS).polymorphic == "strict"
-        _register_polymorph(polymorphic_base, cls, specs, priority, strict)
-        if getattr(cls, _OPTIONS).polymorphic == "strict":
-            _keep_invariant(cls, specs)
+        _register_polymorph(polymorphic_base, cls, specs, priority)
+
+    # A strict class is armed whether or not anything has registered
+    # with it yet, since "nobody has registered" is the case the
+    # setting exists to report. Being armed also means keeping its own
+    # constraints, to refuse a direct call that contradicts them.
+    if getattr(getattr(cls, _OPTIONS, None), "polymorphic", False) == "strict":
+        _arm_polymorph(cls, specs if registration is not None else None)
 
     fields = getattr(cls, _FIELDS, {})
     fields = {name: field for name, field in fields.items() if not field.var}
@@ -1127,12 +1131,41 @@ def _polymorphic_base(mro: tx.Tuple[type, ...]) -> tx.Optional[type]:
     return None
 
 
+def _check_discriminants(
+    clsname: str,
+    polymorphic_base: type,
+    fields: dict,
+    specs: tx.Sequence,
+) -> None:
+    # A field the class it registers with takes, and it does not, is a
+    # field it can never be handed. The base passes the arguments it
+    # was given straight through, so the call the caller wrote would
+    # fail inside the delegation, naming a class they never mentioned.
+    base_fields = getattr(polymorphic_base, _FIELDS)
+    for spec in specs:
+        field = fields[spec.name]
+        if field.init or not base_fields[spec.name].init:
+            continue
+        raise TypeError(
+            f"{clsname} registers on {spec.name!r}, and does not take "
+            f"{spec.name!r} when it is built -- so "
+            f"{polymorphic_base.__name__}({spec.name}=...), which builds "
+            f"{clsname} and passes on what it was given, would fail. To "
+            f"keep {spec.name!r} out of the instances without closing "
+            f"the door on it, write "
+            f"pin_discriminant='classvar' on {clsname} and leave the "
+            f"field to it: the value becomes a class attribute, and the "
+            f"argument is still accepted and dropped."
+        )
+
+
 def _pin_discriminants(
     fields: dict,
     namespace: dict,
     declared: tx.Container[str],
     specs: tx.Sequence,
     action: str,
+    mutable: str,
 ) -> tx.Set[str]:
     # A subclass registered for one exact value already says what that
     # field holds, so it does not have to say it twice: the field is
@@ -1161,7 +1194,15 @@ def _pin_discriminants(
             field.key = SHOW_ATTR(False)
             field.eq = field.order = False
             field.hash = False
+            # A class attribute is meant to be shared, so a mutable one
+            # is not the trap `mutable_default` is about.
             namespace[field.name] = spec.value
+        else:
+            # A pinned default reaches every instance, so it goes
+            # through the same handling a written-out default does:
+            # `on={"cfg": {"a": 1}}` must not hand one dictionary to
+            # every instance of the subclass.
+            _handle_mutable_default(field, mutable)
         pinned.add(field.name)
     return pinned
 
@@ -1667,14 +1708,16 @@ def __pre_new__(
         if options.pin_discriminant != "keep":
             pinned.update(_pin_discriminants(
                 fields, namespace, cls_annotations, specs,
-                options.pin_discriminant,
+                options.pin_discriminant, options.mutable_default,
             ))
+        _check_discriminants(clsname, polymorphic_base, fields, specs)
 
     # A subclass that declares the field again, with no default of its
     # own, has taken the pin away.
     pinned = {
         name for name in pinned
-        if name in fields and fields[name].default is not MISSING
+        if name in fields
+        and (fields[name].default is not MISSING or fields[name].factory)
     }
     if pinned:
         namespace[_PINNED] = frozenset(pinned)
@@ -1732,7 +1775,7 @@ def __pre_new__(
     # Build __init__. The builder writes source, so binding the public
     # name has to wait until `insert_fns` has compiled it (below).
     try:
-        init_kwargs = _make_init(
+        init_kwargs, sentinels = _make_init(
             fields, prepost, clsname,
             {fields[name].public_name for name in pinned},
         )
@@ -1744,7 +1787,7 @@ def __pre_new__(
         # its own `__magic_init__`, one that explains the problem if it
         # is ever called -- without it, `self.__magic_init__(...)` would
         # quietly find a base class's version and set the wrong fields.
-        init_kwargs = None
+        init_kwargs, sentinels = None, ()
         namespace.setdefault(
             _MAGIC("init"), _unbuildable_init(clsname, str(error))
         )
@@ -1881,6 +1924,16 @@ def __pre_new__(
         magic_init.__code__ = magic_init.__code__.replace(
             co_name=magic_init.__name__
         )
+        if sentinels:
+            # A parameter standing behind a pinned one carries a
+            # sentinel where Python's syntax cannot spell "no default",
+            # and every tool that reads a signature -- `help`, an
+            # editor's tooltip, `Signature.bind` -- would take that for
+            # an optional argument. Say what is true instead, and leave
+            # the sentinel to the code.
+            magic_init.__signature__ = _honest_signature(
+                magic_init, sentinels
+            )
         if init_name and init_name not in namespace:
             namespace[init_name] = magic_init
             generated[init_name] = "init"
@@ -2127,6 +2180,26 @@ def _make_doc_elem(field: Field, name: tx.Optional[str] = None) -> str:
     if field.doc:
         doc += "\n" + indent(dedent(field.doc).strip(), " " * 4)
     return doc
+
+
+def _honest_signature(
+    fn: tx.Callable, sentinels: tx.Container[str]
+) -> Signature:
+    # The signature of `fn` with the sentinel defaults taken off, so
+    # that a required argument reads as one. `Signature` refuses to
+    # build a parameter without a default behind one that has a default
+    # -- the very shape being described -- so it is asked not to check.
+    found = signature(fn)
+    parameters = [
+        parameter.replace(default=Parameter.empty)
+        if parameter.name in sentinels else parameter
+        for parameter in found.parameters.values()
+    ]
+    return Signature(
+        parameters,
+        return_annotation=found.return_annotation,
+        __validate_parameters__=False,
+    )
 
 
 def _make_init(
@@ -2388,7 +2461,7 @@ def _make_init(
         "doc": doc,
         "locals": locals,
         "return_type": None,
-    }
+    }, required
 
 
 def _make_repr(qualname: str, fields: dict[str, Field]) -> tx.Callable:
@@ -2757,6 +2830,77 @@ def _make_mapping(
 # derive from ABCs (e.g. Mapping).
 
 
+# ----------------------------------------------------------------------
+# Dispatch
+# ----------------------------------------------------------------------
+
+#: Metaclasses that already dispatch, by the one they were made from,
+#: so a hierarchy shares one rather than growing a metaclass per class.
+_DISPATCHERS: tx.Dict[type, type] = {}
+
+
+def _dispatching(metacls: type) -> type:
+    """A metaclass like `metacls`, that builds a class's subclasses.
+
+    Choosing which subclass to build has to happen in a metaclass
+    `__call__`, and defining one replaces the interpreter's own C-level
+    path with a Python call -- on every instantiation of every class
+    that metaclass builds. So only the classes that asked for it get
+    one: a class written `polymorphic=...` is created with a subclass
+    of whatever metaclass it would otherwise have had, and every other
+    Magic class keeps the fast path untouched.
+
+    Deriving from the metaclass Python already worked out, rather than
+    from a fixed one, is also what keeps this compatible with a
+    metaclass of your own: the result is a subclass of yours, so it can
+    never conflict with it.
+    """
+    if getattr(metacls, _DISPATCHING, False):
+        return metacls
+    made = _DISPATCHERS.get(metacls)
+    if made is not None:
+        return made
+    made = type(metacls)(
+        metacls.__name__ + "Dispatch",
+        (metacls,),
+        {
+            _DISPATCHING: True,
+            "__doc__": _dispatching.__doc__,
+            "__module__": __name__,
+        },
+    )
+
+    # What building a class normally does, read once. `made` has one
+    # base, so this is what `super(made, cls).__call__` would find --
+    # and for a plain Magic class it is the interpreter's own
+    # `type.__call__`, which is the path a class that turns out not to
+    # dispatch should go straight back to.
+    build = metacls.__call__
+
+    def __call__(cls: type, *args, **kwargs) -> tx.Any:
+        # A class no subclass has registered with, and that does not
+        # itself have to be one, has nothing here. The lookup is a
+        # direct one: a subclass answers for the subclasses registered
+        # with *it*, and never for its parent's.
+        found = cls.__dict__.get(_POLYMORPHS)
+        if found is None:
+            return build(cls, *args, **kwargs)
+        if found.invariant is not None:
+            _check_invariant(cls, found, args, kwargs)
+        if not (found.dispatch[0] or found.required):
+            return build(cls, *args, **kwargs)
+        target = _select_polymorph(cls, found, args, kwargs)
+        if target is None:
+            return build(cls, *args, **kwargs)
+        # The subclass is built the same way it would be if it had been
+        # named directly, so a subclass of *it* gets its turn too.
+        return target(*args, **kwargs)
+
+    made.__call__ = __call__
+    _DISPATCHERS[metacls] = made
+    return made
+
+
 class MetaMagic(ABCMeta):
     """
     Examples
@@ -2890,39 +3034,46 @@ class MetaMagic(ABCMeta):
         name, bases, namespace = __pre_new__(
             metacls, name, bases, namespace, **kwargs
         )
+        options = namespace.get(_OPTIONS)
+        if options is not None and options.polymorphic:
+            metacls = _dispatching(metacls)
         cls = super().__new__(metacls, name, bases, namespace)
         cls = __post_new__(cls)
         return cls
 
     @property
     def __signature__(cls) -> Signature:
-        # `inspect.signature(SomeClass)` reads the metaclass `__call__`
-        # when there is one, and would report `(*args, **kwargs)` for
-        # every Magic class. What a reader is asking for is how the
-        # class is built, so answer with the constructor's own
-        # signature, without the `self` it is written with.
-        found = signature(cls.__init__)
-        parameters = list(found.parameters.values())
-        return found.replace(parameters=parameters[1:])
-
-    def __call__(cls, *args, **kwargs) -> tx.Any:
-        # A class no subclass has registered with has nothing here, so
-        # the ordinary case pays one failed dictionary lookup. The
-        # lookup is a direct one: a subclass answers for the subclasses
-        # registered with *it*, and never for its parent's.
-        found = cls.__dict__.get(_POLYMORPHS)
-        if found is None:
-            return super().__call__(*args, **kwargs)
-        if found.invariant is not None:
-            _check_invariant(cls, found, args, kwargs)
-        if not found.entries:
-            return super().__call__(*args, **kwargs)
-        target = _select_polymorph(cls, found, args, kwargs)
-        if target is None:
-            return super().__call__(*args, **kwargs)
-        # The subclass is built the same way it would be if it had been
-        # named directly, so a subclass of *it* gets its turn too.
-        return target(*args, **kwargs)
+        # `inspect.signature(SomeClass)` reads a metaclass `__call__`
+        # before anything else, and a polymorphic class has one -- so
+        # without this, such a class would report `(*args, **kwargs)`
+        # instead of how it is actually built. Answering here keeps
+        # every Magic class saying the same thing, whether or not it
+        # dispatches.
+        #
+        # A signature written by hand wins, wherever in the chain it
+        # was written: `inspect` would have found it by ordinary
+        # attribute lookup, and a property on the metaclass hides it.
+        for base in cls.__mro__:
+            written = base.__dict__.get("__signature__")
+            if written is not None:
+                return written
+        # Otherwise the constructor's own, without the `self` it is
+        # written with. Which constructor is `inspect`'s rule: whichever
+        # of `__init__` and `__new__` is defined first down the chain,
+        # since a class with no `__init__` of its own may still take its
+        # arguments in `__new__`.
+        for base in cls.__mro__:
+            for name in ("__init__", "__new__"):
+                if name in base.__dict__:
+                    found = signature(base.__dict__[name])
+                    # Not `replace`, which checks the result: a pinned
+                    # discriminant makes a signature Python's own
+                    # syntax cannot write, and it is already true.
+                    return Signature(
+                        list(found.parameters.values())[1:],
+                        return_annotation=found.return_annotation,
+                        __validate_parameters__=False,
+                    )
 
     def register_polymorph(
         cls,
@@ -2972,9 +3123,7 @@ class MetaMagic(ABCMeta):
         wanted.update(constraints)
         specs = _specifications(cls, getattr(target, "__name__", target),
                                 wanted)
-        _register_polymorph(
-            cls, target, specs, priority, options.polymorphic == "strict"
-        )
+        _register_polymorph(cls, target, specs, priority)
         return target
 
 

--- a/src/bagof/magic/_options.py
+++ b/src/bagof/magic/_options.py
@@ -25,6 +25,8 @@ from ._utils import SlotsBase, slots
     'validate',         # Use field type as validator if none is provided
     'unresolved_hints',  # What to do about a type hint that never resolves
     'mapping',          # Generate Mapping methods for dict-like behavior
+    'polymorphic',      # Build a registered subclass instead of this class
+    'pin_discriminant',  # What a subclass does with the field it matches on
     'reverse',          # Use the reverse MRO order when listing fields
     'doc',              # Generate class docstring from field docstrings
 )
@@ -63,6 +65,8 @@ class Options(SlotsBase):
         validate=False,
         unresolved_hints="warn",
         mapping=False,
+        polymorphic=False,
+        pin_discriminant="pin",
         reverse=False,
         doc=True,
     )

--- a/src/bagof/magic/_polymorph.py
+++ b/src/bagof/magic/_polymorph.py
@@ -1,0 +1,534 @@
+"""
+Choosing which subclass to build.
+
+A class marked `polymorphic=True` lets its subclasses say which argument
+values they stand for, and calling it hands back the subclass that fits:
+
+```python
+class Chord(Magic, polymorphic=True):
+    mode: str
+    root: str
+
+class MinorChord(Chord, on={"mode": "minor"}):
+    ...
+
+Chord(mode="minor", root="A")     # MinorChord(mode='minor', root='A')
+```
+
+Everything here answers one of three questions.
+
+**What does a constraint mean?** `_specification` turns each value of an
+`on={...}` mapping into a predicate and a *precision* -- how narrow a
+claim it is. An exact value is the narrowest, a bare `...` (the argument
+was supplied at all) the widest.
+
+**Which subclass wins?** A subclass is a candidate when every constraint
+it declares matches. Among the candidates, `select` puts first the one
+given the highest `priority`, then the one constraining the most fields,
+then the one whose constraints are the most precise, then the deepest
+subclass. Registration order is deliberately not part of that, so the
+answer never depends on the order the modules were imported; a remaining
+tie is an `AmbiguousPolymorphError` rather than a coin flip.
+
+**Where does the value come from?** The fields any registration mentions
+are known as soon as it registers, so the class can work out once where
+each of them arrives -- which position in `__init__`, whether it may be
+passed by name, what it defaults to, what converts it. `_Discriminant`
+holds that, and `_read` uses it, so dispatch costs a couple of dict
+lookups per constrained field rather than binding a signature.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "PolymorphError",
+    "NoPolymorphError",
+    "AmbiguousPolymorphError",
+]
+
+# dependencies
+import typing_extensions as tx
+from bagof.validators import Validator
+
+# internals
+from ._constants import (
+    _FIELDS,
+    _GENERATED,
+    _POLYMORPHS,
+    MISSING,
+    MaybeMissing,
+)
+
+# ----------------------------------------------------------------------
+# What can go wrong
+# ----------------------------------------------------------------------
+
+
+class PolymorphError(TypeError):
+    """
+    A class was asked to build one of its subclasses and could not.
+
+    Raised on its own when a subclass is built with a value that
+    contradicts the one it registered for, under `polymorphic="strict"`.
+    `NoPolymorphError` and `AmbiguousPolymorphError` are the two other
+    ways dispatch can fail, and both are kinds of this.
+    """
+
+
+class NoPolymorphError(PolymorphError):
+    """
+    No registered subclass matches the arguments.
+
+    Only `polymorphic="strict"` raises this: `polymorphic=True` builds
+    the class that was called instead.
+    """
+
+
+class AmbiguousPolymorphError(PolymorphError):
+    """
+    Two registered subclasses match the arguments equally well.
+
+    Nothing separates them, and picking either would make the answer
+    depend on which module was imported first. Give one of them a
+    higher `priority` to say which should win.
+    """
+
+
+# ----------------------------------------------------------------------
+# What a constraint means
+# ----------------------------------------------------------------------
+
+#: How narrow a claim each shape of constraint makes. A candidate
+#: constraining `mode` to exactly `"minor"` says more than one accepting
+#: any string, so it wins when both match.
+_EXACT = 4
+_MEMBER = 3
+_PATTERN = 2
+_HINT = 1
+_LOOSE = 0
+
+
+class _Spec:
+    """One `field: constraint` pair of a registration."""
+
+    __slots__ = ("name", "matches", "precision", "value", "text")
+
+    def __init__(
+        self,
+        name: str,
+        matches: tx.Callable[[tx.Any], bool],
+        precision: int,
+        value: MaybeMissing[tx.Any],
+        text: str,
+    ) -> None:
+        self.name = name
+        self.matches = matches
+        self.precision = precision
+        #: The one value this constraint accepts, when it accepts one
+        #: value; `MISSING` otherwise. This is what pinning writes as
+        #: the subclass's default.
+        self.value = value
+        #: How the constraint reads in an error message.
+        self.text = text
+
+
+def _is_hint(spec: tx.Any) -> bool:
+    # A type, or a typing form built out of one (`Literal[...]`,
+    # `Annotated[int, ...]`, `Optional[str]`). Anything of that shape
+    # goes to `bagof-validators`, so a registration can say what it
+    # accepts in the same language a field does.
+    return isinstance(spec, type) or tx.get_origin(spec) is not None
+
+
+def _accepts(spec: tx.Any) -> tx.Callable[[tx.Any], bool]:
+    validator = Validator.get(spec)
+
+    def accepts(value: tx.Any) -> bool:
+        try:
+            validator(value)
+        except Exception:
+            return False
+        return True
+
+    return accepts
+
+
+def _specification(name: str, spec: tx.Any) -> _Spec:
+    """Read one value of an `on={...}` mapping."""
+    if spec is Ellipsis:
+        return _Spec(name, lambda value: True, _LOOSE, MISSING, "anything")
+    if isinstance(spec, (set, frozenset)):
+        return _Spec(
+            name, lambda value: value in spec, _MEMBER, MISSING, repr(spec)
+        )
+    if hasattr(spec, "fullmatch"):
+        return _Spec(
+            name,
+            lambda value: spec.fullmatch(str(value)) is not None,
+            _PATTERN,
+            MISSING,
+            f"matching {spec.pattern!r}",
+        )
+    if _is_hint(spec):
+        return _Spec(name, _accepts(spec), _HINT, MISSING, repr(spec))
+    if callable(spec):
+        return _Spec(
+            name, lambda value: bool(spec(value)), _LOOSE, MISSING, repr(spec)
+        )
+    return _Spec(
+        name, lambda value: bool(value == spec), _EXACT, spec, repr(spec)
+    )
+
+
+def specifications(
+    owner: type, clsname: str, on: tx.Mapping[str, tx.Any]
+) -> tx.Tuple[_Spec, ...]:
+    """
+    Read a whole `on={...}` mapping against the class registering with.
+
+    Its keys name fields the way `owner` declares them, and a name that
+    is no field of `owner` is refused here -- when the class is written,
+    rather than the first time something is built.
+    """
+    if not isinstance(on, tx.Mapping):
+        raise TypeError(
+            f"on= takes a mapping of field names to the values "
+            f"{clsname} stands for, such as on={{'mode': 'minor'}}, "
+            f"and was given {on!r}."
+        )
+    table = getattr(owner, _FIELDS)
+    specs = []
+    for name, spec in on.items():
+        if name not in table:
+            raise TypeError(
+                f"{clsname} registers on {name!r}, which is not a field of "
+                f"{owner.__name__}. Its fields are: "
+                f"{', '.join(repr(field) for field in table) or 'none'}."
+            )
+        specs.append(_specification(name, spec))
+    return tuple(specs)
+
+
+# ----------------------------------------------------------------------
+# Where a value comes from
+# ----------------------------------------------------------------------
+
+
+class _Discriminant:
+    """Where one constrained field's value arrives, on one class."""
+
+    __slots__ = ("name", "public", "position", "keyword", "default",
+                 "convert")
+
+    def __init__(
+        self,
+        name: str,
+        public: str,
+        position: tx.Optional[int],
+        keyword: bool,
+        default: MaybeMissing[tx.Any],
+        convert: tx.Optional[tx.Callable[[tx.Any], tx.Any]],
+    ) -> None:
+        self.name = name
+        self.public = public
+        self.position = position
+        self.keyword = keyword
+        self.default = default
+        self.convert = convert
+
+
+def _generated_init(cls: type) -> bool:
+    # Whether the `__init__` Python will call for this class is one
+    # Magic wrote. A hand-written one takes its arguments in whatever
+    # order it likes, so nothing can be read out of `args` by position.
+    # Every class has `object.__init__` behind it, so there is always
+    # one to find.
+    owner = next(
+        base for base in cls.__mro__ if "__init__" in base.__dict__
+    )
+    return "__init__" in (owner.__dict__.get(_GENERATED) or {})
+
+
+def discriminants(
+    cls: type, names: tx.Iterable[str]
+) -> tx.Tuple[_Discriminant, ...]:
+    """Work out, once, where each of `names` arrives on `cls`."""
+    table = getattr(cls, _FIELDS)
+    # A positional-only field comes first in the signature, whatever
+    # order it was declared in -- the same order `__init__` is built in.
+    positional = [field for field in table.values() if field.positional]
+    order = [field for field in positional if not field.kw]
+    order += [field for field in positional if field.kw]
+    places = {field.name: index for index, field in enumerate(order)}
+    by_position = _generated_init(cls)
+
+    found = []
+    for name in names:
+        field = table[name]
+        default = field.default
+        if field.factory:
+            # A factory default is built once per instance, and building
+            # it here to read it would build it twice. A field defaulted
+            # that way is read as absent when it is not passed.
+            default = MISSING
+        found.append(_Discriminant(
+            name,
+            field.public_name,
+            places.get(field.name) if by_position else None,
+            bool(field.kw),
+            default,
+            field.converter or None,
+        ))
+    return tuple(found)
+
+
+def _read(
+    discriminant: _Discriminant,
+    args: tx.Tuple[tx.Any, ...],
+    kwargs: tx.Dict[str, tx.Any],
+) -> MaybeMissing[tx.Any]:
+    # A keyword-only field is never read out of `args`, and a
+    # positional-only one never out of `kwargs`: reading either the
+    # wrong way round would quietly hand back a neighbour's value.
+    if discriminant.keyword and discriminant.public in kwargs:
+        value = kwargs[discriminant.public]
+    elif (
+        discriminant.position is not None
+        and discriminant.position < len(args)
+    ):
+        value = args[discriminant.position]
+    else:
+        # A default is as good as a value the caller wrote out: the two
+        # spellings of one call must build the same class.
+        value = discriminant.default
+    if value is MISSING or discriminant.convert is None:
+        return value
+    try:
+        return discriminant.convert(value)
+    except Exception:
+        # The value is not one this field accepts. Matching goes on with
+        # what was passed, and `__init__` says what is wrong with it.
+        return value
+
+
+def read(
+    found: tx.Tuple[_Discriminant, ...],
+    args: tx.Tuple[tx.Any, ...],
+    kwargs: tx.Dict[str, tx.Any],
+) -> tx.Dict[str, tx.Any]:
+    """The value of every constrained field, for one call."""
+    return {d.name: _read(d, args, kwargs) for d in found}
+
+
+# ----------------------------------------------------------------------
+# The registry a polymorphic class carries
+# ----------------------------------------------------------------------
+
+
+class _Polymorph:
+    """One subclass, and what it stands for."""
+
+    __slots__ = ("target", "specs", "priority", "depth")
+
+    def __init__(
+        self,
+        target: type,
+        specs: tx.Tuple[_Spec, ...],
+        priority: int,
+        depth: int,
+    ) -> None:
+        self.target = target
+        self.specs = specs
+        self.priority = priority
+        self.depth = depth
+
+    @property
+    def rank(self) -> tx.Tuple[int, int, int, int]:
+        # Explicit priority first, then the number of fields the claim
+        # covers, then how precise those constraints are, then how far
+        # down the class hierarchy the subclass sits -- so refining an
+        # existing subclass does not need a narrower `on=`.
+        return (
+            self.priority,
+            len(self.specs),
+            sum(spec.precision for spec in self.specs),
+            self.depth,
+        )
+
+    def matches(self, values: tx.Mapping[str, tx.Any]) -> bool:
+        for spec in self.specs:
+            value = values[spec.name]
+            if value is MISSING or not spec.matches(value):
+                return False
+        return True
+
+    def __str__(self) -> str:
+        written = ", ".join(
+            f"{spec.name}={spec.text}" for spec in self.specs
+        )
+        return f"{self.target.__name__}({written})"
+
+
+class _Registry:
+    """What a class knows about building something other than itself."""
+
+    __slots__ = ("entries", "discriminants", "invariant", "strict")
+
+    def __init__(self, strict: bool) -> None:
+        self.entries = ()
+        self.discriminants = ()
+        #: This class's own registration, read back on the way in, so
+        #: that building it directly with a contradicting value can be
+        #: refused. Only kept under `polymorphic="strict"`.
+        self.invariant = None
+        self.strict = strict
+
+
+def registry(cls: type, strict: bool) -> _Registry:
+    """This class's own registry, made if it has none yet.
+
+    Never an inherited one: a subclass answers for the subclasses
+    registered with *it*.
+    """
+    found = cls.__dict__.get(_POLYMORPHS)
+    if found is None:
+        found = _Registry(strict)
+        setattr(cls, _POLYMORPHS, found)
+    return found
+
+
+def register(
+    owner: type,
+    target: type,
+    specs: tx.Tuple[_Spec, ...],
+    priority: int,
+    strict: bool,
+) -> None:
+    """Have `owner` build `target` for the arguments `specs` describe."""
+    if not (isinstance(target, type) and issubclass(target, owner)):
+        raise TypeError(
+            f"{owner.__name__} can only build its own subclasses, and "
+            f"{getattr(target, '__name__', target)!r} is not one."
+        )
+    if target is owner:
+        raise TypeError(
+            f"{owner.__name__} cannot be registered against itself: it is "
+            f"already what a call to it builds when nothing else matches."
+        )
+    entry = _Polymorph(
+        target, specs, priority, target.__mro__.index(owner)
+    )
+    found = registry(owner, strict)
+    # A class registering a second time -- a reloaded module, a
+    # decorator applied twice -- replaces its entry rather than adding
+    # one that would then tie with itself. Same name in the same module
+    # is the same registration, whether or not it is the same object.
+    same = (target.__module__, target.__qualname__)
+    entries = [
+        kept for kept in found.entries
+        if (kept.target.__module__, kept.target.__qualname__) != same
+    ]
+    entries.append(entry)
+    names = []
+    for kept in entries:
+        for spec in kept.specs:
+            if spec.name not in names:
+                names.append(spec.name)
+    # Built whole and swapped in, so that anything reading the registry
+    # while a plugin registers reads one state or the other.
+    found.entries = tuple(entries)
+    found.discriminants = discriminants(owner, names)
+
+
+def invariant(cls: type, specs: tx.Tuple[_Spec, ...]) -> None:
+    """Keep `cls`'s own registration, to check calls to it against."""
+    found = registry(cls, True)
+    found.invariant = (specs, discriminants(cls, [s.name for s in specs]))
+
+
+# ----------------------------------------------------------------------
+# Choosing
+# ----------------------------------------------------------------------
+
+
+def _written(values: tx.Mapping[str, tx.Any]) -> str:
+    """The arguments dispatch went on, said the way they were passed."""
+    written = ", ".join(
+        f"{name}={value!r}"
+        for name, value in values.items()
+        if value is not MISSING
+    )
+    return written or "nothing it was given"
+
+
+def select(
+    cls: type,
+    found: _Registry,
+    args: tx.Tuple[tx.Any, ...],
+    kwargs: tx.Dict[str, tx.Any],
+) -> tx.Optional[type]:
+    """
+    Which subclass of `cls` to build, or `None` to build `cls` itself.
+    """
+    values = read(found.discriminants, args, kwargs)
+    candidates = [entry for entry in found.entries if entry.matches(values)]
+    if not candidates:
+        # An abstract class cannot stand in for the subclass that was
+        # not found: falling through would raise Python's own "can't
+        # instantiate", which says nothing about the choice that was
+        # being made.
+        abstract = getattr(cls, "__abstractmethods__", None)
+        if found.strict or abstract:
+            why = (
+                f"{cls.__name__} is abstract, so it can only be built as "
+                f"one of the subclasses registered with it"
+                if abstract else
+                f"{cls.__name__} only builds one of the subclasses "
+                f"registered with it"
+            )
+            considered = "\n".join(f"  - {entry}" for entry in found.entries)
+            raise NoPolymorphError(
+                f"{why}, and none of them matches {_written(values)}. It "
+                f"considered:\n{considered}\nIf the one you expected is "
+                f"not in that list, the module it is written in has not "
+                f"been imported."
+            )
+        return None
+    best = max(candidates, key=lambda entry: entry.rank)
+    tied = [
+        entry for entry in candidates
+        if entry is not best and entry.rank == best.rank
+    ]
+    if tied:
+        names = ", ".join(
+            sorted([best.target.__name__]
+                   + [entry.target.__name__ for entry in tied])
+        )
+        raise AmbiguousPolymorphError(
+            f"{cls.__name__}({_written(values)}) matches {names} equally "
+            f"well, and there is nothing to choose between them. Say which "
+            f"one wins by giving it a higher priority -- "
+            f"`class {best.target.__name__}({cls.__name__}, on={{...}}, "
+            f"priority=1)`."
+        )
+    return best.target
+
+
+def check(
+    cls: type,
+    found: _Registry,
+    args: tx.Tuple[tx.Any, ...],
+    kwargs: tx.Dict[str, tx.Any],
+) -> None:
+    """Refuse a call to `cls` that contradicts what it registered for."""
+    specs, where = found.invariant
+    values = read(where, args, kwargs)
+    for spec in specs:
+        value = values[spec.name]
+        if value is MISSING or spec.matches(value):
+            continue
+        raise PolymorphError(
+            f"{cls.__name__} is what {spec.name}={spec.text} builds, so "
+            f"{spec.name}={value!r} contradicts it. Build the class that "
+            f"value belongs to instead."
+        )

--- a/src/bagof/magic/_polymorph.py
+++ b/src/bagof/magic/_polymorph.py
@@ -54,7 +54,9 @@ from bagof.validators import Validator
 from ._constants import (
     _FIELDS,
     _GENERATED,
+    _OPTIONS,
     _POLYMORPHS,
+    _REGISTRATION,
     MISSING,
     MaybeMissing,
 )
@@ -79,8 +81,10 @@ class NoPolymorphError(PolymorphError):
     """
     No registered subclass matches the arguments.
 
-    Only `polymorphic="strict"` raises this: `polymorphic=True` builds
-    the class that was called instead.
+    A class raises this when it cannot stand in for the subclass that
+    was not found: under `polymorphic="strict"`, and whenever the class
+    is abstract. A plain `polymorphic=True` class builds itself
+    instead.
     """
 
 
@@ -140,6 +144,24 @@ def _is_hint(spec: tx.Any) -> bool:
     return isinstance(spec, type) or tx.get_origin(spec) is not None
 
 
+def _guarded(
+    matches: tx.Callable[[tx.Any], tx.Any]
+) -> tx.Callable[[tx.Any], bool]:
+    # A value a constraint cannot even be compared with is not one it
+    # accepts. Anything may turn up here -- a registration is checked
+    # against whatever the caller passed, before conversion has had a
+    # say -- so an `__eq__` that raises, an unhashable value handed to
+    # a set, or a value `str()` refuses must all read as "no match"
+    # rather than coming out of the constructor as themselves.
+    def guard(value: tx.Any) -> bool:
+        try:
+            return bool(matches(value))
+        except Exception:
+            return False
+
+    return guard
+
+
 def _accepts(spec: tx.Any) -> tx.Callable[[tx.Any], bool]:
     validator = Validator.get(spec)
 
@@ -153,31 +175,33 @@ def _accepts(spec: tx.Any) -> tx.Callable[[tx.Any], bool]:
     return accepts
 
 
-def _specification(name: str, spec: tx.Any) -> _Spec:
-    """Read one value of an `on={...}` mapping."""
+def _shape(
+    spec: tx.Any
+) -> tx.Tuple[tx.Callable[[tx.Any], tx.Any], int, MaybeMissing[tx.Any], str]:
+    # What one constraint matches, how narrow a claim that is, the one
+    # value it accepts when it accepts one, and how it reads.
     if spec is Ellipsis:
-        return _Spec(name, lambda value: True, _LOOSE, MISSING, "anything")
+        return (lambda value: True), _LOOSE, MISSING, "anything"
     if isinstance(spec, (set, frozenset)):
-        return _Spec(
-            name, lambda value: value in spec, _MEMBER, MISSING, repr(spec)
-        )
+        return (lambda value: value in spec), _MEMBER, MISSING, repr(spec)
     if hasattr(spec, "fullmatch"):
-        return _Spec(
-            name,
+        return (
             lambda value: spec.fullmatch(str(value)) is not None,
             _PATTERN,
             MISSING,
             f"matching {spec.pattern!r}",
         )
     if _is_hint(spec):
-        return _Spec(name, _accepts(spec), _HINT, MISSING, repr(spec))
+        return _accepts(spec), _HINT, MISSING, repr(spec)
     if callable(spec):
-        return _Spec(
-            name, lambda value: bool(spec(value)), _LOOSE, MISSING, repr(spec)
-        )
-    return _Spec(
-        name, lambda value: bool(value == spec), _EXACT, spec, repr(spec)
-    )
+        return spec, _LOOSE, MISSING, repr(spec)
+    return (lambda value: value == spec), _EXACT, spec, repr(spec)
+
+
+def _specification(name: str, spec: tx.Any) -> _Spec:
+    """Read one value of an `on={...}` mapping."""
+    matches, precision, value, text = _shape(spec)
+    return _Spec(name, _guarded(matches), precision, value, text)
 
 
 def specifications(
@@ -328,7 +352,7 @@ def read(
 class _Polymorph:
     """One subclass, and what it stands for."""
 
-    __slots__ = ("target", "specs", "priority", "depth")
+    __slots__ = ("target", "specs", "rank")
 
     def __init__(
         self,
@@ -339,20 +363,17 @@ class _Polymorph:
     ) -> None:
         self.target = target
         self.specs = specs
-        self.priority = priority
-        self.depth = depth
-
-    @property
-    def rank(self) -> tx.Tuple[int, int, int, int]:
-        # Explicit priority first, then the number of fields the claim
-        # covers, then how precise those constraints are, then how far
-        # down the class hierarchy the subclass sits -- so refining an
-        # existing subclass does not need a narrower `on=`.
-        return (
-            self.priority,
-            len(self.specs),
-            sum(spec.precision for spec in self.specs),
-            self.depth,
+        #: How strong a claim this is, worked out once because none of
+        #: it can change: an explicit priority first, then the number
+        #: of fields the claim covers, then how precise those
+        #: constraints are, then how far down the class hierarchy the
+        #: subclass sits -- so refining an existing subclass does not
+        #: need a narrower `on=`.
+        self.rank = (
+            priority,
+            len(specs),
+            sum(spec.precision for spec in specs),
+            depth,
         )
 
     def matches(self, values: tx.Mapping[str, tx.Any]) -> bool:
@@ -372,19 +393,29 @@ class _Polymorph:
 class _Registry:
     """What a class knows about building something other than itself."""
 
-    __slots__ = ("entries", "discriminants", "invariant", "strict")
+    __slots__ = ("dispatch", "invariant", "strict", "required")
 
-    def __init__(self, strict: bool) -> None:
-        self.entries = ()
-        self.discriminants = ()
+    def __init__(self, strict: bool, required: bool) -> None:
+        #: The registered subclasses, and where each constrained field
+        #: arrives, as one value. Rebuilt whole and stored in a single
+        #: assignment, so a construction on another thread reads either
+        #: the state before a registration or the state after it, never
+        #: entries whose fields the reader has no place to look up.
+        self.dispatch = ((), ())
         #: This class's own registration, read back on the way in, so
         #: that building it directly with a contradicting value can be
         #: refused. Only kept under `polymorphic="strict"`.
         self.invariant = None
+        #: Refuse to build this class when nothing matches.
         self.strict = strict
+        #: Refuse even when nothing has registered yet. A strict class
+        #: that something else builds -- a leaf of the hierarchy -- is
+        #: exempt: it has to stay buildable, since being built is the
+        #: whole point of having been registered.
+        self.required = required
 
 
-def registry(cls: type, strict: bool) -> _Registry:
+def registry(cls: type) -> _Registry:
     """This class's own registry, made if it has none yet.
 
     Never an inherited one: a subclass answers for the subclasses
@@ -392,9 +423,29 @@ def registry(cls: type, strict: bool) -> _Registry:
     """
     found = cls.__dict__.get(_POLYMORPHS)
     if found is None:
-        found = _Registry(strict)
+        strict = getattr(
+            getattr(cls, _OPTIONS, None), "polymorphic", False
+        ) == "strict"
+        found = _Registry(strict, strict and _REGISTRATION not in cls.__dict__)
         setattr(cls, _POLYMORPHS, found)
     return found
+
+
+def arm(cls: type, specs: tx.Optional[tx.Tuple[_Spec, ...]]) -> None:
+    """Give a strict class the registry its own setting calls for.
+
+    It needs one before any subclass has registered, or the setting
+    would do nothing at all until the module holding the first subclass
+    happened to be imported -- which is the very case it exists to
+    report. When the class is itself registered somewhere, its own
+    constraints are kept here too, so that building it directly with a
+    value that contradicts them can be refused.
+    """
+    found = registry(cls)
+    if specs is not None:
+        found.invariant = (
+            specs, discriminants(cls, [spec.name for spec in specs])
+        )
 
 
 def register(
@@ -402,7 +453,6 @@ def register(
     target: type,
     specs: tx.Tuple[_Spec, ...],
     priority: int,
-    strict: bool,
 ) -> None:
     """Have `owner` build `target` for the arguments `specs` describe."""
     if not (isinstance(target, type) and issubclass(target, owner)):
@@ -415,17 +465,24 @@ def register(
             f"{owner.__name__} cannot be registered against itself: it is "
             f"already what a call to it builds when nothing else matches."
         )
+    if not isinstance(priority, int) or isinstance(priority, bool):
+        raise TypeError(
+            f"the priority of {target.__name__} is {priority!r}, and a "
+            f"priority is a whole number: the subclass with the highest "
+            f"one wins when two match equally well."
+        )
     entry = _Polymorph(
         target, specs, priority, target.__mro__.index(owner)
     )
-    found = registry(owner, strict)
+    found = registry(owner)
+    entries, _ = found.dispatch
     # A class registering a second time -- a reloaded module, a
     # decorator applied twice -- replaces its entry rather than adding
     # one that would then tie with itself. Same name in the same module
     # is the same registration, whether or not it is the same object.
     same = (target.__module__, target.__qualname__)
     entries = [
-        kept for kept in found.entries
+        kept for kept in entries
         if (kept.target.__module__, kept.target.__qualname__) != same
     ]
     entries.append(entry)
@@ -434,16 +491,7 @@ def register(
         for spec in kept.specs:
             if spec.name not in names:
                 names.append(spec.name)
-    # Built whole and swapped in, so that anything reading the registry
-    # while a plugin registers reads one state or the other.
-    found.entries = tuple(entries)
-    found.discriminants = discriminants(owner, names)
-
-
-def invariant(cls: type, specs: tx.Tuple[_Spec, ...]) -> None:
-    """Keep `cls`'s own registration, to check calls to it against."""
-    found = registry(cls, True)
-    found.invariant = (specs, discriminants(cls, [s.name for s in specs]))
+    found.dispatch = (tuple(entries), discriminants(owner, names))
 
 
 # ----------------------------------------------------------------------
@@ -470,8 +518,9 @@ def select(
     """
     Which subclass of `cls` to build, or `None` to build `cls` itself.
     """
-    values = read(found.discriminants, args, kwargs)
-    candidates = [entry for entry in found.entries if entry.matches(values)]
+    entries, where = found.dispatch
+    values = read(where, args, kwargs)
+    candidates = [entry for entry in entries if entry.matches(values)]
     if not candidates:
         # An abstract class cannot stand in for the subclass that was
         # not found: falling through would raise Python's own "can't
@@ -479,20 +528,8 @@ def select(
         # being made.
         abstract = getattr(cls, "__abstractmethods__", None)
         if found.strict or abstract:
-            why = (
-                f"{cls.__name__} is abstract, so it can only be built as "
-                f"one of the subclasses registered with it"
-                if abstract else
-                f"{cls.__name__} only builds one of the subclasses "
-                f"registered with it"
-            )
-            considered = "\n".join(f"  - {entry}" for entry in found.entries)
-            raise NoPolymorphError(
-                f"{why}, and none of them matches {_written(values)}. It "
-                f"considered:\n{considered}\nIf the one you expected is "
-                f"not in that list, the module it is written in has not "
-                f"been imported."
-            )
+            raise NoPolymorphError(_nothing_matched(cls, entries, values,
+                                                    bool(abstract)))
         return None
     best = max(candidates, key=lambda entry: entry.rank)
     tied = [
@@ -512,6 +549,34 @@ def select(
             f"priority=1)`."
         )
     return best.target
+
+
+def _nothing_matched(
+    cls: type,
+    entries: tx.Tuple[_Polymorph, ...],
+    values: tx.Mapping[str, tx.Any],
+    abstract: bool,
+) -> str:
+    why = (
+        f"{cls.__name__} is abstract, so it can only be built as one of "
+        f"the subclasses registered with it"
+        if abstract else
+        f"{cls.__name__} only builds one of the subclasses registered "
+        f"with it"
+    )
+    if not entries:
+        # Nothing has registered, so there are no constrained fields
+        # and nothing to say about the arguments.
+        return (
+            f"{why}, and none has yet: the module holding the subclass "
+            f"you expect has not been imported."
+        )
+    considered = "\n".join(f"  - {entry}" for entry in entries)
+    return (
+        f"{why}, and none of them matches {_written(values)}. It "
+        f"considered:\n{considered}\nIf the one you expected is not in "
+        f"that list, the module it is written in has not been imported."
+    )
 
 
 def check(

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -26,6 +26,7 @@ SOURCES = [
     "_fields.py",
     "_magic.py",
     "_options.py",
+    "_polymorph.py",
 ]
 
 #: Hand-written pages, relative to the repository root.

--- a/tests/test_polymorphism.py
+++ b/tests/test_polymorphism.py
@@ -1,0 +1,830 @@
+"""Building one class and getting back one of its subclasses.
+
+A `polymorphic` class chooses which of its subclasses to build from the
+arguments it was given. What is worth testing is less the happy path
+than the four places this kind of feature usually goes wrong: an answer
+that depends on import order, an argument read out of the wrong slot,
+a hierarchy more than two deep, and a copy that quietly rebuilds
+something else.
+"""
+
+# stdlib
+import copy
+import pickle
+import re
+from abc import abstractmethod
+from inspect import signature
+
+# dependencies
+import pytest
+import typing_extensions as tx
+from bagof.converters.exceptions import ConversionError
+
+# locals
+from bagof.magic import (
+    AmbiguousPolymorphError,
+    ClassVar,
+    ConvertTo,
+    Factory,
+    KwOnly,
+    Magic,
+    NoInit,
+    NoPolymorphError,
+    PolymorphError,
+    asdict,
+    magic,
+    replace,
+)
+
+# ======================================================================
+# Classes at module level, for the copies -- pickle can only find a
+# class that lives somewhere it can be named.
+# ======================================================================
+
+
+class Chord(Magic, polymorphic=True):
+    root: str
+    mode: str = "major"
+
+
+class MinorChord(Chord, on={"mode": "minor"}):
+    pass
+
+
+class HarmonicMinor(MinorChord, on={"root": "A"}):
+    pass
+
+
+# ======================================================================
+# The basics
+# ======================================================================
+
+
+class TestDispatch:
+
+    def test_a_matching_subclass_is_built(self) -> None:
+        chord = Chord(root="C", mode="minor")
+        assert type(chord) is MinorChord
+        assert chord.mode == "minor" and chord.root == "C"
+
+    def test_nothing_matching_builds_the_class_itself(self) -> None:
+        assert type(Chord(root="C", mode="lydian")) is Chord
+
+    def test_a_class_with_no_registrations_is_untouched(self) -> None:
+        class Plain(Magic):
+            x: int
+
+        assert type(Plain(1)) is Plain
+
+    def test_positional_and_keyword_agree(self) -> None:
+        # The whole feature only half-exists if the two spellings of one
+        # call build different classes.
+        assert type(Chord("C", "minor")) is type(Chord(root="C", mode="minor"))
+
+    def test_a_subclass_called_directly_does_not_dispatch_upward(
+        self
+    ) -> None:
+        # Calling the subclass is the escape hatch, so it needs no flag.
+        assert type(MinorChord(root="C")) is MinorChord
+
+    def test_a_subclass_that_registers_nothing_is_no_candidate(self) -> None:
+        class Ninth(MinorChord):
+            pass
+
+        assert type(Chord(root="C", mode="minor")) is not Ninth
+
+    def test_the_signature_is_still_the_constructors(self) -> None:
+        # Dispatch happens in the metaclass, which is where `inspect`
+        # looks first; the answer must still be about the class.
+        assert list(signature(Chord).parameters) == ["root", "mode"]
+
+
+# ======================================================================
+# What a constraint may be
+# ======================================================================
+
+
+class TestConstraints:
+
+    @pytest.fixture
+    def base(self) -> type:
+        class Value(Magic, polymorphic=True):
+            v: tx.Any = None
+            w: int = 0
+
+        return Value
+
+    def test_an_exact_value(self, base: type) -> None:
+        class One(base, on={"v": 1}):
+            pass
+
+        assert type(base(v=1)) is One
+        assert type(base(v=2)) is base
+
+    def test_a_set_of_values(self, base: type) -> None:
+        class Vowel(base, on={"v": {"a", "e"}}):
+            pass
+
+        assert type(base(v="a")) is Vowel
+        assert type(base(v="z")) is base
+
+    def test_a_regular_expression(self, base: type) -> None:
+        class Word(base, on={"v": re.compile(r"[a-z]+")}):
+            pass
+
+        assert type(base(v="abc")) is Word
+        # `fullmatch`, so a prefix is not enough.
+        assert type(base(v="abc1")) is base
+
+    def test_a_type(self, base: type) -> None:
+        class Whole(base, on={"v": int}):
+            pass
+
+        assert type(base(v=3)) is Whole
+        assert type(base(v="3")) is base
+
+    def test_a_typing_form(self, base: type) -> None:
+        class Named(base, on={"v": tx.Literal["a", "b"]}):
+            pass
+
+        assert type(base(v="b")) is Named
+        assert type(base(v="c")) is base
+
+    def test_a_callable(self, base: type) -> None:
+        class Big(base, on={"v": lambda v: v > 3}):
+            pass
+
+        assert type(base(v=4)) is Big
+        assert type(base(v=2)) is base
+
+    def test_presence(self, base: type) -> None:
+        class Given(base, on={"v": ...}):
+            pass
+
+        # `v` defaults to None, so it is always there to be matched.
+        assert type(base()) is Given
+
+    def test_a_field_with_nothing_to_read_is_absent(self) -> None:
+        class Maybe(Magic, polymorphic=True):
+            a: int = 0
+            b: NoInit[tx.Any]
+
+        class Wanted(Maybe, on={"b": ...}):
+            pass
+
+        # `b` is no argument and has no default, so there is nothing to
+        # read and nothing to match.
+        assert type(Maybe()) is Maybe
+
+    def test_every_constraint_must_match(self, base: type) -> None:
+        class Both(base, on={"v": int, "w": 2}):
+            pass
+
+        assert type(base(v=1)) is base
+        assert type(base(v=1, w=2)) is Both
+
+    def test_a_name_that_is_no_field_is_refused_when_written(
+        self, base: type
+    ) -> None:
+        with pytest.raises(TypeError, match="not a field of"):
+            class Typo(base, on={"vv": 1}):
+                pass
+
+    def test_on_must_be_a_mapping(self, base: type) -> None:
+        with pytest.raises(TypeError, match="takes a mapping"):
+            class Wrong(base, on=["v"]):
+                pass
+
+
+# ======================================================================
+# Choosing between candidates
+# ======================================================================
+
+
+class TestRanking:
+
+    @pytest.fixture
+    def base(self) -> type:
+        class Tone(Magic, polymorphic=True):
+            a: str = "a"
+            b: str = "b"
+
+        return Tone
+
+    def test_more_constrained_fields_wins(self, base: type) -> None:
+        class One(base, on={"a": "x"}):
+            pass
+
+        class Two(base, on={"a": "x", "b": "y"}):
+            pass
+
+        assert type(base(a="x", b="y")) is Two
+        assert type(base(a="x", b="z")) is One
+
+    def test_a_more_precise_constraint_wins(self, base: type) -> None:
+        class Loose(base, on={"a": str}):
+            pass
+
+        class Tight(base, on={"a": "x"}):
+            pass
+
+        assert type(base(a="x")) is Tight
+        assert type(base(a="q")) is Loose
+
+    def test_a_deeper_subclass_wins(self, base: type) -> None:
+        class Outer(base, on={"a": "x"}):
+            pass
+
+        class Inner(Outer):
+            pass
+
+        base.register_polymorph(Inner, a="x")
+        assert type(base(a="x")) is Inner
+
+    def test_priority_beats_everything(self, base: type) -> None:
+        class Careful(base, on={"a": "x", "b": "y"}):
+            pass
+
+        class Insistent(base, on={"a": "x"}, priority=1):
+            pass
+
+        assert type(base(a="x", b="y")) is Insistent
+
+    def test_an_unconstrained_registration_is_a_fallback(
+        self, base: type
+    ) -> None:
+        class Special(base, on={"a": "x"}):
+            pass
+
+        class Anything(base, on={}, priority=-1):
+            pass
+
+        assert type(base(a="x")) is Special
+        assert type(base(a="q")) is Anything
+
+    def test_a_tie_is_refused_by_name(self, base: type) -> None:
+        class Left(base, on={"a": "x"}):
+            pass
+
+        class Right(base, on={"a": "x"}):
+            pass
+
+        with pytest.raises(AmbiguousPolymorphError) as raised:
+            base(a="x")
+        message = str(raised.value)
+        assert "Left" in message and "Right" in message
+        assert "a='x'" in message
+
+    def test_priority_settles_a_tie(self, base: type) -> None:
+        class Left(base, on={"a": "x"}):
+            pass
+
+        class Right(base, on={"a": "x"}, priority=1):
+            pass
+
+        assert type(base(a="x")) is Right
+
+    def test_priority_without_on_is_refused(self, base: type) -> None:
+        with pytest.raises(TypeError, match="priority= without on="):
+            class Lost(base, priority=1):
+                pass
+
+
+# ======================================================================
+# Where the value is read from
+# ======================================================================
+
+
+class TestReadingTheArguments:
+
+    def test_a_default_counts_as_a_supplied_value(self) -> None:
+        # Otherwise `Chord(root="A")` and `Chord(root="A",
+        # mode="major")` would build different classes.
+        class Tune(Magic, polymorphic=True):
+            root: str
+            mode: str = "major"
+
+        class Major(Tune, on={"mode": "major"}):
+            pass
+
+        assert type(Tune(root="A")) is Major
+        assert type(Tune(root="A", mode="major")) is Major
+
+    def test_a_factory_default_is_read_as_absent(self) -> None:
+        # Building it here would build it twice, once to look at and
+        # once to keep.
+        class Bag(Magic, polymorphic=True):
+            items: Factory[list]
+
+        class Empty(Bag, on={"items": ...}):
+            pass
+
+        assert type(Bag()) is Bag
+        assert type(Bag(items=[])) is Empty
+
+    def test_a_keyword_only_field_is_never_read_out_of_args(self) -> None:
+        class Mixed(Magic, polymorphic=True):
+            first: str = ""
+            second: KwOnly[str] = ""
+
+        class Second(Mixed, on={"second": "x"}):
+            pass
+
+        # "x" arrives as `first`; reading `second` by position would
+        # find it there and dispatch on a neighbour's value.
+        assert type(Mixed("x")) is Mixed
+        assert type(Mixed(second="x")) is Second
+
+    def test_a_positional_only_field_is_never_read_out_of_kwargs(
+        self
+    ) -> None:
+        class Fixed(Magic, polymorphic=True, positional_only=True):
+            first: str = ""
+
+        class First(Fixed, on={"first": "x"}):
+            pass
+
+        assert type(Fixed("x")) is First
+
+    def test_a_hand_written_init_dispatches_by_keyword(self) -> None:
+        class Free(Magic, polymorphic=True, init=False):
+            kind: str = ""
+
+            def __init__(self, *args: tx.Any, **kwargs: tx.Any) -> None:
+                self.__magic_init__(*args, **kwargs)
+
+        class Known(Free, on={"kind": "k"}):
+            pass
+
+        # Nothing can be read out of `args`: the order is whatever the
+        # hand-written signature says.
+        assert type(Free(kind="k")) is Known
+
+    def test_the_converter_runs_before_matching(self) -> None:
+        class Counted(Magic, polymorphic=True):
+            n: ConvertTo[int] = 0
+
+        class Three(Counted, on={"n": 3}):
+            pass
+
+        assert type(Counted(n="3")) is Three
+
+    def test_a_value_the_converter_refuses_is_left_to_init(self) -> None:
+        class Counted(Magic, polymorphic=True):
+            n: ConvertTo[int] = 0
+
+        class Three(Counted, on={"n": 3}):
+            pass
+
+        with pytest.raises(ConversionError, match="Counted.n"):
+            Counted(n="three")
+
+    def test_an_alias_is_read_under_the_name_the_caller_types(self) -> None:
+        class Aliased(Magic, polymorphic=True):
+            _mode: str = "major"
+
+        class Minor(Aliased, on={"_mode": "minor"}):
+            pass
+
+        # `on=` names the field as the class declares it; the argument
+        # arrives under the public name.
+        assert type(Aliased(mode="minor")) is Minor
+
+
+# ======================================================================
+# More than one level
+# ======================================================================
+
+
+class TestNarrowing:
+
+    def test_a_grandchild_is_reached_in_two_hops(self) -> None:
+        assert type(Chord(root="A", mode="minor")) is HarmonicMinor
+
+    def test_each_level_must_match_in_turn(self) -> None:
+        # `HarmonicMinor` is unreachable without satisfying
+        # `MinorChord` first, whatever its own constraint says.
+        assert type(Chord(root="A")) is Chord
+
+    def test_a_grandchild_called_directly_still_works(self) -> None:
+        assert type(HarmonicMinor(root="A")) is HarmonicMinor
+
+
+# ======================================================================
+# strict
+# ======================================================================
+
+
+class TestStrict:
+
+    @pytest.fixture
+    def base(self) -> type:
+        class Strict(Magic, polymorphic="strict"):
+            kind: str = ""
+
+        return Strict
+
+    def test_nothing_matching_is_refused(self, base: type) -> None:
+        class Known(base, on={"kind": "k"}):
+            pass
+
+        with pytest.raises(NoPolymorphError) as raised:
+            base(kind="q")
+        message = str(raised.value)
+        assert "Known(kind='k')" in message
+        assert "has not been imported" in message
+
+    def test_a_leaf_with_no_registrations_still_builds(
+        self, base: type
+    ) -> None:
+        # Options are inherited, so every subclass is strict too. If
+        # that meant "never build me", the leaves would be unusable.
+        class Known(base, on={"kind": "k"}):
+            pass
+
+        assert type(Known(kind="k")) is Known
+
+    def test_a_contradicting_value_is_refused(self, base: type) -> None:
+        class Known(base, on={"kind": "k"}):
+            pass
+
+        with pytest.raises(PolymorphError, match="contradicts"):
+            Known(kind="q")
+
+    def test_a_contradiction_is_allowed_when_not_strict(self) -> None:
+        class Loose(Magic, polymorphic=True):
+            kind: str = ""
+
+        class Known(Loose, on={"kind": "k"}):
+            pass
+
+        assert Known(kind="q").kind == "q"
+
+    def test_an_unconstrained_field_is_not_contradicted(
+        self, base: type
+    ) -> None:
+        class Ranged(base, on={"kind": {"k", "l"}}):
+            pass
+
+        assert Ranged(kind="l").kind == "l"
+
+
+# ======================================================================
+# An abstract base
+# ======================================================================
+
+
+class TestAbstractBase:
+
+    @pytest.fixture
+    def base(self) -> type:
+        class Shape(Magic, polymorphic=True):
+            kind: str = ""
+
+            @abstractmethod
+            def area(self) -> int:
+                ...
+
+        return Shape
+
+    def test_it_builds_a_concrete_subclass(self, base: type) -> None:
+        class Square(base, on={"kind": "square"}):
+            def area(self) -> int:
+                return 1
+
+        assert base(kind="square").area() == 1
+
+    def test_nothing_matching_says_so(self, base: type) -> None:
+        class Square(base, on={"kind": "square"}):
+            def area(self) -> int:
+                return 1
+
+        with pytest.raises(NoPolymorphError, match="is abstract"):
+            base(kind="circle")
+
+
+# ======================================================================
+# Registering by hand
+# ======================================================================
+
+
+class TestRegisterPolymorph:
+
+    @pytest.fixture
+    def base(self) -> type:
+        class Root(Magic, polymorphic=True):
+            kind: str = ""
+
+        return Root
+
+    def test_a_class_can_be_registered_afterwards(self, base: type) -> None:
+        class Later(base):
+            pass
+
+        assert base.register_polymorph(Later, kind="k") is Later
+        assert type(base(kind="k")) is Later
+
+    def test_on_and_keywords_say_the_same_thing(self, base: type) -> None:
+        class Later(base):
+            pass
+
+        base.register_polymorph(Later, on={"kind": "k"}, priority=2)
+        assert type(base(kind="k")) is Later
+
+    def test_registering_again_replaces_rather_than_duplicates(
+        self, base: type
+    ) -> None:
+        class Later(base):
+            pass
+
+        base.register_polymorph(Later, kind="k")
+        base.register_polymorph(Later, kind="k")
+        # A duplicate entry would tie with itself.
+        assert type(base(kind="k")) is Later
+
+    def test_a_class_cannot_register_against_itself(self, base: type) -> None:
+        with pytest.raises(TypeError, match="against itself"):
+            base.register_polymorph(base, kind="k")
+
+    def test_only_a_subclass_can_be_registered(self, base: type) -> None:
+        class Stranger(Magic):
+            kind: str = ""
+
+        with pytest.raises(TypeError, match="only build its own subclasses"):
+            base.register_polymorph(Stranger, kind="k")
+
+    def test_a_cycle_cannot_be_built(self, base: type) -> None:
+        # Only strict subclasses can be registered, so delegation always
+        # goes down the hierarchy and cannot come back around.
+        class Middle(base, on={"kind": "k"}):
+            pass
+
+        class Leaf(Middle, on={"kind": "k"}):
+            pass
+
+        with pytest.raises(TypeError, match="only build its own subclasses"):
+            Leaf.register_polymorph(base, kind="k")
+        assert type(base(kind="k")) is Leaf
+
+    def test_a_class_that_does_not_dispatch_refuses(self) -> None:
+        class Plain(Magic):
+            kind: str = ""
+
+        class Sub(Plain):
+            pass
+
+        with pytest.raises(TypeError, match="does not build its subclasses"):
+            Plain.register_polymorph(Sub, kind="k")
+
+    def test_on_without_a_polymorphic_base_is_refused(self) -> None:
+        class Plain(Magic):
+            kind: str = ""
+
+        with pytest.raises(TypeError, match="none of the classes"):
+            class Sub(Plain, on={"kind": "k"}):
+                pass
+
+
+# ======================================================================
+# The discriminant field on the subclass
+# ======================================================================
+
+
+class TestPinDiscriminant:
+
+    @pytest.fixture
+    def base(self) -> type:
+        class Tune(Magic, polymorphic=True):
+            root: str
+            mode: str = "major"
+
+        return Tune
+
+    def test_pin_gives_the_field_the_matched_value(self, base: type) -> None:
+        class Minor(base, on={"mode": "minor"}):
+            pass
+
+        assert Minor(root="A").mode == "minor"
+        assert asdict(Minor(root="A")) == {"root": "A", "mode": "minor"}
+
+    def test_pin_leaves_a_field_the_subclass_writes_alone(
+        self, base: type
+    ) -> None:
+        class Minor(base, on={"mode": "minor"}):
+            mode: str = "dorian"
+
+        assert Minor(root="A").mode == "dorian"
+
+    def test_pin_only_applies_to_a_single_exact_value(
+        self, base: type
+    ) -> None:
+        class Modal(base, on={"mode": {"dorian", "lydian"}}):
+            pass
+
+        assert Modal(root="A").mode == "major"
+
+    def test_classvar_stores_nothing_per_instance(self, base: type) -> None:
+        class Sus(base, on={"mode": "sus"}, pin_discriminant="classvar"):
+            pass
+
+        assert Sus.mode == "sus"
+        assert asdict(Sus(root="A")) == {"root": "A"}
+        assert repr(Sus(root="A")) == "Sus(root='A')"
+
+    def test_classvar_still_accepts_the_argument(self, base: type) -> None:
+        class Sus(base, on={"mode": "sus"}, pin_discriminant="classvar"):
+            pass
+
+        # Both the delegated call and the direct one pass `mode`, so
+        # neither may be refused.
+        assert type(base(root="A", mode="sus")) is Sus
+        assert Sus(root="A", mode="sus").mode == "sus"
+
+    def test_keep_leaves_the_field_as_it_was(self, base: type) -> None:
+        class Minor(base, on={"mode": "minor"}, pin_discriminant="keep"):
+            pass
+
+        assert Minor(root="A").mode == "major"
+
+    def test_a_pin_can_be_taken_back_by_redeclaring_the_field(
+        self, base: type
+    ) -> None:
+        class Minor(base, on={"mode": "minor"}):
+            pass
+
+        class Stricter(Minor):
+            mode: str
+
+        with pytest.raises(TypeError, match="missing"):
+            Stricter(root="A")
+
+    def test_a_declared_classvar_is_left_alone(self, base: type) -> None:
+        class Minor(base, on={"mode": "minor"}):
+            mode: ClassVar[str] = "minor"
+
+        assert Minor.mode == "minor"
+        assert asdict(Minor(root="A")) == {"root": "A"}
+
+
+class TestPinnedSignature:
+    """A pinned default can leave a required parameter behind it.
+
+    Python cannot spell `f(mode="minor", root)`, so the parameters after
+    a pinned one are given a sentinel and the body turns a sentinel that
+    is still there back into the usual complaint.
+    """
+
+    @pytest.fixture
+    def base(self) -> type:
+        class Tune(Magic, polymorphic=True):
+            mode: str
+            root: str
+
+        return Tune
+
+    def test_the_class_can_still_be_built(self, base: type) -> None:
+        class Minor(base, on={"mode": "minor"}):
+            pass
+
+        assert Minor(root="A").root == "A"
+        assert Minor("minor", "A").root == "A"
+
+    def test_the_missing_argument_is_named(self, base: type) -> None:
+        class Minor(base, on={"mode": "minor"}):
+            pass
+
+        with pytest.raises(
+            TypeError, match="missing a required argument: 'root'"
+        ):
+            Minor()
+
+    def test_a_pin_inherited_from_a_base_still_counts(
+        self, base: type
+    ) -> None:
+        class Minor(base, on={"mode": "minor"}):
+            pass
+
+        class Harmonic(Minor, on={"root": "A"}):
+            pass
+
+        assert type(base(mode="minor", root="A")) is Harmonic
+
+    def test_two_hand_written_fields_are_still_refused(self) -> None:
+        # Nothing here was pinned, so the class is refused as before.
+        class First(Magic, polymorphic=True):
+            a: int = 0
+
+        with pytest.raises(SyntaxError, match="without a default"):
+            class Second(First):
+                b: int
+
+
+# ======================================================================
+# Copies
+# ======================================================================
+
+
+class TestCopies:
+    """A copy rebuilds the class it already is, without dispatching."""
+
+    @pytest.mark.parametrize(
+        "duplicate",
+        [
+            lambda obj: pickle.loads(pickle.dumps(obj)),
+            copy.copy,
+            copy.deepcopy,
+        ],
+        ids=["pickle", "copy", "deepcopy"],
+    )
+    def test_a_dispatched_instance_survives(self, duplicate: object) -> None:
+        chord = Chord(root="C", mode="minor")
+        assert type(chord) is MinorChord
+        again = duplicate(chord)
+        assert type(again) is MinorChord
+        assert again == chord
+
+    def test_a_copy_does_not_re_dispatch(self) -> None:
+        # Registering later only changes what is built later, and a
+        # copy is not a construction.
+        class Tune(Magic, polymorphic=True):
+            mode: str = "major"
+
+        plain = Tune(mode="lydian")
+        assert type(plain) is Tune
+
+        class Lydian(Tune, on={"mode": "lydian"}):
+            pass
+
+        assert type(copy.copy(plain)) is Tune
+        assert type(copy.deepcopy(plain)) is Tune
+        assert type(Tune(mode="lydian")) is Lydian
+
+
+# ======================================================================
+# The options themselves
+# ======================================================================
+
+
+class TestOptions:
+
+    def test_polymorphic_takes_three_values(self) -> None:
+        with pytest.raises(ValueError, match="polymorphic must be"):
+            class Wrong(Magic, polymorphic="yes"):
+                pass
+
+    def test_pin_discriminant_takes_three_values(self) -> None:
+        with pytest.raises(ValueError, match="pin_discriminant must be"):
+            class Wrong(Magic, pin_discriminant="maybe"):
+                pass
+
+    def test_the_decorator_can_ask_for_it(self) -> None:
+        @magic(polymorphic=True)
+        class Root:
+            kind: str = ""
+
+        class Leaf(Root, on={"kind": "k"}):
+            pass
+
+        assert type(Root(kind="k")) is Leaf
+
+    def test_the_decorator_cannot_register(self) -> None:
+        # A class that inherits from a Magic class has already been
+        # built, so `on=` belongs on the class statement.
+        @magic(polymorphic=True)
+        class Root:
+            kind: str = ""
+
+        with pytest.raises(TypeError, match="already a Magic class"):
+            @magic(on={"kind": "k"})
+            class Leaf(Root):
+                pass
+
+    def test_replace_rebuilds_through_the_class_it_has(self) -> None:
+        # `replace` calls the class the instance already has, so a
+        # change can narrow it further -- but an instance that is
+        # already a subclass never goes back up to try a sibling.
+        class Tune(Magic, polymorphic=True, frozen=True, slots=True):
+            root: str
+            mode: str = "major"
+
+        class Minor(Tune, on={"mode": "minor"}):
+            pass
+
+        class Modal(Tune, on={"mode": "dorian"}):
+            pass
+
+        assert type(replace(Tune(root="A"), mode="minor")) is Minor
+        assert type(replace(Minor(root="A"), mode="dorian")) is Minor
+        assert replace(Minor(root="A"), root="B").root == "B"
+
+    def test_the_setting_is_inherited(self) -> None:
+        class Root(Magic, polymorphic=True):
+            kind: str = ""
+
+        class Middle(Root, on={"kind": "k"}):
+            pass
+
+        class Leaf(Middle, on={"kind": "k"}):
+            pass
+
+        assert type(Root(kind="k")) is Leaf

--- a/tests/test_polymorphism.py
+++ b/tests/test_polymorphism.py
@@ -564,6 +564,9 @@ class TestAbstractBase:
             def area(self) -> int:
                 return 1
 
+        # The registration itself is sound -- "circle" is refused for
+        # matching nothing, not because there was nothing to match.
+        assert base(kind="square").area() == 1
         with pytest.raises(NoPolymorphError, match="is abstract"):
             base(kind="circle")
 
@@ -884,7 +887,7 @@ class TestPinningAndSkippedDefaults:
         # Python reports too few arguments before the body runs at all,
         # so a factory that would fail must not get to speak first.
         def explode() -> int:
-            raise RuntimeError("the factory ran")
+            raise RuntimeError("the factory ran")  # pragma: no cover
 
         class Tune(Magic, polymorphic=True):
             mode: str
@@ -1023,6 +1026,10 @@ class TestIntrospection:
                 return super().__new__(cls)
 
         assert list(signature(Built).parameters) == ["a", "b"]
+        # Through `__new__` rather than `Built(1)`: with no `__init__` of
+        # its own the class inherits one that takes no arguments, so the
+        # ordinary call cannot reach the constructor being described.
+        assert isinstance(Built.__new__(Built, 1), Built)
 
 
 # ======================================================================

--- a/tests/test_polymorphism.py
+++ b/tests/test_polymorphism.py
@@ -13,7 +13,7 @@ import copy
 import pickle
 import re
 from abc import abstractmethod
-from inspect import signature
+from inspect import Parameter, Signature, signature
 
 # dependencies
 import pytest
@@ -28,6 +28,7 @@ from bagof.magic import (
     Factory,
     KwOnly,
     Magic,
+    MetaMagic,
     NoInit,
     NoPolymorphError,
     PolymorphError,
@@ -231,6 +232,18 @@ class TestRanking:
         assert type(base(a="x")) is Tight
         assert type(base(a="q")) is Loose
 
+    def test_more_fields_beats_more_precision(self, base: type) -> None:
+        # Two constraints worth 3 between them beat one worth 4: how
+        # many fields the claim covers is read before how narrow they
+        # are, and the two must not be weighed together.
+        class Broad(base, on={"a": {"x", "y"}, "b": ...}):
+            pass
+
+        class Sharp(base, on={"a": "x"}):
+            pass
+
+        assert type(base(a="x", b="b")) is Broad
+
     def test_a_deeper_subclass_wins(self, base: type) -> None:
         class Outer(base, on={"a": "x"}):
             pass
@@ -283,6 +296,13 @@ class TestRanking:
             pass
 
         assert type(base(a="x")) is Right
+
+    def test_a_priority_that_is_not_a_number_is_refused(
+        self, base: type
+    ) -> None:
+        with pytest.raises(TypeError, match="a priority is a whole number"):
+            class Wrong(base, on={"a": "x"}, priority="high"):
+                pass
 
     def test_priority_without_on_is_refused(self, base: type) -> None:
         with pytest.raises(TypeError, match="priority= without on="):
@@ -345,6 +365,41 @@ class TestReadingTheArguments:
             pass
 
         assert type(Fixed("x")) is First
+
+    def test_a_positional_only_value_is_not_looked_for_by_name(
+        self
+    ) -> None:
+        # `first` cannot be passed by name at all, so a keyword of that
+        # name is not its value and must not be read as one.
+        class Fixed(Magic, polymorphic="strict", positional_only=True):
+            first: str = ""
+
+        class First(Fixed, on={"first": "x"}):
+            pass
+
+        assert type(Fixed("x")) is First
+        with pytest.raises(NoPolymorphError):
+            Fixed(first="x")
+
+    def test_a_value_that_cannot_be_compared_does_not_match(self) -> None:
+        class Awkward:
+            def __eq__(self, other: tx.Any) -> bool:
+                raise RuntimeError("no")
+
+            __hash__ = None
+
+        class Held(Magic, polymorphic=True):
+            v: tx.Any = None
+
+        class One(Held, on={"v": 1}):
+            pass
+
+        class Some(Held, on={"v": {1, 2}}):
+            pass
+
+        # Neither constraint can look at it, and neither may let its
+        # own failure out of the constructor.
+        assert type(Held(v=Awkward())) is Held
 
     def test_a_hand_written_init_dispatches_by_keyword(self) -> None:
         class Free(Magic, polymorphic=True, init=False):
@@ -443,6 +498,16 @@ class TestStrict:
             pass
 
         assert type(Known(kind="k")) is Known
+
+    def test_a_root_with_nothing_registered_is_refused(self) -> None:
+        # The case the setting exists for: the module holding the
+        # subclass has not been imported. Building a plain one silently
+        # would be exactly the failure it is meant to report.
+        class Alone(Magic, polymorphic="strict"):
+            kind: str = ""
+
+        with pytest.raises(NoPolymorphError, match="has not been imported"):
+            Alone(kind="k")
 
     def test_a_contradicting_value_is_refused(self, base: type) -> None:
         class Known(base, on={"kind": "k"}):
@@ -658,12 +723,48 @@ class TestPinDiscriminant:
         with pytest.raises(TypeError, match="missing"):
             Stricter(root="A")
 
-    def test_a_declared_classvar_is_left_alone(self, base: type) -> None:
-        class Minor(base, on={"mode": "minor"}):
+    def test_a_hand_written_classvar_discriminant_is_refused(
+        self, base: type
+    ) -> None:
+        # The base passes `mode` straight through, so a subclass whose
+        # constructor does not take it could only be reached by a call
+        # that then fails inside the delegation.
+        with pytest.raises(TypeError, match="pin_discriminant='classvar'"):
+            class Minor(base, on={"mode": "minor"}):
+                mode: ClassVar[str] = "minor"
+
+    def test_a_discriminant_the_base_does_not_take_either_is_fine(
+        self
+    ) -> None:
+        # Nothing can pass it on, so nothing can fail on it.
+        class Tune(Magic, polymorphic=True):
+            root: str = ""
+            mode: NoInit[str] = "major"
+
+        class Minor(Tune, on={"mode": "minor"}):
             mode: ClassVar[str] = "minor"
 
         assert Minor.mode == "minor"
-        assert asdict(Minor(root="A")) == {"root": "A"}
+
+    def test_a_pinned_mutable_default_is_not_shared(self) -> None:
+        class Tune(Magic, polymorphic=True):
+            cfg: dict = None
+
+        class Tagged(Tune, on={"cfg": {"a": 1}}):
+            pass
+
+        first, second = Tagged(), Tagged()
+        assert first.cfg == {"a": 1} and first.cfg is not second.cfg
+        first.cfg["b"] = 2
+        assert Tagged().cfg == {"a": 1}
+
+    def test_a_pinned_mutable_default_obeys_the_class_setting(self) -> None:
+        class Tune(Magic, polymorphic=True, mutable_default="raise"):
+            cfg: dict = None
+
+        with pytest.raises(ValueError, match="shared by every instance"):
+            class Tagged(Tune, on={"cfg": {"a": 1}}):
+                pass
 
 
 class TestPinnedSignature:
@@ -717,6 +818,71 @@ class TestPinnedSignature:
         with pytest.raises(SyntaxError, match="without a default"):
             class Second(First):
                 b: int
+
+
+# ======================================================================
+# What the outside world sees
+# ======================================================================
+
+
+class TestIntrospection:
+
+    def test_only_a_polymorphic_class_pays_for_dispatch(self) -> None:
+        # Choosing a subclass has to happen in a metaclass `__call__`,
+        # and having one costs every instantiation of every class that
+        # metaclass builds. So a class that never asked for it keeps
+        # the metaclass -- and the interpreter's own fast path -- that
+        # it had before the feature existed.
+        class Plain(Magic):
+            x: int = 0
+
+        class Root(Magic, polymorphic=True):
+            x: int = 0
+
+        class Leaf(Root):
+            pass
+
+        assert type(Plain) is MetaMagic
+        assert type(Root) is not MetaMagic
+        assert issubclass(type(Root), MetaMagic)
+        # One metaclass for the whole hierarchy, not one per class.
+        assert type(Leaf) is type(Root)
+
+    def test_a_pinned_parameter_leaves_the_next_one_required(self) -> None:
+        class Tune(Magic, polymorphic=True):
+            mode: str
+            root: str
+
+        class Minor(Tune, on={"mode": "minor"}):
+            pass
+
+        found = signature(Minor)
+        assert found.parameters["mode"].default == "minor"
+        # It carries a sentinel so that the generated code can tell it
+        # was not passed -- but nothing reading the signature should
+        # ever see one, or `root` would look optional.
+        assert found.parameters["root"].default is Parameter.empty
+        with pytest.raises(TypeError, match="missing a required argument"):
+            found.bind()
+        assert found.bind(root="A").arguments == {"root": "A"}
+
+    def test_a_signature_written_by_hand_still_wins(self) -> None:
+        written = Signature(
+            [Parameter("raw", Parameter.POSITIONAL_OR_KEYWORD)]
+        )
+
+        class Hand(Magic):
+            x: int = 0
+            __signature__ = written
+
+        assert signature(Hand) is written
+
+    def test_a_class_that_takes_its_arguments_in_new(self) -> None:
+        class Built(Magic, init=False):
+            def __new__(cls, a: int, b: int = 2) -> "Built":
+                return super().__new__(cls)
+
+        assert list(signature(Built).parameters) == ["a", "b"]
 
 
 # ======================================================================


### PR DESCRIPTION
Closes #21. The design is the one settled on that issue and its comments.

```python
class Chord(Magic, polymorphic=True):
    mode: str
    root: str

class MinorChord(Chord, on={"mode": "minor"}): ...
class ModalChord(Chord, on={"mode": {"dorian", "lydian"}}): ...
```

```pycon
>>> Chord(mode="minor", root="A")
MinorChord(mode='minor', root='A')
>>> Chord("dorian", "C")            # positional gives the same class
ModalChord(mode='dorian', root='C')
>>> Chord("major", "G")             # nothing matches
Chord(mode='major', root='G')
```

All six constraint shapes, the agreed ranking (`priority` → constrained fields → precision → MRO depth → `AmbiguousPolymorphError`), and **registration order never decides anything**. Nothing else in the ecosystem does this: pydantic's discriminated unions only work as a field annotation inside a model, and `dataclasses`/`attrs` have no equivalent.

## It costs other classes nothing

The first attempt put `__call__` on `MetaMagic`, which replaced C-level `type.__call__` with a Python frame **for every Magic class in every `bagof-*` and `fiery-*` package**, polymorphic or not — a measured 241 → 543 ns per construction. That was not a cost to spend on everyone else's behalf.

A polymorphic class is now created with a *subclass* of whatever metaclass it would otherwise have had, built once per metaclass and shared by the hierarchy. `MetaMagic` has no `__call__`, so nothing else changes:

| | main | branch |
|---|---|---|
| `Point(1)` | 183 ns | 187 ns |

Within noise. What opting in costs: ~320 ns for a class inside the hierarchy that does not dispatch, ~1.5 µs for a dispatch that matches nothing, ~2.3 µs for one that delegates.

No metaclass conflict is possible by construction, since the generated metaclass derives from the one Python already selected — a user metaclass composes, and its `__call__` still runs, for the class actually built rather than the one that dispatched.

## The signature tells the truth

Pinning a discriminant produces a defaulted parameter followed by a required one, which Python cannot spell. Parameters after a pinned one carry a sentinel default and the body raises — but the generated function now also carries a `__signature__` with those marked `Parameter.empty`:

```
signature       (mode='minor', root)
root default    Parameter.empty
bind()          missing a required argument: 'root'
<REQUIRED> in help()   no
```

so `help()`, IDEs and anything driven off `Signature.bind` see the truth. The sentinel stays where only the generated code meets it.

A class that pins nothing was **proven** unaffected: of 508 classes built across the whole existing suite, 507 generate byte-identical `__init__` source, the one difference being a memory address inside a docstring default.

## Two `inspect.signature` regressions fixed

Adding a metaclass `__call__` made `inspect.signature(SomeMagicClass)` report `(*args, **kwargs)`, so a `__signature__` property was needed. Its first version broke two things, both now correct and byte-identical to `main`: a hand-written `__signature__` in a class body (a metaclass property is a data descriptor and was winning), and a class whose parameters come from `__new__`. The property now mirrors `inspect`'s own rule.

## Four more the review found

**A pinned mutable default was shared across instances** and bypassed `mutable_default` entirely — the exact bug that option exists to prevent. It now goes through the same handling; skipped only under `pin_discriminant="classvar"`, where the value genuinely is a class attribute.

**A hand-written `ClassVar` discriminant broke both call paths** — the snippet from #21's own comments. It is refused at build time now, naming `pin_discriminant="classvar"` as the spelling that works. Refusal over delegation-time stripping: it costs nothing at runtime and the working spelling already exists. The check only fires when the base *does* take the field, so the case where neither takes it stays legal.

**`polymorphic="strict"` was a no-op until the first subclass was imported** — the case it exists for. It is armed when the class is built, and a strict root with nothing registered says the module holding the subclass has not been imported. A class that is itself registered stays exempt, so leaves remain buildable.

**The registry was two stores** despite a comment claiming otherwise, so a construction on another thread between them got a bare `KeyError`. It is one tuple assigned once.

Plus: `priority=` is type-checked at registration, every constraint predicate is guarded so a raising `__eq__` reads as "no match", and `NoPolymorphError`'s docstring no longer claims only `strict` raises it.

## Known and accepted

`@magic(on={...})` is unsupported — a class inheriting a Magic base has already been built, so the decorator raises. `on=` works on the class statement or through `register_polymorph`. Documented as intentional.

`asdict` drops a `classvar`-pinned discriminant, so a `fromdict` round trip cannot rebuild the subclass — which is what #21's final comment decided to accept, with `pin` as the default for exactly that reason. Now a warning box in the README rather than an implication.

## Tests

`tests/test_polymorphism.py`, and every fix above was mutation-checked — reverting it in the source turns the suite red, including 46 failures for putting `__call__` back on `MetaMagic`. Both test gaps the review found are closed: the kwargs half of the keyword guard, and the ranking's count-before-precision order.

954 passed on 3.11, 3.12 and 3.13; `_polymorph.py` at 100%.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_