### PR TITLE
Say how a frozen class fills in a derived field

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,21 @@ one:
 {'title': 'Ada', 'slug': 'ada'}
 ```
 
+On a frozen class, `__post_init__` cannot set such a field by assignment —
+refusing one after construction is what `frozen` is for. Reach past it with
+`object.__setattr__`, the same thing `dataclasses` and `attrs` ask for here:
+
+```pycon
+>>> class Slug(Magic, frozen=True):
+...     title: str
+...     slug: NoInit[str]
+...
+...     def __post_init__(self, arguments):
+...         object.__setattr__(self, "slug", self.title.lower())
+>>> Slug("Hello World")
+Slug(title='Hello World', slug='hello world')
+```
+
 **A handful of functions** that work on any Magic class, or on one of its
 instances — `Point` from the top of this page, say:
 


### PR DESCRIPTION
Closes #66, the way you called it on the issue — class authors use
`object.__setattr__`.

The issue's own complaint was that the escape hatch is not written down
anywhere, so this writes it down rather than just closing:

```pycon
>>> class Slug(Magic, frozen=True):
...     title: str
...     slug: NoInit[str]
...
...     def __post_init__(self, arguments):
...         object.__setattr__(self, "slug", self.title.lower())
>>> Slug("Hello World")
Slug(title='Hello World', slug='hello world')
```

It goes right after the passage that already explains that such a field
"holds none until something sets it" — the frozen case being exactly the one
where it is not obvious what *something* can be.

## Checked the neighbours

Your "this is also the recommendation in attrs I believe" is right, and
`dataclasses` agrees. Both refuse the plain assignment in post-init and both
take `object.__setattr__`:

| | plain `self.slug = ...` | `object.__setattr__` |
|---|---|---|
| `attrs` 26.1.0 | `FrozenInstanceError: can't set attribute` | works |
| `dataclasses` | `FrozenInstanceError: cannot assign to field 'slug'` | works |

Two of three agree, so we say the same thing rather than loosening `frozen`
to allow assignment during construction — which was the other option the
issue floated.

`tests/test_docstrings.py` executes the block, on 3.8, 3.11 and 3.14.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_