### PR TITLE
Add field(), the spelling a type checker understands

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Task(name='build', tags=['ci'], priority=2)
 ```
 
 If you are coming from `dataclasses` or `attrs`, the spelling you already
-know works too — `Field(...)` as the default value. Both produce the same
+know works too — `field(...)` as the default value. Both produce the same
 field, so use whichever reads better:
 
 === "In the annotation"
@@ -126,17 +126,24 @@ field, so use whichever reads better:
 === "As the default"
 
     ```python
-    from bagof.magic import Magic, Field
+    from bagof.magic import Magic, field
 
     class Task(Magic):
         name: str
-        tags: list = Field(factory=list)
-        token: str = Field(default="", repr=False)
+        tags: list = field(factory=list)
+        token: str = field(default="", repr=False)
     ```
 
 The annotation form composes better — several of them stack on one field
-without nesting — and the `Field(...)` form takes anything the annotations
+without nesting — and the `field(...)` form takes anything the annotations
 cannot say.
+
+`Field(...)` is the same thing spelled with a capital letter, and still
+works. Prefer the lowercase one where you have the choice: mypy reads
+`tags: list = Field(factory=list)` as assigning a `Field` to a `list` and
+objects, while `field(...)` says it produces whatever the field is
+annotated as. Inside an `Annotated`, where there is no assignment for a
+checker to object to, either reads the same.
 
 ### Conversion and validation come from the type
 

--- a/src/bagof/magic/_fields.py
+++ b/src/bagof/magic/_fields.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 __all__ = [
     "Field",
+    "field",
     "Default",
     "Factory",
     "ConvertTo",
@@ -561,6 +562,29 @@ def _stored(obj: tx.Any, field: Field) -> tx.Tuple[bool, tx.Any]:
 
 # ----------------------------------------------------------------------
 # Annotations
+def field(**kwargs: tx.Any) -> tx.Any:
+    """
+    Describe one field, for use as its default.
+
+    ```python
+    class Task(Magic):
+        name: str
+        tags: list = field(factory=list)
+        token: str = field(default="", repr=False)
+    ```
+
+    Takes exactly what `Field` takes, and does the same thing. The
+    difference is what a type checker makes of it: this says it produces
+    whatever the field is annotated as, so `tags: list = field(...)`
+    reads as a `list` with a default rather than as a `Field` assigned to
+    a `list`.
+
+    Writing `Field(...)` in that position still works, and still builds
+    the same object.
+    """
+    return Field(**kwargs)
+
+
 # ----------------------------------------------------------------------
 
 

--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -217,6 +217,7 @@ from ._errors import field_error
 from ._fields import *  # noqa: F401, F403
 from ._fields import _OVERRIDABLE, Field, _stored
 from ._fields import __all__ as __all_fields__
+from ._fields import field as _field
 from ._generics import substitute as _substitute
 from ._generics import type_arguments as _type_arguments
 from ._options import *  # noqa: F401, F403
@@ -3059,7 +3060,7 @@ def _dispatching(metacls: type) -> type:
 # out as literals because that is the only form a checker reads;
 # `tests/test_dataclass_transform.py` compares them with the real ones.
 @tx.dataclass_transform(
-    field_specifiers=(Field,),
+    field_specifiers=(Field, _field),
     eq_default=True,
     order_default=False,
     kw_only_default=False,
@@ -3438,7 +3439,7 @@ class Magic(metaclass=MetaMagic):
 
 
 @tx.dataclass_transform(
-    field_specifiers=(Field,),
+    field_specifiers=(Field, _field),
     eq_default=True,
     order_default=False,
     kw_only_default=False,
@@ -3449,7 +3450,7 @@ def magic(**kwargs) -> tx.Callable[[type], type]: ...
 
 
 @tx.dataclass_transform(
-    field_specifiers=(Field,),
+    field_specifiers=(Field, _field),
     eq_default=True,
     order_default=False,
     kw_only_default=False,
@@ -3460,7 +3461,7 @@ def magic(cls: type, **kwargs) -> type: ...
 
 
 @tx.dataclass_transform(
-    field_specifiers=(Field,),
+    field_specifiers=(Field, _field),
     eq_default=True,
     order_default=False,
     kw_only_default=False,

--- a/tests/test_dataclass_transform.py
+++ b/tests/test_dataclass_transform.py
@@ -48,19 +48,20 @@ class TestTheDefaultsAgree:
         recorded = magic.__dataclass_transform__
         assert recorded[declared] == Options._DEFAULTS[option]
 
-    def test_field_is_the_field_specifier(self) -> None:
-        # `x: int = Field(default=3)` is only understood as a field
-        # rather than as a plain assignment because `Field` is named
-        # here.
-        from bagof.magic._fields import Field
+    def test_both_spellings_are_field_specifiers(self) -> None:
+        # `x: int = field(default=3)` is only understood as a field
+        # rather than as a plain assignment because the thing on the
+        # right is named here. Both spellings are, so either works.
+        from bagof.magic._fields import Field, field
 
         assert MetaMagic.__dataclass_transform__["field_specifiers"] == (
             Field,
+            field,
         )
 
 
 FIXTURE = '''
-from bagof.magic import Magic, Field
+from bagof.magic import Magic, Field, field
 
 
 class Point(Magic):
@@ -70,10 +71,12 @@ class Point(Magic):
 
 class Task(Magic):
     name: str
+    tags: list = field(factory=list)
     token: str = Field(default="", repr=False)
 
 
 reveal_type(Point.__init__)
+reveal_type(Task.__init__)
 Point("nope", 2.0)
 '''
 
@@ -115,19 +118,26 @@ class TestACheckerSeesTheConstructor:
         said = _run_mypy(tmp_path)
         assert 'has incompatible type "str"; expected "float"' in said
 
-    def test_mypy_still_objects_to_a_field_written_as_a_default(
+    def test_a_default_written_with_field_is_understood(
         self, tmp_path: Path
     ) -> None:
-        # A known limitation rather than a goal. PEP 681 lets a field
-        # specifier be a class, and pyright reads `token: str =
-        # Field(default="")` as a field with a default. mypy reads it as
-        # assigning a `Field` to a `str` and says so. Every other
-        # library in this space spells its specifier as a function
-        # returning `Any`, which is what sidesteps it; ours is a class,
-        # and changing that is a bigger question than this file.
+        # `field(...)` says it produces whatever the field is annotated
+        # as, so the default is read as a default rather than as a
+        # `Field` being assigned to the wrong type.
+        said = _run_mypy(tmp_path)
+        assert "tags: builtins.list[Any] =" in said
+        assert 'variable has type "list[Any]"' not in said
+
+    def test_mypy_still_objects_to_the_class_written_as_a_default(
+        self, tmp_path: Path
+    ) -> None:
+        # `Field(...)` in a default is the older spelling and still
+        # builds the same object. pyright reads it as a field with a
+        # default; mypy reads it as assigning a `Field` to a `str` and
+        # says so, which is why `field(...)` exists.
         #
