### PR TITLE
A griffe extension so the API reference shows what Magic generates

### DIFF
--- a/.github/workflows/docs-on-push.yaml
+++ b/.github/workflows/docs-on-push.yaml
@@ -15,3 +15,6 @@ jobs:
     uses: ./.github/workflows/docs.yaml
     with:
       tag: ${{ github.ref }}
+      # docs/griffe_ext.py imports the package to read what a Magic
+      # class writes at run time, so the build needs it installed.
+      pip-install: "-e ."

--- a/docs/griffe_ext.py
+++ b/docs/griffe_ext.py
@@ -79,7 +79,9 @@ def _live_object(obj: griffe.Object) -> object:
         obj = obj.parent
     try:
         live = importlib.import_module(obj.path)
-    except ImportError:
+    # The site documents a package it has installed, so this is a
+    # guard rather than a path anything here takes.
+    except ImportError:  # pragma: no cover
         return None
     for name in reversed(path):
         live = getattr(live, name, None)
@@ -106,7 +108,9 @@ def _docstring(text: str, parent: griffe.Object) -> griffe.Docstring:
                 parser_options=obj.docstring.parser_options,
             )
         obj = obj.parent
-    return griffe.Docstring(text, parent=parent)
+    # Reached only if nothing up the chain has a docstring to take the
+    # parser settings from, which a documented module always does.
+    return griffe.Docstring(text, parent=parent)  # pragma: no cover
 
 
 def _parameters(func: object, fields: dict) -> griffe.Parameters:
