### PR TITLE
Fix _doc_type dropping a PEP 585 generic's parameter on 3.9/3.10

### DIFF
--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -1982,6 +1982,15 @@ def _doc_type(type: tx.Any) -> str:
         return type.__forward_arg__
     if isinstance(type, str):
         return type
+    # A parameterised generic (`list[str]`) must be spelled out in full, not
+    # abbreviated to the plain class it wraps. Checking this before the
+    # `builtins.type` branch matters on Python 3.9 and 3.10, where
+    # `isinstance(list[str], type)` is True (a PEP 585 quirk fixed in 3.11) —
+    # so `type.__qualname__` there would silently drop the `[str]`.
+    # `_get_origin` returns the input unchanged when it has no origin, so
+    # comparing by identity is how "this has an origin" is asked here.
+    if _get_origin(type) is not type:
+        return repr(type)
     if isinstance(type, builtins.type):
         return type.__qualname__
     return repr(type)

--- a/tests/test_annotations_as_strings.py
+++ b/tests/test_annotations_as_strings.py
@@ -17,6 +17,7 @@ instead of taking the family down with it.
 from __future__ import annotations
 
 import inspect
+import sys
 import warnings
 from typing import TYPE_CHECKING
 
@@ -238,6 +239,22 @@ class TestUnavailableTypes:
         fields = Config.__magic_fields__
         assert m._doc_type(fields["names"].type) == "list[str]"
         assert m._doc_type(fields["timeout"].type) == "int | None"
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 9),
+        reason="list[str] cannot be built at runtime before 3.9",
+    )
+    def test_a_parameterised_builtin_generic_keeps_its_parameter(
+        self
+    ) -> None:
+        # Pins `_doc_type` itself, not just a class that carries the type
+        # by name. `list[str]` is a real object here (unlike the test
+        # above, where an unavailable type falls back to text), which is
+        # what exposes the parameter Python versions disagree on: on 3.9
+        # and 3.10, `isinstance(list[str], type)` is True, so a check that
+        # asks "is this a class" before "is this a parameterised generic"
+        # takes the wrong branch and reports the type as plain `list`.
+        assert m._doc_type(list[str]) == "list[str]"
 
     def test_a_class_can_refer_to_itself(self) -> None:
         class Node(Magic):


### PR DESCRIPTION
## Summary

Closes #84.

`_doc_type` checked `isinstance(type, builtins.type)` before checking whether
the hint is a parameterised generic. On Python 3.9 and 3.10,
`isinstance(list[str], type)` is `True` — a PEP 585 quirk fixed in 3.11 — so
those two versions took the `__qualname__` branch and rendered `list[str]`
as bare `list`, silently dropping the parameter from generated docs.

The fix asks the alias question first, using the module's existing
`_get_origin` helper: it returns its input unchanged when there is no
origin, so `_get_origin(type) is not type` is true exactly when `type` is a
parameterised generic, regardless of what `isinstance` says about it on a
given version.

- `src/bagof/magic/_magic.py`: reorder the check in `_doc_type`.
- `tests/test_annotations_as_strings.py`: add a regression test that pins
  `_doc_type(list[str])` directly (guarded for pre-3.9, where `list[str]`
  can't be built at runtime at all), next to the existing test that already
  covered this indirectly through a full class build.

## Test plan

- [x] `tests/test_annotations_as_strings.py::TestUnavailableTypes::test_a_type_a_newer_python_would_be_needed_for_keeps_the_family` — the test named in the issue — fails on 3.9/3.10 before this change, passes after, on all 7 supported interpreters.
- [x] New regression test pins `_doc_type` directly.
- [x] `ruff check src tests` and `codespell src tests` clean.

Before/after, across 3.8–3.14 (`PYTHONPATH` pointed at the sibling `bagof-*` sources, via `uv run --python <ver>`):

| | 3.8 | 3.9 | 3.10 | 3.11 | 3.12 | 3.13 | 3.14 |
|---|---|---|---|---|---|---|---|
| before | pass | **fail** | **fail** | pass | pass | pass | pass |
| after | pass (1 new test skipped) | pass | pass | pass | pass | pass | pass |


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_