-        # Pinned so that a future mypy quietly fixing it does not go
-        # unnoticed: if this starts failing, delete it and the note in
-        # the docs with it.
+        # Pinned so that a future mypy quietly accepting it does not go
+        # unnoticed: if this starts failing, the two spellings have
+        # become equivalent and the docs can stop distinguishing them.
         said = _run_mypy(tmp_path)
         assert 'expression has type "Field"' in said

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -13,6 +13,6 @@ def test_public_api_is_exported() -> None:
     """The headline names are exported."""
     import bagof.magic as magic
 
-    for name in ("Magic", "magic", "Field"):
+    for name in ("Magic", "magic", "Field", "field"):
         assert name in magic.__all__
         assert hasattr(magic, name)


### PR DESCRIPTION
The gap left open by #91, now that you've asked for it.

`Field(default="")` written as a field's default reads, to mypy, as assigning
a `Field` to whatever the field is annotated as:

```
error: Incompatible types in assignment (expression has type "Field",
       variable has type "str")
```

pyright accepts it, so this only bites half of users — which is arguably worse
than it biting everyone.

## Checked the neighbours, and they are unanimous

All three separate the callable from the class:

| | function | class |
|---|---|---|
| `dataclasses` | `field()` | `Field` |
| `attrs` | `field()` | `Attribute` |
| `pydantic` | `Field()` | `FieldInfo` |

The function is what people write; the class is what the field table is made
of. `dataclasses` is the closest match to where we already are — it keeps its
class named `Field` too, and `fields()` hands ours back — so `field()` is the
lowercase function beside it.

Both are registered as PEP 681 field specifiers, so either spelling is
understood as a field rather than a plain assignment.

## Measured, both spellings side by side in one fixture

| | mypy | pyright |
|---|---|---|
| `tags: list = field(factory=list)` | accepted | accepted |
| `token: str = Field(default="")` | objects | accepted |

and the inferred constructor is right either way:

```
(self: Task, name: str, tags: list[Any] = ..., token: str = ...)
```

## What I tried first and rejected

An `Any`-returning `__new__` on the class under `TYPE_CHECKING` — the obvious
way to keep one name. pyright takes it; mypy does not. I built a three-way
isolated repro (plain class / function returning `Any` / class with
`Any`-returning `__new__`) to be sure before touching real code: **only a real
function satisfies both checkers.**

## Nothing else changes

`Field(...)` is untouched and still builds the same object, so no existing
code moves. Inside an `Annotated` — `Annotated[int, Field(alias="ex")]` —
there is no assignment for a checker to object to, so the two read the same
there and the README says so.

The README now leads with `field(...)` in the "as the default" tab and
explains when the capital-letter one still matters.

One thing worth noting for review: `field` is a local variable name all over
`_magic.py`, so it is imported there aliased as `_field` rather than through
the star import.

## Tests

The existing specifier test caught the change and now asserts both are
registered. Added: mypy accepts `field(...)` and infers the default from it;
mypy still objects to `Field(...)`, pinned so that a future mypy accepting it
fails loudly rather than leaving the docs distinguishing two spellings that
have become equivalent.

1021 pass on 3.8 through 3.14; ruff and codespell clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_