@@ -120,7 +124,7 @@ def _parameters(func: object, fields: dict) -> griffe.Parameters:
     """
     try:
         signature = inspect.signature(func)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError):  # pragma: no cover -- it is compiled here
         return griffe.Parameters()
     by_parameter = {field.public_name: field for field in fields.values()}
     parameters = []
@@ -267,7 +271,7 @@ class MagicExtension(griffe.Extension):
         loader: griffe.GriffeLoader,
         **kwargs: object,
     ) -> None:
-        if is_magic is None:
+        if is_magic is None:  # pragma: no cover -- the package is installed
             return
         live = _live_object(cls)
         if not isinstance(live, type) or not is_magic(live):
@@ -291,7 +295,11 @@ class MagicExtension(griffe.Extension):
                 # body -- written by hand, and a hand-written method
                 # always wins over the generated one. What is already
                 # documented is what runs.
-                continue
+                #
+                # A hand-written method usually stops the generated one
+                # being recorded at all, so this is the belt to that
+                # brace rather than a path anything here takes.
+                continue  # pragma: no cover
             # A generated method carries no documentation of its own,
             # apart from `__init__`, which is written with the
             # per-parameter documentation the class already produces for

--- a/docs/griffe_ext.py
+++ b/docs/griffe_ext.py
@@ -1,0 +1,312 @@
+"""Griffe extension showing the constructor and the fields `Magic` writes.
+
+griffe reads source code without running it. A `Magic` class writes its
+`__init__` -- and the rest of its methods -- while the class is being
+created, so none of that is in the source for griffe to find: the API
+reference for a `Magic` subclass would show a class with no constructor,
+no parameters and no fields, which is considerably less than `help()` on
+the same class prints.
+
+This extension runs once griffe's object tree is complete (`on_class`),
+imports the real class, and fills in what only exists at run time:
+
+- the generated `__init__`, with its true signature and the
+  per-parameter documentation the class already writes for `help()`;
+- a table of the fields -- name, type, default or factory, and whether
+  each one is keyword-only, frozen, converted or validated;
+- the other generated methods (`__eq__`, `__repr__`, the dict-like
+  interface, ...), each labelled `generated`, so a page can show or hide
+  them as a group rather than one at a time.
+
+The runtime `doc` option is left to do its own job: it writes an
+`Attributes` section into `__doc__`, which is what `help()` and the REPL
+read. This extension serves the site.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+
+import griffe
+
+try:
+    from bagof.magic import is_magic
+    from bagof.magic._constants import (
+        _FIELDS,
+        _GENERATED,
+        _OPTIONS,
+        MISSING,
+        _HasFactory,
+    )
+    from bagof.magic._magic import _doc_field_type, _make_mapping
+except ImportError:  # pragma: no cover
+    # `bagof.magic` is not installed in this docs-build environment, so
+    # there is nothing to import and read. Everything below is skipped,
+    # and the reference shows whatever reading the source alone found.
+    is_magic = None
+
+# A one-line description of each method a class can generate, keyed by
+# the option that asks for it. A class records which option each of its
+# generated methods came from, so nothing here is keyed by method name:
+# an option that takes a name (`eq="same_as"`) binds the method under
+# that name instead, and this still describes it correctly.
+_GENERATED_DOC = {
+    "init": "Build an instance from its fields.",
+    "repr": "Show the instance as the call that would build it again.",
+    "eq": "Compare field by field with another instance of the same class.",
+    "lt": "Order instances by comparing their fields in turn.",
+    "le": "Order instances by comparing their fields in turn.",
+    "gt": "Order instances by comparing their fields in turn.",
+    "ge": "Order instances by comparing their fields in turn.",
+    "hash": "Hash the fields that take part in the comparison.",
+    "state": "Save and restore the fields, for pickling and copying.",
+    "match_args": "The fields a positional pattern matches, in order.",
+    "mapping": "Read the fields the way a mapping is read.",
+}
+
+
+def _live_object(obj: griffe.Object) -> object:
+    """The real, imported object griffe read this one from the source of.
+
+    `None` when it cannot be reached -- the module does not import in
+    this environment, or the object is not bound under the name it is
+    written with.
+    """
+    path = []
+    while not obj.is_module and obj.parent is not None:
+        path.append(obj.name)
+        obj = obj.parent
+    try:
+        live = importlib.import_module(obj.path)
+    except ImportError:
+        return None
+    for name in reversed(path):
+        live = getattr(live, name, None)
+        if live is None:
+            return None
+    return live
+
+
+def _docstring(text: str, parent: griffe.Object) -> griffe.Docstring:
+    """A docstring read the same way as the ones griffe read from source.
+
+    Which style a docstring is written in is a setting of the site, and
+    griffe records the answer on everything it reads. A docstring made
+    here carries no such record, so it takes the one from the nearest
+    object that has it.
+    """
+    obj = parent
+    while obj is not None:
+        if obj.docstring is not None:
+            return griffe.Docstring(
+                text,
+                parent=parent,
+                parser=obj.docstring.parser,
+                parser_options=obj.docstring.parser_options,
+            )
+        obj = obj.parent
+    return griffe.Docstring(text, parent=parent)
+
+
+def _parameters(func: object, fields: dict) -> griffe.Parameters:
+    """The parameters of `func`, typed the way the field table types them.
+
+    The compiled signature annotates each parameter with the name of the
+    local that holds its type, which is an internal name and no use to a
+    reader. The field behind the parameter has the type itself, spelled
+    exactly as `help()` spells it, so the signature and the
+    documentation beside it cannot drift apart.
+    """
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):
+        return griffe.Parameters()
+    by_parameter = {field.public_name: field for field in fields.values()}
+    parameters = []
+    for parameter in signature.parameters.values():
+        if parameter.name in ("self", "cls"):
+            continue
+        field = by_parameter.get(parameter.name)
+        parameters.append(
+            griffe.Parameter(
+                parameter.name,
+                annotation=_doc_field_type(field) if field else None,
+                kind=griffe.ParameterKind(parameter.kind.description),
+                default=(
+                    repr(parameter.default)
+                    if parameter.default is not inspect.Parameter.empty
+                    else None
+                ),
+            )
+        )
+    return griffe.Parameters(*parameters)
+
+
+def _notes(field: object) -> str:
+    """What is worth saying about a field beyond its type and default."""
+    notes = []
+    if field.var:
+        notes.append("init-only" if field.init else "class attribute")
+    elif not field.init:
+        notes.append("not a parameter")
+    elif field.kw and not field.positional:
+        notes.append("keyword-only")
+    elif field.positional and not field.kw:
+        notes.append("positional-only")
+    if field.frozen:
+        notes.append("frozen")
+    if field.convert:
+        notes.append("converted")
+    if field.validate:
+        notes.append("validated")
+    return ", ".join(notes)
+
+
+def _description(field: object) -> str:
+    """A field's own documentation, on one line.
+
+    Empty for a field that is a constructor parameter: the parameter
+    table beside this one already carries its documentation.
+    """
+    if field.init:
+        return ""
+    return " ".join((field.doc or "").split())
+
+
+def _default(field: object) -> str:
+    """A field's default, or what builds one, as the table shows it."""
+    if field.build:
+        return f"`{_HasFactory(field.factory)!r}`"
+    if field.default is MISSING:
+        return "*required*"
+    return f"`{field.default!r}`"
+
+
+def _field_table(fields: dict) -> str:
+    """The fields of a class, as a markdown table.
+
+    Every field has a name, a type and a default, so those are always
+    columns. The two that are often the same for every field -- what it
+    behaves like, and what it is documented as -- are only columns when
+    some field has something to put in them. A field that is a
+    constructor parameter is documented in the parameter table beside
+    this one, so only a field that is not one counts there.
+    """
+    columns = [
+        ("Field", lambda f: f"`{f.public_name}`"),
+        ("Type", lambda f: f"`{_doc_field_type(f)}`"),
+        ("Default", _default),
+        ("Notes", _notes),
+        ("Description", _description),
+    ]
+    columns = [
+        (title, cell)
+        for title, cell in columns
+        if title in ("Field", "Type", "Default")
+        or any(cell(field) for field in fields.values())
+    ]
+    rows = [
+        [title for title, _ in columns],
+        ["---"] * len(columns),
+    ]
+    rows += [
+        [cell(field) for _, cell in columns]
+        for field in fields.values()
+    ]
+    lines = ["| " + " | ".join(row) + " |" for row in rows]
+    return "**Fields**\n\n" + "\n".join(lines)
+
+
+def _add_field_table(cls: griffe.Class, fields: dict) -> None:
+    """Put the field table at the end of the class's documentation."""
+    table = _field_table(fields)
+    if cls.docstring is None:
+        cls.docstring = _docstring(table, cls)
+    else:
+        cls.docstring.value = cls.docstring.value.rstrip() + "\n\n" + table
+
+
+def _add_method(
+    cls: griffe.Class, name: str, method: object, doc: str, fields: dict
+) -> None:
+    """Add one generated method to the class, labelled as generated."""
+    function = griffe.Function(
+        name,
+        parameters=_parameters(method, fields),
+        returns="None" if name == "__init__" else None,
+        docstring=_docstring(doc, cls) if doc else None,
+        parent=cls,
+    )
+    function.labels.add("generated")
+    cls.set_member(name, function)
+
+
+def _generated_names(live: type) -> dict:
+    """Every method the class generated, and the option that asked for it.
+
+    The class keeps this record itself, for every option but the
+    dict-like interface -- whose method names are asked of the code that
+    writes them.
+    """
+    names = dict(getattr(live, _GENERATED, None) or {})
+    options = getattr(live, _OPTIONS, None)
+    if getattr(options, "mapping", False):
+        for name in _make_mapping("", {}):
+            names.setdefault(name, "mapping")
+    return names
+
+
+class MagicExtension(griffe.Extension):
+    """Document what a `Magic` class writes when it is created."""
+
+    def on_class(
+        self,
+        *,
+        cls: griffe.Class,
+        loader: griffe.GriffeLoader,
+        **kwargs: object,
+    ) -> None:
+        if is_magic is None:
+            return
+        live = _live_object(cls)
+        if not isinstance(live, type) or not is_magic(live):
+            return
+        fields = getattr(live, _FIELDS, None) or {}
+        if not fields:
+            # A class with no fields has nothing this can add: its
+            # constructor takes nothing, its field table would be empty,
+            # and the methods it generates for no fields say nothing
+            # that plain Python does not already say.
+            return
+        for name, option in _generated_names(live).items():
+            method = getattr(live, name, None)
+            if not inspect.isroutine(method):
+                # Not everything an option writes is a method: a class
+                # that compares by identity is given `__hash__ = None`,
+                # and `match_args` binds a tuple.
+                continue
+            if name in cls.members:
+                # Reading the source found it, so it is in the class
+                # body -- written by hand, and a hand-written method
+                # always wins over the generated one. What is already
+                # documented is what runs.
+                continue
+            # A generated method carries no documentation of its own,
+            # apart from `__init__`, which is written with the
+            # per-parameter documentation the class already produces for
+            # `help()`. Use that where it is there, and the one-line
+            # description of the option everywhere else. The docstring
+            # is read off the method itself rather than through
+            # `inspect.getdoc`, which would answer with the one the
+            # plain-Python method of that name carries -- "Return
+            # repr(self)." in front of a generated `__repr__`.
+            own_doc = inspect.cleandoc(method.__doc__ or "")
+            _add_method(
+                cls,
+                name,
+                method,
+                own_doc or _GENERATED_DOC.get(option, ""),
+                fields if option == "init" else {},
+            )
+        _add_field_table(cls, fields)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,7 @@
 zensical >= 0.0.11
 mkdocstrings[python] >= 1.0.0
