### PR TITLE
Let init=False fall back to plain Python

### DIFF
--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -847,6 +847,11 @@ _ORDER_METHODS = {
 #: ordering, no hash once `__eq__` is written, and nothing for a `case`
 #: pattern to bind.
 _NEUTRAL = {
+    # `object.__init__` rather than a do-nothing function of our own:
+    # it is the one that accepts the extra arguments when a class takes
+    # them in `__new__`, which is a large part of why anyone turns
+    # `init` off.
+    "init": object.__init__,
     "repr": object.__repr__,
     "eq": object.__eq__,
     "lt": _no_order,
@@ -1934,6 +1939,17 @@ def __pre_new__(
         if init_name and init_name not in namespace:
             namespace[init_name] = magic_init
             generated[init_name] = "init"
+
+    # `__init__` is bound above by hand rather than through `_install`,
+    # since it is compiled rather than closed over, so the part of
+    # `_install` that stands an inherited generated method down has to
+    # be spelled out here too. Without it a class that turns `init` off
+    # inherits `Magic`'s own generated `__init__`, which was made for a
+    # class with no fields and so accepts nothing but `self`.
+    for name in _inherited_generated(base_mro, "init"):
+        if name != init_name and name not in namespace:
+            namespace[name] = _NEUTRAL["init"]
+            generated[name] = "init"
 
     namespace[_GENERATED] = generated
 
@@ -3224,7 +3240,16 @@ class MetaMagic(ABCMeta):
                     # Through `getattr`, not the class dict: `__new__`
                     # is stored as a `staticmethod`, which is only
                     # callable in its own right from Python 3.10.
-                    found = signature(getattr(base, name))
+                    written = getattr(base, name)
+                    # A class that turns `init` off holds `object`'s own
+                    # `__init__`, which describes nothing. `inspect`
+                    # reads that as no constructor rather than as one
+                    # taking `(*args, **kwargs)`, and keeps looking --
+                    # so a class taking its arguments in `__new__` still
+                    # reports them.
+                    if written is getattr(object, name, None):
+                        continue
+                    found = signature(written)
                     # Not `replace`, which checks the result: a pinned
                     # discriminant makes a signature Python's own
                     # syntax cannot write, and it is already true.

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -4387,6 +4387,94 @@ class TestInitFalseIsAnEscapeHatch:
                 b: Annotated[int, Field(alias="v")]
 
 
+class TestInitFalseLeavesPlainPython:
+    """Turning `init` off must hand back what a plain class would do.
+
+    `Magic` is itself built with no fields, so its own generated
+    `__init__` accepts nothing but `self`. Inheriting that instead of
+    `object.__init__` makes some classes impossible to build at all.
+    """
+
+    def test_a_class_can_take_its_arguments_in_new(self) -> None:
+        # `object.__init__` accepts the extra arguments when `__new__`
+        # is overridden, which is most of the reason to turn `init` off.
+        class Built(Magic, init=False):
+            def __new__(cls, a: int, b: int = 2) -> "Built":
+                inst = super().__new__(cls)
+                inst.a = a
+                inst.b = b
+                return inst
+
+        assert Built(1).a == 1
+        assert Built(1, 5).b == 5
+
+    def test_the_inherited_generated_init_is_stood_down(self) -> None:
+        class Plain(Magic, init=False):
+            x: int
+
+        assert Plain.__init__ is object.__init__
+
+    def test_a_subclass_does_not_inherit_its_base_s_init(self) -> None:
+        class A(Magic):
+            x: int
+
+        class B(A, init=False):
+            y: int = 0
+
+        assert B.__init__ is object.__init__
+
+    def test_asking_for_it_under_another_name_stands_it_down_too(
+        self
+    ) -> None:
+        class Named(Magic, init="setup"):
+            x: int
+
+        assert Named.__init__ is object.__init__
+        instance = Named.__new__(Named)
+        instance.setup(3)
+        assert instance.x == 3
+
+    def test_a_hand_written_init_in_a_base_survives(self) -> None:
+        # Only what Magic generated is stood down. Anything written by
+        # hand is left exactly where it is.
+        class Base(Magic):
+            x: int
+
+            def __init__(self, raw: str) -> None:
+                self.__magic_init__(int(raw))
+
+        class Sub(Base, init=False):
+            pass
+
+        assert Sub("7").x == 7
+
+    def test_the_signature_is_the_one_plain_python_reports(self) -> None:
+        # A class holding `object.__init__` has no constructor to
+        # describe, so the arguments are whatever `__new__` takes --
+        # the same answer a class with no `Magic` in sight gives.
+        class Built(Magic, init=False):
+            def __new__(cls, a: int, b: int = 2) -> "Built":
+                return super().__new__(cls)
+
+        class Plain:
+            def __new__(cls, a: int, b: int = 2) -> "Plain":
+                return super().__new__(cls)
+
+        assert list(inspect.signature(Built).parameters) == ["a", "b"]
+        assert (
+            list(inspect.signature(Built).parameters)
+            == list(inspect.signature(Plain).parameters)
+        )
+
+    def test_the_private_init_is_still_generated(self) -> None:
+        class Plain(Magic, init=False):
+            x: int
+
+        instance = Plain.__new__(Plain)
+        instance.__magic_init__(5)
+        assert instance.x == 5
+
+
 class TestGeneratedMethodNames:
 
     def test_init_is_named_init(self) -> None:

--- a/tests/test_polymorphism.py
+++ b/tests/test_polymorphism.py
@@ -1026,10 +1026,7 @@ class TestIntrospection:
                 return super().__new__(cls)
 
         assert list(signature(Built).parameters) == ["a", "b"]
-        # Through `__new__` rather than `Built(1)`: with no `__init__` of
-        # its own the class inherits one that takes no arguments, so the
-        # ordinary call cannot reach the constructor being described.
-        assert isinstance(Built.__new__(Built, 1), Built)
+        assert isinstance(Built(1), Built)
 
 
 # ======================================================================


### PR DESCRIPTION
Closes #87.

`Magic` is built with no fields, so its generated `__init__` accepts nothing
but `self` — and every class that turned `init` off inherited that instead of
`object.__init__`:

```pycon
>>> class Built(Magic, init=False):
...     def __new__(cls, a, b=2):
...         ...
>>> Built(1)
TypeError: Magic.__init__() takes 1 positional argument but 2 were given
```

No spelling of `Built(...)` worked, and the error named a class the author
never wrote. This is the case `init=False` exists for: when `__new__` is
overridden, `object.__init__` deliberately accepts the extra arguments, which
is what lets a class take its arguments there.

## The fix is #23's, applied to the option it missed

#23 built exactly this machinery — when an option is off, stand down an
inherited **generated** method and leave anything hand-written alone — and
applied it to `eq`, `repr`, `order` and `hash`. `init` was left out because it
is bound by hand rather than through `_install` (it is compiled rather than
closed over), so the same step is now spelled out where it is bound, and
`init` joins `_NEUTRAL`.

## `__signature__` needed the other half

This is the part the existing tests caught, and it is worth flagging because
it only appears once the first half works. `__signature__` reports whichever
of `__init__` and `__new__` comes first down the chain, and a stood-down
`__init__` now sits in the class's own dict — so it started answering
`(*args, **kwargs)` for a class whose arguments are in `__new__`.

I checked what CPython does rather than deciding it. An explicit
`__init__ = object.__init__` and no `__init__` at all give the **same**
signature, on every supported version:

| | 3.8 | 3.9 | 3.10 | 3.11 | 3.12 | 3.13 | 3.14 |
|---|---|---|---|---|---|---|---|
| `__init__ = object.__init__` | `(a, b=2)` | `(a, b=2)` | `(a, b=2)` | `(a, b=2)` | `(a, b=2)` | `(a, b=2)` | `(a, b=2)` |
| no `__init__` | `(a, b=2)` | `(a, b=2)` | `(a, b=2)` | `(a, b=2)` | `(a, b=2)` | `(a, b=2)` | `(a, b=2)` |

So `object`'s own `__init__` reads as no constructor rather than one taking
anything, and the lookup keeps going. A test pins that our answer equals what
a class with no `Magic` in sight reports.

It also let me drop a workaround from #81's suite: that test reached the
constructor through `Built.__new__(Built, 1)` because the ordinary call could
not work. It can now.

## What is covered

- a class taking its arguments in `__new__` builds, and reports them
- `init=False` leaves `object.__init__`, not `Magic.__init__`
- a subclass of an ordinary Magic class does not inherit that class's `__init__`
- `init="setup"` stands `__init__` down too — asking for it under another name
  says you do not want the usual one, which is what `_install` already does
- a hand-written `__init__` in a base **survives** `init=False`
- `__magic_init__` is still generated and callable either way

## Checked

1007 tests pass on 3.8, 3.9, 3.10, 3.11, 3.12, 3.13 and 3.14; ruff and
codespell clean. Both halves were mutation-checked with `__pycache__` cleared
between runs — removing the neutralisation turns 5 tests red, removing the
signature skip turns 2 red.

## One thing this does not fix

`replace()` on an `init=False` class still fails, because it reconstructs
through `__init__` and there now isn't one. It failed before this change too
(`TypeError: Magic.__init__() got an unexpected keyword argument 'x'`); the
message is now `R() takes no arguments`, which at least names the user's own
class. #23 sketched `replace` calling `__magic_init__` directly, but that
would bypass a hand-written `__init__`, which cuts against what #79 settled —
so it is a decision rather than a tidy-up, and I have left it out and filed it
separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_