### PR TITLE
Say that replace() runs a converter again

### DIFF
--- a/src/bagof/magic/_api.py
+++ b/src/bagof/magic/_api.py
@@ -355,6 +355,34 @@ def replace(obj: tx.Any, **changes: tx.Any) -> tx.Any:
 
         A hook that only checks its arguments, or that fills in a field
         the constructor does not take, is unaffected.
+
+    !!! warning "A converter runs again too"
+        The same applies to conversion: the values going back in have
+        already been converted once, so a converter that does not give
+        the same answer for its own output changes the value each time.
+
+        ```pycon
+        >>> def double(value):
+        ...     return value * 2
+        ...
+        >>> class Doubled(Magic):
+        ...     x: ConvertTo[int, double] = 3
+        ...
+        >>> Doubled()
+        Doubled(x=6)
+        >>> replace(Doubled())
+        Doubled(x=12)
+        ```
+
+        A converter that comes from a type hint is almost always safe
+        here -- `int("7")` and `int(7)` are both `7` -- so this is a
+        question for one you wrote yourself. `dataclasses.replace` and
+        `attrs.evolve` behave the same way, for the same reason: the
+        copy is a construction, not a copy of the bytes.
+
+        Where that matters, turn conversion off for the fields it
+        affects, or write the converter so that running it twice is the
+        same as running it once.
     """
     cls = type(obj)
     # Every field, pseudo-fields included: a change has to be turned


### PR DESCRIPTION
Closes #79.

The docstring already warned that a `__post_init__` deriving a field runs a second time. Conversion has exactly the same shape and was not mentioned:

```pycon
>>> class Doubled(Magic):
...     x: ConvertTo[int, double] = 3
>>> Doubled()
Doubled(x=6)
>>> replace(Doubled())
Doubled(x=12)
```

`replace()` with **no changes at all** does not come back equal.

## Left as behaviour, because the neighbours agree

Checked all three rather than arguing it:

```
attrs      : A().x = 6  | evolve(A()).x = 12              # converter re-runs
dataclasses: R(2,3).area = 6 | replace(r, w=4).area = 12  # __post_init__ re-runs
dataclasses: S(5).x = 50 | replace(s).x = 500             # identical to ours, in the stdlib
```

Two of the three reconstruct through `__init__` and accept both consequences; `dataclasses.replace` doubles a self-derived field exactly as we do. Pydantic differs — `model_copy(update=...)` does not validate at all — but it gives that different behaviour a different name.

Copying unchanged fields with `object.__setattr__` was considered and rejected: it would make this the only one of the four that does not re-run `__post_init__`, which is a bigger divergence than the double-conversion it fixes, and it would silently carry a stale derived value where the constructor at least recomputes.

So the docstring says what happens, names `dataclasses.replace` and `attrs.evolve` so a reader arriving from either recognises it, and says what to do about it — turn conversion off for the affected fields, or write a converter that agrees with its own output.

The example uses `ConvertTo[int, double]` rather than an `Annotated` spelling, because every `pycon` block is executed on 3.8 as well as current and `Annotated` is not in `typing` there.

893 passed; ruff and codespell clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_