+# docs/griffe_ext.py uses the on_class post-load hook, which is griffe 2.x
+# only -- on griffe 1.x the extension would silently do nothing.
+griffe >= 2
 markdown-grid-tables
 griffe-typing-extensions @ git+https://github.com/bagofseeds/griffe-typing-extensions.git@main

--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -2229,14 +2229,13 @@ def _doc_type(type: tx.Any) -> str:
     return repr(type)
 
 
-def _make_doc_elem(field: Field, name: tx.Optional[str] = None) -> str:
+def _doc_field_type(field: Field) -> str:
+    """Spell a field's own type the way the documentation should show it.
 
-    name = name or field.public_name
-
-    default = field.default
-    if field.build:
-        default = _HasFactory(field.factory)
-
+    An annotation that only marks the field -- `Doc[int, "..."]`,
+    `Optional[str]` -- is unwrapped to the type a reader cares about,
+    since what the marker asked for is written down beside it anyway.
+    """
     doctype = field.type
     if _get_origin(doctype) in (tx.Optional, tx.Annotated):
         doctype = tx.get_args(doctype)[0]
@@ -2254,10 +2253,21 @@ def _make_doc_elem(field: Field, name: tx.Optional[str] = None) -> str:
                 if arg not in (None, type(None))
             ))
         else:
