### PR TITLE
Say to check the neighbours before deciding a judgement call

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,6 +279,43 @@ catching it means intercepting `__call__` on the alias.
    placeholder: spell an option's accepted values in prose, not in
    numpydoc's `{"a", "b"}` notation.
 
+## When a behaviour is a judgement call, check the neighbours first
+
+`dataclasses`, `attrs` and `pydantic` have all met most of the questions
+this package meets. Before deciding one by argument, **find out what they
+actually do** — by running it, not by remembering:
+
+```sh
+python3 -m venv /tmp/priorart && /tmp/priorart/bin/pip install -q attrs pydantic
+```
+
+If two or more of them agree, follow them, and say in the commit message
+that you checked. A consensus across the three is worth more than a
+better-sounding argument, because it is what a reader arriving from any
+of them already expects — and it means a wart we share is a wart they
+have already taught people about.
+
+Where they disagree, the tie-breaker is usually *why*: `attrs` runs
+converters on defaults because you write the converter beside the
+default, while `pydantic` does not validate defaults because its
+coercion comes from the type. Ours comes from the type too, but is opt
+in — so which of them we resemble depends on the question, and that is
+the thing to work out.
+
+Two worked examples, both of which reversed a decision that had been
+argued the other way:
+
+- **Defaults are converted and validated** (#68) because `convert=True`
+  is an explicit act by the author, the same act as `converter=int`
+  beside `default="7"` in attrs. Pydantic's reason for skipping does not
+  transfer.
+- **`replace()` reconstructs through `__init__`** (#79), so a
+  non-idempotent converter sees its own output and a field derived from
+  itself compounds. `dataclasses.replace` does exactly this — the
+  standard library doubles it too — and `attrs.evolve` re-runs
+  converters the same way. Pydantic's `model_copy` differs, and gives
+  the different behaviour a different name.
+
 ## Documentation style (`README.md`, `docs/*.md`, public docstrings)
 
 Docs are for **humans who are not necessarily experts in arcane Python


### PR DESCRIPTION
A standing rule for CLAUDE.md, prompted by two decisions today that were argued one way and then reversed by finding out what the neighbours actually do.

`dataclasses`, `attrs` and `pydantic` have met most of the questions this package meets. Before deciding one by argument, find out what they do — **by running it, not by remembering**. If two or more agree, follow them, and say in the commit message that you checked.

A consensus is worth more than a better-sounding argument, because it is what a reader arriving from any of them already expects — and because a wart we share is one they have already taught people about.

Where they disagree, the tie-breaker is usually *why*. `attrs` runs converters on defaults because you write the converter beside the default; `pydantic` does not validate defaults because its coercion comes from the type. Ours comes from the type too, but is opt-in — so which of them we resemble depends on the question, and working that out is the actual job.

Both worked examples in the note reversed a decision:

**#68, defaults.** I argued attrs' justification did not transfer to us, since their converter is written on the field and ours comes from the hint. Wrong: `convert=True` is off by default, so turning it on *is* the explicit act, the same act as `converter=int` beside `default="7"`. Pydantic's reason for skipping is the one that does not transfer, because its coercion is on by virtue of being a `BaseModel`.

**#79, `replace()`.** A converter that is not idempotent sees its own output, and a field derived from itself compounds — `D(x=6)` → `replace` → `D(x=12)`. I proposed copying unchanged fields with `object.__setattr__` instead. Then:

```
attrs      : A().x = 6  | evolve(A()).x = 12          # same doubling
dataclasses: R(2,3).area = 6 | replace(r, w=4).area = 12   # __post_init__ re-runs
dataclasses: S(5).x = 50 | replace(s).x = 500         # identical to ours, in the stdlib
```

Two of the three reconstruct through `__init__`, re-run the post-init hook, and accept both consequences. The third does something different *and gives it a different name* (`model_copy`, which does not validate at all). Copying would have made us the only one of the four not to re-run `__post_init__` — a bigger divergence than the bug it fixed.

So #79 closes as working-as-intended, with a docstring saying what `replace` re-runs and the `x=500` example in it, which is what `dataclasses` does about the same wart.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_