### PR TITLE
Run the tests when a hand-written page changes

### DIFF
--- a/.github/workflows/coverage-on-push.yaml
+++ b/.github/workflows/coverage-on-push.yaml
@@ -10,12 +10,20 @@ on:
       - tests/**
       - pyproject.toml
       - .github/workflows/test*.yaml
+      # The suite executes the examples in the hand-written pages, so a
+      # change to one of those can turn it red on its own.
+      - README.md
+      - docs/**
   pull_request:
     paths:
       - src/**
       - tests/**
       - pyproject.toml
       - .github/workflows/test*.yaml
+      # The suite executes the examples in the hand-written pages, so a
+      # change to one of those can turn it red on its own.
+      - README.md
+      - docs/**
 
 permissions:
   contents: read

--- a/.github/workflows/test-on-push.yaml
+++ b/.github/workflows/test-on-push.yaml
@@ -10,12 +10,20 @@ on:
       - tests/**
       - pyproject.toml
       - .github/workflows/test*.yaml
+      # The suite executes the examples in the hand-written pages, so a
+      # change to one of those can turn it red on its own.
+      - README.md
+      - docs/**
   pull_request:
     paths:
       - src/**
       - tests/**
       - pyproject.toml
       - .github/workflows/test*.yaml
+      # The suite executes the examples in the hand-written pages, so a
+      # change to one of those can turn it red on its own.
+      - README.md
+      - docs/**
 
 permissions:
   contents: read


### PR DESCRIPTION
The test workflows fire on `src/**`, `tests/**`, `pyproject.toml` and the
workflow files. `tests/test_docstrings.py` executes every `pycon` block in
`README.md` and `docs/comparison.md`, so a change to one of those pages can
turn the suite red on its own — and nothing runs to say so.

This is a live gap here, not a theoretical one. PR #85 changed `README.md` and
added a new `pycon` block; the only checks that ran were ruff and codespell. I
had to verify the example locally on 3.8, 3.11 and 3.14 by hand, because CI
would not have caught a broken one.

```diff
     paths:
       - src/**
       - tests/**
       - pyproject.toml
       - .github/workflows/test*.yaml
+      # The suite executes the examples in the hand-written pages, so a
+      # change to one of those can turn it red on its own.
+      - README.md
+      - docs/**
```

Applied to both `test-on-push.yaml` and `coverage-on-push.yaml`, in each of
their `push` and `pull_request` blocks. The same change is going to the other
repos, so the workflows stay identical across the org.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_