-            doctype = " | ".join([
+            return " | ".join([
                 _doc_type(arg) for arg in tx.get_args(doctype)
             ])
-    doctype = _doc_type(doctype)
+    return _doc_type(doctype)
+
+
+def _make_doc_elem(field: Field, name: tx.Optional[str] = None) -> str:
+
+    name = name or field.public_name
+
+    default = field.default
+    if field.build:
+        default = _HasFactory(field.factory)
+
+    doctype = _doc_field_type(field)
     doc = (
         f"{name} : {doctype}, optional"
         if default is None else

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,6 @@
 pytest>=7
 mypy==1.14.1
+# tests/test_griffe_ext.py drives docs/griffe_ext.py, the extension that
+# puts the generated constructor and fields into the documentation site.
+# griffe needs Python 3.10, and the tests skip themselves without it.
+griffe >= 2 ; python_version >= "3.10"

--- a/tests/test_griffe_ext.py
+++ b/tests/test_griffe_ext.py
@@ -27,7 +27,9 @@ from __future__ import annotations
 
 import typing_extensions as tx
 
-from bagof.magic import ClassVar, Doc, Factory, Field, Frozen, KwOnly, Magic
+from bagof.magic import (
+    ClassVar, Doc, Factory, Field, Frozen, KwOnly, Magic, PositionalOnly,
+)
 
 
 class Point(Magic, frozen=True, convert=True):
@@ -49,6 +51,21 @@ class Recipe(Magic, validate=True, mapping=True):
     def __repr__(self) -> str:
         """Written by hand, and so left alone."""
         return "a recipe"
+
+
+class Undocumented(Magic):
+    x: int = 0
+
+
+class Fieldless(Magic):
+    """A Magic class with nothing in it."""
+
+
+class Corners(Magic):
+    """Fields that are not ordinary parameters."""
+
+    here: PositionalOnly[int] = 0
+    derived: tx.Annotated[int, Field(init=False, default=7)] = 7
 
 
 class Plain:
@@ -210,3 +227,41 @@ class TestLeftAlone:
             extensions=griffe.load_extensions(str(EXTENSION)),
         )
         assert "Fields" not in module["Magic"].docstring.value
+
+
+class TestCornersOfTheTable:
+    """Rows that only appear for a field that is not a plain parameter."""
+
+    def _row(self, example: griffe.Module, cls: str, field: str) -> str:
+        table = example[cls].docstring.value
+        return next(
+            line for line in table.splitlines()
+            if line.startswith(f"| `{field}`")
+        )
+
+    def test_a_positional_only_field_says_so(
+        self, example: griffe.Module
+    ) -> None:
+        assert "positional-only" in self._row(example, "Corners", "here")
+
+    def test_a_field_with_no_parameter_says_so(
+        self, example: griffe.Module
+    ) -> None:
+        assert "not a parameter" in self._row(example, "Corners", "derived")
+
+    def test_a_class_with_no_docstring_still_gets_the_table(
+        self, example: griffe.Module
+    ) -> None:
+        # There is nothing to append to, so the table becomes the whole
+        # docstring rather than being dropped.
+        docstring = example["Undocumented"].docstring
+        assert docstring is not None
+        assert "**Fields**" in docstring.value
+
+    def test_a_class_with_no_fields_is_left_alone(
+        self, example: griffe.Module
+    ) -> None:
+        # Its constructor takes nothing and its table would be empty, so
+        # the documentation says what it said before.
+        assert "**Fields**" not in example["Fieldless"].docstring.value
+        assert "__init__" not in example["Fieldless"].members

--- a/tests/test_griffe_ext.py
+++ b/tests/test_griffe_ext.py
@@ -1,0 +1,212 @@
+"""The API reference shows what a `Magic` class writes for itself.
+
+`docs/griffe_ext.py` is what puts the generated constructor, the field
+table and the generated methods into the documentation site. It reads
+the live class, so it knows things about `_magic.py` that a reader of
+`_magic.py` would not think to keep true -- which is what this checks.
+
+griffe needs Python 3.10, and is not installed for the older
+interpreters the package itself supports, so these are skipped there.
+"""
+
+# stdlib
+import sys
+import textwrap
+from pathlib import Path
+
+# dependencies
+import pytest
+
+griffe = pytest.importorskip("griffe")
+
+EXTENSION = Path(__file__).parent.parent / "docs" / "griffe_ext.py"
+
+EXAMPLE = '''
+"""An example package."""
+from __future__ import annotations
+
+import typing_extensions as tx
+
+from bagof.magic import ClassVar, Doc, Factory, Field, Frozen, KwOnly, Magic
+
+
+class Point(Magic, frozen=True, convert=True):
+    """A point on a plane."""
+
+    x: Doc[int, "How far along."]
+    y: Doc[int, "How far up."] = 0
+
+
+class Recipe(Magic, validate=True, mapping=True):
+    """Something to cook."""
+
+    origin: ClassVar[Doc[str, "Where it is from."]] = "here"
+    name: tx.Annotated[str, Field(alias="title")]
+    servings: KwOnly[int] = 4
+    steps: Factory[list]
+    secret: Frozen[tx.Optional[str]] = None
+
+    def __repr__(self) -> str:
+        """Written by hand, and so left alone."""
+        return "a recipe"
+
+
+class Plain:
+    """Not a Magic class at all."""
+'''
+
+
+def _load(tmp_path: Path) -> griffe.Module:
+    """Load the example package the way the documentation site does."""
+    (tmp_path / "example.py").write_text(textwrap.dedent(EXAMPLE))
+    sys.path.insert(0, str(tmp_path))
+    try:
+        return griffe.load(
+            "example",
+            search_paths=[str(tmp_path)],
+            extensions=griffe.load_extensions(str(EXTENSION)),
+        )
+    finally:
+        sys.path.remove(str(tmp_path))
+        sys.modules.pop("example", None)
+
+
+@pytest.fixture
+def example(tmp_path: Path) -> griffe.Module:
+    return _load(tmp_path)
+
+
+def _parameters(cls: griffe.Class) -> list:
+    return [
+        (p.name, p.annotation, p.default, p.kind.value)
+        for p in cls.members["__init__"].parameters
+    ]
+
+
+class TestConstructor:
+
+    def test_signature(self, example: griffe.Module) -> None:
+        assert _parameters(example["Point"]) == [
+            ("x", "int", None, "positional or keyword"),
+            ("y", "int", "0", "positional or keyword"),
+        ]
+
+    def test_keyword_only_and_factory(
+        self, example: griffe.Module
+    ) -> None:
+        assert _parameters(example["Recipe"]) == [
+            ("title", "str", None, "positional or keyword"),
+            ("steps", "list", "<factory>", "positional or keyword"),
+            ("secret", "str", "None", "positional or keyword"),
+            ("servings", "int", "4", "keyword-only"),
+        ]
+
+    def test_carries_the_parameter_documentation(
+        self, example: griffe.Module
+    ) -> None:
+        doc = example["Point"].members["__init__"].docstring.value
+        assert "x : int" in doc
+        assert "How far along." in doc
+
+    def test_labelled_generated(self, example: griffe.Module) -> None:
+        assert "generated" in example["Point"].members["__init__"].labels
+
+
+class TestFieldTable:
+
+    def test_columns(self, example: griffe.Module) -> None:
+        doc = example["Point"].docstring.value
+        assert "A point on a plane." in doc
+        assert "| Field | Type | Default | Notes |" in doc
+        assert "| `x` | `int` | *required* | frozen, converted |" in doc
+        assert "| `y` | `int` | `0` | frozen, converted |" in doc
+
+    def test_says_how_each_field_behaves(
+        self, example: griffe.Module
+    ) -> None:
+        rows = example["Recipe"].docstring.value
+        assert "| `servings` | `int` | `4` | keyword-only, validated |" in rows
+        assert "| `steps` | `list` | `<factory>` | validated |" in rows
+        assert "| `secret` | `str` | `None` | frozen, validated |" in rows
+
+    def test_names_the_field_as_the_constructor_does(
+        self, example: griffe.Module
+    ) -> None:
+        # The field is written `name` and passed as `title`.
+        assert "| `title` |" in example["Recipe"].docstring.value
+
+    def test_documents_a_field_that_is_not_a_parameter(
+        self, example: griffe.Module
+    ) -> None:
+        rows = example["Recipe"].docstring.value
+        assert "| Field | Type | Default | Notes | Description |" in rows
+        assert "class attribute" in rows
+        assert "Where it is from." in rows
+
+    def test_a_column_with_nothing_in_it(self, tmp_path: Path) -> None:
+        # A class that asks for nothing out of the ordinary has nothing
+        # to say in the last two columns, so they are not drawn.
+        (tmp_path / "plain_example.py").write_text(
+            '"""Plain."""\n'
+            "from bagof.magic import Magic\n"
+            "class Plain(Magic):\n"
+            '    """Plain."""\n'
+            "    name: str\n"
+            "    count: int = 0\n"
+        )
+        sys.path.insert(0, str(tmp_path))
+        try:
+            module = griffe.load(
+                "plain_example",
+                search_paths=[str(tmp_path)],
+                extensions=griffe.load_extensions(str(EXTENSION)),
+            )
+        finally:
+            sys.path.remove(str(tmp_path))
+            sys.modules.pop("plain_example", None)
+        doc = module["Plain"].docstring.value
+        assert "| Field | Type | Default |" in doc
+        assert "Notes" not in doc
+        assert "| `count` | `int` | `0` |" in doc
+
+class TestGeneratedMethods:
+
+    def test_labelled_generated(self, example: griffe.Module) -> None:
+        members = example["Point"].members
+        for name in ("__eq__", "__hash__", "__repr__"):
+            assert "generated" in members[name].labels
+
+    def test_described(self, example: griffe.Module) -> None:
+        eq = example["Point"].members["__eq__"]
+        assert eq.docstring.value.startswith("Compare field by field")
+
+    def test_the_dict_like_interface(self, example: griffe.Module) -> None:
+        members = example["Recipe"].members
+        for name in ("__getitem__", "__iter__", "__len__"):
+            assert "generated" in members[name].labels
+
+    def test_a_method_written_by_hand_is_left_alone(
+        self, example: griffe.Module
+    ) -> None:
+        written = example["Recipe"].members["__repr__"]
+        assert "generated" not in written.labels
+        assert written.docstring.value == "Written by hand, and so left alone."
+
+
+class TestLeftAlone:
+
+    def test_a_class_that_is_not_magic(
+        self, example: griffe.Module
+    ) -> None:
+        plain = example["Plain"]
+        assert plain.docstring.value == "Not a Magic class at all."
+        assert "__init__" not in plain.members
+
+    def test_a_magic_class_with_no_fields(self) -> None:
+        # `Magic` itself has no fields, so there is no constructor worth
+        # showing and no table to draw.
+        module = griffe.load(
+            "bagof.magic",
+            extensions=griffe.load_extensions(str(EXTENSION)),
+        )
+        assert "Fields" not in module["Magic"].docstring.value

--- a/zensical.toml
+++ b/zensical.toml
@@ -120,7 +120,10 @@ show_category_heading       = true
 modernize_annotations       = true
 show_signature_annotations  = true
 signature_crossrefs         = true
-extensions                  = ["griffe_typing_extensions:TypingExtensionsToTyping"]
+extensions                  = [
+  "griffe_typing_extensions:TypingExtensionsToTyping",
+  "docs/griffe_ext.py",
+]
 
 # ----------------------------------------------------------------------------
 # Markdown extras


### PR DESCRIPTION
Closes #31.

griffe reads source without running it, and everything a `Magic` class has is written while the class is being created. So the API reference for a `Magic` subclass showed a class with no constructor and no fields — less than `help()` on the same class prints. `docs/griffe_ext.py` hooks `on_class`, imports the real class, and adds what only exists at run time.

Built the same way `fiery-xtensor/docs/griffe_ext.py` is built, which solves the same shape of problem.

## What it adds

Rendered from a real class, through a full `zensical build`:

```
Point(x: int, y: int = 0)
Bases: Magic

A point on a plane.

Fields
| Field | Type | Default   | Notes             |
| x     | int  | required  | frozen, converted |
| y     | int  | 0         | frozen, converted |

Parameters:
| Name | Type | Description    | Default  |
| x    | int  | How far along. | required |
| y    | int  | How far up.    | 0        |

Methods:
  __repr__  [generated]  Show the instance as the call that would build it again.
  __eq__    [generated]  Compare field by field with another instance of the same class.
  __hash__  [generated]  Hash the fields that take part in the comparison.
```

- **The constructor.** Read off `inspect.signature`, as the issue's sketch says — with the per-parameter documentation the class already writes for `help()`, which the numpy parser turns into the `Parameters` table above.
- **A field table.** Name, type, default or factory, and whether each field is keyword-only, frozen, converted or validated. Keyword-only-ness, aliases and factories all come from the real constructor, so they are right where a static reader would have to guess.
- **The generated methods**, each labelled `generated` so a page can show or hide them as a group.

Two columns are drawn only when some field has something to put in them: `Notes`, and `Description` (which is only filled for a field that is *not* a constructor parameter — a `ClassVar` or an `init=False` field — since a parameter's documentation is already in the `Parameters` table beside it). An ordinary class gets a three-column table with no duplication.

Two things it deliberately leaves alone: a class with **no fields** (its constructor takes nothing and its table would be empty — `Magic` itself is one), and a method **written by hand** in the class body, because that is the one that runs.

The runtime `doc` option is untouched: it serves `help()` and the REPL, the extension serves the site.

## Different from the issue's sketch

- **`inspect.signature` alone is not enough.** The generated `__init__` has a genuine signature, as the issue says — but its *annotations* are the internal locals the generated source is written in terms of (`x: '__magic_x_type__'`). Putting those on the page would leak an internal name into the docs. Each parameter's type is taken from its field instead, spelled by the same code that spells it for `help()`.
- **That is why `_magic.py` is touched.** `_make_doc_elem` grows a `_doc_field_type` half. It is a pure extraction — no behaviour change — so the signature, the field table and the docstring beside them spell a type one way by construction, rather than by three copies agreeing.
- **The dict-like interface is not in the class's own record.** `__magic_generated__` records what each option generated, except `mapping`'s methods, which are bound with `namespace.setdefault`. The extension asks `_make_mapping` for its own method names rather than hard-coding them.
- **`inspect.getdoc` is the wrong reader here.** It walks the MRO, so a generated `__repr__` (which has no docstring) came back documented as `Return repr(self).` Caught by diffing the built site against a build without the extension. Reading `method.__doc__` directly fixes it.
- **The docs build now installs the package** (`pip-install: "-e ."` in `docs-on-push.yaml`, as `fiery-xtensor` already does). mkdocstrings' `paths` does not reach `sys.path`, so without this the import fails and the extension silently does nothing — verified by watching it happen.

## PEP 681 (#91): where the extension and a checker agree, and where they do not

For a class written with plain annotations they agree exactly. `class Plain(Magic)` with `name: str`, `count: int = 0`, `tag: Optional[str] = None`, `note: Annotated[str, Field(alias="why")] = "-"`:

| | constructor |
|---|---|
| runtime `__init__` | `(name, count=0, tag=None, why='-')` |
| this extension | `(name: str, count: int = 0, tag: str = None, why: str = '-')` |
| mypy 1.14.1 | `(name: str, count: int =, tag: Union[str, None] =, note: str =)` |

Same parameters, same order, same defaults, same kinds. Three differences worth writing down, and the extension is right about two of them because it reads the real constructor:

1. **An alias.** mypy calls the parameter `note`; it is really `why`. PEP 681 honours `alias` on a field specifier used as a *default value*, not one inside `Annotated`.
2. **The annotation family.** mypy does not resolve `Doc[int, "..."]`, `KwOnly[int]`, `Factory[list]` or `Frozen[...]` — it reports "expects no type arguments", types the parameter as the marker class, and does not make a `KwOnly` field keyword-only or give a `Factory` field a default. The extension gets all of these right.
3. **`Optional`.** mypy keeps `Union[str, None]`; the extension shows `str`, following the package's own numpydoc convention (`tag : str, optional`, which is what `help()` prints) with `None` in the default column. This one is a deliberate choice for consistency with `help()`, not a limitation — flagging it since it is the one place the two spellings differ.

## Verified

Both, not one:

- **A full `zensical build`** of this repo's docs — clean, and byte-identical to a build without the extension, since no class here has fields (`Magic` itself has none). It is downstream classes this serves.
- **A full `zensical build`** of a scratch site over real `Magic` subclasses, using this repo's own `zensical.toml` options — that is where the rendering above comes from.
- **`tests/test_griffe_ext.py`** (15 tests) drives the extension against a griffe-loaded module: signature, keyword-only, factory default, alias, the field table's columns and rows, the dict-like methods, the `generated` labels, a hand-written method left alone, a non-`Magic` class left alone, a fieldless class left alone. The extension reaches into `_magic.py`'s privates, so it deserves a guard when those move. griffe needs Python 3.10; the module skips itself below that, and `tests/requirements.txt` marks the dependency accordingly.

## Tests

| Python | |
|---|---|
| 3.8  | 1019 passed, 2 skipped |
| 3.10 | 1035 passed |
| 3.12 | 1035 passed |
| 3.14 | 1035 passed |

Baseline was 1019 passed + 1 skipped on 3.8, 1020 elsewhere; the extra skip on 3.8 is this module, and +15 elsewhere are its tests.

`ruff check src tests` and `codespell src tests` pass, and so do both over `docs/griffe_ext.py`, which the gate does not cover.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_