### PR TITLE
Rewrite documentation and docstrings for human readers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,77 +320,65 @@ argued the other way:
 
 ## Documentation style (`README.md`, `docs/*.md`, public docstrings)
 
-Docs are for **humans who are not necessarily experts in arcane Python
-features**. They want to know how to use `magic` well — to write correct,
-readable, efficient code. Apply this to every hand-written page and to every
-public docstring:
+Docs are for **Python developers who want to use `magic` to build clean data
+classes**. They are not experts in metaclasses, typing internals, or the
+builder's implementation. Every sentence should help them write correct,
+readable code. Apply this to every hand-written page and to every public
+docstring:
 
-1. **Show the sugar first.** When several spellings do the same thing, lead
-   with the nicest one and list the rest in `=== "..."` tabs.
-2. **Plain language.** No agentic or internal-monologue phrasing, and no
-   unexplained internal names — those belong in code comments and in this
-   file, not in the docs. Say what a reader needs in order to *use* the
-   library, not what the builder does internally.
+1. **Lead with what the user writes.** Show the simplest spelling first.
+   When several spellings do the same thing, put them in `=== "..."` tabs.
+2. **Say what it does, not how it works.** No internal function names, no
+   private attributes, no implementation-level explanations. Those belong in
+   code comments and in this file.
 3. **Real `pycon`, not pseudo-code.** An example that shows a value must show
-   the value the interpreter actually prints. For the annotation family in
-   `_fields.py` this means showing the lowering as it really is:
+   what the interpreter actually prints:
 
    ```pycon
    >>> Factory[list]
-   typing.Annotated[list, Factory(factory=True)]
+   typing.Annotated[list, Factory(build=True)]
    ```
 
-   not an invented `~>` arrow. Every such block should be copy-pasteable and
-   true.
-4. **An example must run on the oldest supported Python.** `tests/
+   Every `pycon` block should be copy-pasteable and true.
+4. **Examples must run on the oldest supported Python.** `tests/
    test_docstrings.py` executes every `pycon` block, and CI runs it on 3.8 as
    well as current. The usual trap is `typing`: `Annotated` only exists from
    3.9. Prefer the package's own sugar (`Doc[int, "..."]`, `Frozen[int]`) in
-   examples, which works everywhere and is what the docs should be showing
-   anyway.
-5. **Leanness bar.** If an example does not read as short and natural, that is
-   a signal: either a nicer spelling already exists and the example should use
-   it, or `magic` is missing sugar — file an `enhancement` issue for the gap
-   rather than shipping an awkward example.
+   examples.
+5. **Short sentences, no filler.** If a sentence can be cut without losing
+   meaning, cut it. If an example reads as awkward, that is a signal that
+   `magic` is missing sugar. File an `enhancement` issue for the gap.
 
 **This applies equally to every public docstring** (anything without a leading
-underscore, reachable from `bagof.magic`) — the API reference renders them
-directly through `mkdocstrings`, so a docstring *is* a doc page. Concretely, a
-public docstring must **not**:
+underscore, reachable from `bagof.magic`). The API reference renders them
+directly through `mkdocstrings`, so a docstring *is* a doc page. A public
+docstring must **not**:
 
-- reference an issue or PR number, or a review finding — that belongs in a
-  commit message, a code comment, or this file;
-- name an internal mechanism the reader has no reason to know about (which
-  helper resolves it, which private attribute holds it);
-- read like a note to a fellow contributor ("kept for symmetry with X", "this
-  used to be broken") — say what the reader needs, not how it got that way.
+- reference an issue/PR number or a review finding;
+- name an internal mechanism the reader has no reason to know about;
+- read like a note to a fellow contributor.
 
-Internal rationale and history still belong somewhere — just not in a public
-docstring. Use a code comment near the implementation, or a section of this
-file.
+Internal rationale and history belong in a code comment near the
+implementation, or in a section of this file.
 
 ### Code comments, private docstrings and error messages
 
-Same standard, different reader. The audience here is a contributor opening
-the file for the first time, with no background on how the builder works —
-not you, later, remembering why you did it.
+The audience is a contributor opening the file for the first time, with no
+background on how the builder works.
 
 1. **Say what the code does, not what you decided.** "Replace any inherited
    generated method for this option" is useful. "Rather than try to tell them
-   apart, we now raise" is a changelog entry; put that in the commit message.
-2. **Name a helper for what it actually does**, not for the shape of what it
-   returns. `_defines` sounded like a predicate and returned a class;
-   `_defining_class` says it.
-3. **An error message is read by someone stuck**, not by whoever wrote the
-   check. It must name what happened, in the reader's vocabulary, and what to
-   write instead. Never mention metaclasses, namespaces, rebuilding, or any
-   private helper — a user has no reason to know those exist, and naming them
-   makes a fixable mistake feel like a library bug. Compare:
+   apart, we now raise" is a changelog entry. Put that in the commit message.
+2. **Name a helper for what it does.** `_defines` sounded like a predicate
+   and returned a class; `_defining_class` says it.
+3. **Error messages are read by someone stuck.** Name what happened and what
+   to write instead. Never mention metaclasses, namespaces, rebuilding, or any
+   private helper. A user has no reason to know those exist. Compare:
 
    > `Chord has already been built by Magic, so it cannot be rebuilt: pass
    > the options to the class statement instead`
 
-   with what it became:
+   with:
 
    > `Chord is already a Magic class, so it cannot be built a second time.
    > This happens when @magic is used twice on the same class, or when it is
@@ -398,9 +386,9 @@ not you, later, remembering why you did it.
    > class statement instead — `class Chord(Magic, frozen=True)` — which does
    > the same job.`
 
-4. **Don't reference an internal name a user could not have typed.** The
-   `slots` helper in `_utils.py` is ours; an error that mentions it sends the
-   reader looking for something they never used.
+4. **No internal names in user-facing errors.** The `slots` helper in
+   `_utils.py` is ours; an error that mentions it sends the reader looking for
+   something they never used.
 
 ## Third-party code
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 **Classes that build themselves from your type hints.**
 
-Write down what your data looks like. `Magic` writes the `__init__`, the
-`__repr__`, the comparisons — and, if you ask it to, converts and checks every
-value on the way in.
+Write your fields as annotations. `Magic` generates `__init__`, `__repr__`,
+`__eq__`, and everything else.
 
 ```python
 from bagof.magic import Magic
@@ -24,7 +23,7 @@ Traceback (most recent call last):
 AttributeError: Cannot set frozen field 'x'
 ```
 
-If you would rather decorate than inherit, both spellings do the same thing:
+If you prefer a decorator:
 
 === "Base class"
 
@@ -49,12 +48,11 @@ If you would rather decorate than inherit, both spellings do the same thing:
 
 ---
 
-## Three things that make it different
+## Three things that set it apart
 
 ### Settings are inherited
 
-Say it once on a base class and every subclass keeps it. No repeating the same
-decorator down a hierarchy.
+Set an option on a base class. Every subclass keeps it.
 
 ```python
 class Record(Magic, frozen=True, kw_only=True):
@@ -69,9 +67,8 @@ class User(Record):
 User(id=1, name='ada')
 ```
 
-A subclass that wants something different just says so — `class Draft(Record,
-frozen=False)`. That reaches the fields the subclass declares itself; add
-`override=True` for it to reach the inherited ones as well:
+A subclass can change any setting. `override=True` makes the change apply
+to inherited fields too:
 
 ```python
 class Draft(Record, frozen=False, override=True):
@@ -85,22 +82,21 @@ class Draft(Record, frozen=False, override=True):
 Draft(id=2, note='')
 ```
 
-A field that asked for something in its own annotation — `Frozen[int]`,
-`KwOnly[int]` — keeps it either way.
+A field that names its own preference in its annotation (like `Frozen[int]`
+or `KwOnly[int]`) keeps it regardless.
 
 ### Per-field behaviour lives in the annotation
 
-What a field does is written where the field is, so the default stays where
-you expect it:
+Each field says what it does, right where it is declared:
 
 ```python
 from bagof.magic import Magic, Factory, KwOnly, NoRepr
 
 class Task(Magic):
     name: str
-    tags: Factory[list]          # a fresh list per task, not one shared list
-    token: NoRepr[str] = ""      # kept, but never printed
-    priority: KwOnly[int] = 0    # must be passed by name
+    tags: Factory[list]          # a fresh list per instance
+    token: NoRepr[str] = ""      # present, but hidden from repr
+    priority: KwOnly[int] = 0    # keyword-only argument
 ```
 
 ```pycon
@@ -108,9 +104,8 @@ class Task(Magic):
 Task(name='build', tags=['ci'], priority=2)
 ```
 
-If you are coming from `dataclasses` or `attrs`, the spelling you already
-know works too — `field(...)` as the default value. Both produce the same
-field, so use whichever reads better:
+The `field(...)` spelling from `dataclasses` and `attrs` also works. Both
+produce the same `Field`:
 
 === "In the annotation"
 
@@ -134,21 +129,18 @@ field, so use whichever reads better:
         token: str = field(default="", repr=False)
     ```
 
-The annotation form composes better — several of them stack on one field
-without nesting — and the `field(...)` form takes anything the annotations
+The annotation form composes naturally. Several annotations stack on one
+field without nesting. The `field(...)` form covers anything the annotations
 cannot say.
 
-`Field(...)` is the same thing spelled with a capital letter, and still
-works. Prefer the lowercase one where you have the choice: mypy reads
-`tags: list = Field(factory=list)` as assigning a `Field` to a `list` and
-objects, while `field(...)` says it produces whatever the field is
-annotated as. Inside an `Annotated`, where there is no assignment for a
-checker to object to, either reads the same.
+`Field(...)` is the same thing with a capital letter. Prefer the lowercase
+`field(...)` when using it as a default value: mypy reads
+`tags: list = Field(factory=list)` as assigning a `Field` to a `list` slot,
+while `field(...)` says it produces whatever the annotation requires.
 
 ### Conversion and validation come from the type
 
-Turn them on and the type hint does the work — parsing a config file, checking
-an API payload, cleaning user input:
+Turn them on and the type hint does the work:
 
 ```python
 class Config(Magic, convert=True, validate=True):
@@ -161,8 +153,8 @@ class Config(Magic, convert=True, validate=True):
 Config(host='localhost', port=9000)
 ```
 
-`"9000"` became `9000` because the hint said `int`. Prefer to be selective?
-Mark individual fields instead:
+`"9000"` became `9000` because the hint said `int`. To convert only some
+fields, mark them individually:
 
 === "Whole class"
 
@@ -183,16 +175,14 @@ Mark individual fields instead:
     ```
 
 The rules come from [`bagof-converters`][converters] and
-[`bagof-validators`][validators], so anything they understand — nested
-containers, unions, enums, `TypedDict`, dates, paths, numpy arrays — works
+[`bagof-validators`][validators]. Anything they understand (nested
+containers, unions, enums, `TypedDict`, dates, paths, numpy arrays) works
 here too.
 
-A hint may name something that does not exist yet when the class is
-written: a class that refers to itself, a name defined further down the
-file, a type imported only for type checking. It is looked up the first
-time the field is actually used instead, by which point the module has
-finished loading — so an ordinary forward reference simply works, and
-`Router("9000").port` below is a `Port`.
+A type hint can name something that does not exist yet: a class that refers
+to itself, a name defined later in the file, a type imported only under
+`if TYPE_CHECKING`. The name is looked up the first time the field is used.
+By then the module has finished loading, so forward references simply work:
 
 ```python
 class Router(Magic, convert=True):
@@ -202,7 +192,7 @@ class Port(int):
     pass
 ```
 
-If the name is still not there by then, the field carries on unconverted
+If the name is still missing at first use, the field carries on unconverted
 and unvalidated, and says so once:
 
 ```
@@ -210,26 +200,22 @@ Router.port: the name `Port` is not defined, so `port` is not being
 converted.
 ```
 
-A field whose default was to be built from its type has nothing to carry
-on with, so that one raises instead.
+A field that needs its type to build a default has nothing to fall back on,
+so it raises instead.
 
-`unresolved_hints` decides what that report is. Turning it into an error
-is worth doing in CI, where a hint that never resolves is a mistake
-rather than something to live with:
+`unresolved_hints` controls the report: `"warn"` (the default), `"raise"`,
+or `"ignore"`. Setting `"raise"` is worth doing in CI, where an unresolved
+hint is a mistake rather than something to tolerate:
 
 ```python
 class Service(Magic, convert=True, unresolved_hints="raise"):
     port: int = 8080
 ```
 
-The third choice, `"ignore"`, says nothing at all — for a hint you know
-will not resolve and do not want to hear about again.
-
 ### Leaving the defaults alone
 
-A default is converted and validated like anything else, so a class is as
-strict about the values it was written with as about the ones it is handed.
-Sometimes only the incoming values need the attention:
+A default is converted and validated like any other value. Sometimes only
+the incoming values need the attention:
 
 ```python
 class Node(Magic, convert=True, convert_defaults=False):
@@ -243,10 +229,10 @@ Node(name='root', parent=None)
 ```
 
 `parent: Optional["Node"]` is the precise spelling and needs nothing turned
-off. But when the defaults in a class are already exactly what you meant,
-`convert_defaults=False` and `validate_defaults=False` say to take them as
-written. Anything a caller passes is still converted and validated, as is
-anything assigned afterwards.
+off. But when the defaults in a class are already exactly right,
+`convert_defaults=False` and `validate_defaults=False` take them as
+written. Values a caller passes are still converted and validated, as are
+values assigned afterwards.
 
 ---
 
@@ -265,10 +251,9 @@ class Row(Magic, mapping=True):
 {'name': 'ada', 'age': 36}
 ```
 
-A key is there while its field is holding a value. A field the constructor
-does not take, and that has no default, holds none until something sets it —
-so it stays out of the view until then, and joins it the moment it is given
-one:
+A key is present while its field holds a value. A field the constructor
+does not take, and that has no default, holds nothing until something
+sets it. It stays out of the view until then:
 
 ```pycon
 >>> class Draft(Magic, mapping=True):
@@ -282,9 +267,9 @@ one:
 {'title': 'Ada', 'slug': 'ada'}
 ```
 
-On a frozen class, `__post_init__` cannot set such a field by assignment —
-refusing one after construction is what `frozen` is for. Reach past it with
-`object.__setattr__`, the same thing `dataclasses` and `attrs` ask for here:
+On a frozen class, `__post_init__` cannot set such a field by assignment.
+Use `object.__setattr__`, the same approach `dataclasses` and `attrs`
+require:
 
 ```pycon
 >>> class Slug(Magic, frozen=True):
@@ -297,8 +282,7 @@ refusing one after construction is what `frozen` is for. Reach past it with
 Slug(title='Hello World', slug='hello world')
 ```
 
-**A handful of functions** that work on any Magic class, or on one of its
-instances — `Point` from the top of this page, say:
+**Functions that work on any Magic class** (using `Point` from above):
 
 ```pycon
 >>> from bagof.magic import replace, asdict, astuple
@@ -311,26 +295,20 @@ Point(x=1.0, y=20.0)
 ```
 
 `replace` builds the copy by calling the class again, so conversion,
-validation and the init hooks all run on the new values — which is also why it
-works on a frozen class. The other side of that: a `__post_init__` which works
-one field out from another works it out again, starting from the value it
-already worked out, so `replace` with no changes at all can come back
-different. `asdict` hands the values back exactly as they are stored: it does
-not copy them, and a field holding another object gives you that object rather
-than a dict of its fields. Like the dict-like view, it leaves out a field that
-is holding no value; `astuple` says so instead, because a position only means
-anything while every field is in the tuple.
+validation and init hooks all run on the new values. This is also why it
+works on a frozen class. The other side of that: a `__post_init__` that
+derives one field from another will derive it again from the already-derived
+value. `asdict` returns values exactly as stored, without copying or
+recursing. A field with no value is left out. `astuple` raises instead,
+because a missing position would shift everything after it.
 
 There is also `fields` and `fields_dict` for the fields themselves, and
-`is_magic` to ask whether a class was built by `Magic` at all.
+`is_magic` to ask whether a class was built by `Magic`.
 
-**A field with no value** is left out of `repr()` as well, so an object you
-are half-way through filling in still prints. Equality counts it rather than
-skipping it: two objects are equal when the same fields are holding values and
-those values match — one that has been given a value is never equal to one
-that is still without, and `hash` agrees. Ordering is the one that refuses,
-for the same reason `astuple` does: a comparison reads the fields in turn, so
-it needs all of them.
+**A field with no value** is left out of `repr()` too, so a
+partially-filled object still prints cleanly. Equality counts it: two
+objects are equal when the same fields hold values and those values
+match. `hash` agrees.
 
 ```pycon
 >>> class Draft(Magic):
@@ -349,7 +327,7 @@ False
 ```
 
 **Mutable defaults that are not shared.** In a plain class, `x: list = []`
-hands every instance the *same* list. Here each one gets its own:
+gives every instance the same list. Here each one gets its own:
 
 ```pycon
 >>> class Basket(Magic):
@@ -360,14 +338,14 @@ hands every instance the *same* list. Here each one gets its own:
 []
 ```
 
-Set `mutable_default="raise"` to be stopped at the class definition instead,
-as `dataclasses` and `attrs` do — or `"allow"` when one shared object really
-is what you want.
+Set `mutable_default="raise"` to reject mutable defaults at class
+definition time, the way `dataclasses` and `attrs` do. Or `"allow"` when
+one shared object is what you want.
 
-**Hooks around construction.** Write `__pre_init__` or `__post_init__` and
-it runs on the way in. Give it a parameter and it receives everything the
-constructor was called with — `__pre_init__` sees the values as passed,
-`__post_init__` sees them as stored:
+**Hooks around construction.** Write `__pre_init__` or `__post_init__`
+and it runs during construction. Give it a parameter and it receives
+everything the constructor was called with. `__pre_init__` sees values as
+passed. `__post_init__` sees them as stored:
 
 ```python
 from bagof.magic import Magic, InitVar
@@ -385,9 +363,8 @@ class Circle(Magic):
 Circle(radius=6.0)
 ```
 
-**Generic classes.** A `Magic` class can take a type parameter like any
-other, and a subclass that says what it stands for gets fields of that
-type:
+**Generic classes.** A `Magic` class can take a type parameter, and a
+subclass that fills it in gets fields of that type:
 
 ```python
 from typing import Generic, TypeVar
@@ -409,20 +386,16 @@ Box(item='1')
 IntBox(item=1)
 ```
 
-`item` is `T` on `Box`, which is no type to convert to and nothing to
-validate against, and `int` on `IntBox` -- which is why one of them turns
-the string into a number and the other does not. It works the same way
-when the parameter is buried in the annotation (`List[T]`, `Optional[T]`,
-`Dict[str, T]`), and a class that fills in one parameter of two leaves the
-other standing for its own subclasses to fill in.
+`item` is `T` on `Box` (no specific type to convert to) and `int` on
+`IntBox` (which is why the string becomes a number). This works the same
+way when the parameter is nested (`List[T]`, `Optional[T]`, `Dict[str, T]`).
 
-Writing the parameter where the object is built -- `Box[int]("1")` -- is a
-different thing. That is a `typing` alias rather than a class, so it builds
-a plain `Box` and `item` stays as it was; give the subclass a name when you
-want the fields to follow.
+Writing the parameter at the call site, `Box[int]("1")`, is different. That
+produces a `typing` alias, not a class. It builds a plain `Box` and `item`
+stays `T`. Give the subclass a name when you want the fields to follow.
 
-**Documentation that writes itself.** Describe a field and it shows up in the
-class docstring and in the generated `__init__`:
+**Documentation that writes itself.** Describe a field and it shows up in
+the class docstring and in the generated `__init__`:
 
 ```python
 from bagof.magic import Doc
@@ -452,8 +425,7 @@ delay : float, default=0.5
 
 ## Building the right subclass
 
-A class can hand back one of its subclasses, chosen from the arguments it was
-given. Say which subclass stands for what, and call the base:
+A class can hand back one of its subclasses, chosen from the arguments:
 
 ```python
 class Chord(Magic, polymorphic=True):
@@ -473,12 +445,12 @@ MinorChord(root='A', mode='minor', variant='natural')
 Chord(root='C', mode='major', variant='natural')
 ```
 
-A default counts as a value the caller wrote out, so `Chord(root="C")` and
-`Chord(root="C", mode="major")` always give you the same class.
+A default counts the same as a value the caller passed, so `Chord(root="C")`
+and `Chord(root="C", mode="major")` always produce the same class.
 
-`MinorChord` does not have to write `mode` out again either: matching on one
-exact value gives the field that value as its default, so the subclass can be
-built on its own with only what is left.
+`MinorChord` does not need to write `mode` out again. Matching on one exact
+value gives the field that value as its default, so the subclass can be
+built on its own:
 
 ```pycon
 >>> MinorChord(root="A")
@@ -499,21 +471,19 @@ type to fit, or a question to answer:
 | `lambda v: v > 3` | the call answers yes |
 | `...` | the argument was given at all |
 
-A subclass is in the running when *every* constraint it wrote matches.
+A subclass is in the running when every constraint it declares matches.
 
 ### Which subclass wins
 
-More conditions beats fewer, and a narrower condition beats a wider one. In
-order: how many fields the subclass constrains, then how precise those
-constraints are (an exact value, then a set, then a pattern, then a type),
-then how far down the hierarchy the subclass sits.
+More conditions beats fewer. A narrower condition beats a wider one. In
+order: how many fields the subclass constrains, then how precise the
+constraints are (exact value, then set, then pattern, then type), then how
+far down the hierarchy the subclass sits.
 
-Nothing else is looked at — in particular not the order the subclasses were
-written or imported, which is what makes these systems answer differently on
-a different day. Two subclasses that no rule separates raise
-`AmbiguousPolymorphError` instead, and `priority=` settles it. It is also how
-you spell "when nothing else fits", since a subclass that constrains nothing
-matches everything:
+Import order is never considered. Two subclasses that no rule separates
+raise `AmbiguousPolymorphError`. Use `priority=` to settle it. It is also
+how you spell "when nothing else fits", since a subclass that constrains
+nothing matches everything:
 
 ```python
 class Note(Magic, polymorphic=True):
@@ -535,8 +505,8 @@ Natural(name='C')
 
 ### Narrowing more than once
 
-A subclass of a subclass registers with its parent, so each step narrows the
-choice by one:
+A subclass of a subclass registers with its parent, so each step narrows
+the choice:
 
 ```python
 class HarmonicMinor(MinorChord, on={"variant": "harmonic"}):
@@ -549,8 +519,7 @@ HarmonicMinor(root='A', mode='minor', variant='harmonic')
 ```
 
 Reaching `HarmonicMinor` means satisfying `MinorChord` first. Ask for
-`variant="harmonic"` without a `mode` and the first step matches nothing, so
-that is where it stops:
+`variant="harmonic"` without a `mode` and the first step matches nothing:
 
 ```pycon
 >>> Chord(root="A", variant="harmonic")
@@ -569,33 +538,28 @@ Chord(root='A', mode='major', variant='harmonic')
 Diminished(root='B', mode='dim', variant='natural')
 ```
 
-Registering later only changes what is built later; instances that already
-exist are untouched.
+Registering later only changes what is built later. Existing instances are
+untouched.
 
 ### The two settings
 
-`polymorphic="strict"` refuses to build the class itself, and names the
-subclasses it considered — which is how one in a module nobody imported shows
-up as the missing import it is, rather than as a dispatch that quietly did
-nothing. It says so even when *nothing* has registered yet, since that is the
-same mistake one step earlier. A class that is itself registered somewhere is
-exempt: being built is the whole point of having registered, so a leaf with no
-subclasses of its own is built normally and the setting is safe to inherit
-down a whole hierarchy.
+`polymorphic="strict"` refuses to build the class itself. It names the
+subclasses it considered. This is how a missing import shows up as a missing
+import, rather than as a dispatch that quietly did nothing. A class that is
+itself registered somewhere is exempt: building it is the whole point of
+having registered, so a leaf with no subclasses of its own works normally.
 
 `pin_discriminant` decides what the matched field becomes on the subclass.
-`"pin"`, the default, gives it that value as its default — it stays in the
-repr, in `==`, and in anything that walks the fields. `"classvar"` makes it a
-class attribute instead, stored once rather than once per instance; the
-constructor still accepts it and throws it away, so both
+`"pin"` (the default) gives it that value as a default. It stays in repr,
+in `==`, and in anything that walks the fields. `"classvar"` makes it a
+class attribute, stored once rather than once per instance. The constructor
+still accepts and discards the value, so both
 `Chord(root="A", mode="sus")` and `SusChord(root="A", mode="sus")` keep
 working. `"keep"` leaves the field exactly as the subclass wrote it.
 
-A pinned value is a default the class author wrote — on the class statement
-rather than beside the field, but theirs either way — so it is converted,
-validated and copied per instance exactly as `mode: str = "minor"` would be,
-and `convert_defaults` and `validate_defaults` apply to it like any other
-default.
+A pinned value is a default the class author wrote. It is converted,
+validated and copied per instance, exactly as `mode: str = "minor"` would
+be. `convert_defaults` and `validate_defaults` apply to it the same way.
 
 ```python
 class SusChord(Chord, on={"mode": "sus"}, pin_discriminant="classvar"):
@@ -611,18 +575,18 @@ SusChord(root='B', variant='natural')
 
 !!! warning "`classvar` and round trips"
     Under `"classvar"` the discriminant is no longer one of the instance's
-    fields, so `asdict` leaves it out — and a dictionary without it cannot be
+    fields, so `asdict` leaves it out. A dictionary without it cannot be
     dispatched back to the same subclass. Use `"pin"` whenever the values
     have to survive a round trip through a config file or a database.
 
-Writing the class attribute out yourself instead — `mode: ClassVar[str] =
-"minor"` — is refused, and the error says why: the base passes `mode` on to
-whatever it builds, so a subclass whose constructor does not take it could
-only be reached by a call that then fails. `pin_discriminant="classvar"` is
-that spelling, done in a way that keeps both calls working.
+Writing the class attribute yourself, `mode: ClassVar[str] = "minor"`, is
+refused. The error explains why: the base passes `mode` on to whatever it
+builds, so a subclass whose constructor does not take it would break.
+`pin_discriminant="classvar"` is that spelling, done so that both calls
+keep working.
 
-Pickling and copying rebuild through the class an instance already has, so
-neither of them goes back through the dispatch.
+Pickling and copying rebuild through the class an instance already has.
+Neither goes back through the dispatch.
 
 ---
 
@@ -633,10 +597,10 @@ Each of these can be used bare (`x: Frozen[int]`) or with a value
 
 | Annotation | What it does | Opposite |
 | --- | --- | --- |
-| `Default[T, v]` | give the field a default | — |
-| `Factory[T]` | build the default by calling something | — |
-| `ConvertTo[T]` | convert whatever comes in | — |
-| `Validate[T]` | reject anything that does not fit | — |
+| `Default[T, v]` | give the field a default | -- |
+| `Factory[T]` | build the default by calling something | -- |
+| `ConvertTo[T]` | convert whatever comes in | -- |
+| `Validate[T]` | reject anything that does not fit | -- |
 | `Init[T]` | say it is an argument, which it is anyway | `NoInit` |
 | `Kw[T]` | may be passed by name | `NotKw` |
 | `Positional[T]` | may be passed by position | `NotPositional` |
@@ -649,19 +613,17 @@ Each of these can be used bare (`x: Frozen[int]`) or with a value
 | `Compare[T]` | both of the above | `NoCompare` |
 | `Hash[T]` | count towards `hash()` | `NoHash` |
 | `Key[T]` | appear in the dict-like view | `NotKey` |
-| `ClassVar[T]` | shared by every instance | — |
-| `InitVar[T]` | passed in, used, not kept | — |
-| `Doc[T, "..."]` | describe the field | — |
+| `ClassVar[T]` | shared by every instance | -- |
+| `InitVar[T]` | passed in, used, not kept | -- |
+| `Doc[T, "..."]` | describe the field | -- |
 
-Each one sets exactly what its name mentions, and what it sets wins over
-the class setting: on a `kw_only=True` class, `x: Positional[int]` can be
-passed by position anyway, while `x: NotKw[int]` forbids the one way in
-that was left and so has no parameter at all — it takes its default,
-exactly like `NoInit[int]`. What an annotation says nothing about follows
-the class as usual.
+Each annotation sets exactly what its name says, and that wins over the
+class setting: on a `kw_only=True` class, `x: Positional[int]` can still
+be passed by position, while `x: NotKw[int]` forbids the only way left and
+the field takes its default instead (the same as `NoInit[int]`).
 
-Several of them go on one field by nesting, and when two disagree the outer
-one has the last word.
+Several annotations stack on one field by nesting. When two disagree, the
+outer one wins.
 
 ```pycon
 >>> class ByName(Magic):
@@ -676,22 +638,18 @@ ByName(x=1)
 ByPosition(x=1)
 ```
 
-`Init` and `NoInit` say *whether* a field is an argument at all; `Kw`,
-`Positional` and the two `...Only` pairs say *how* it may be passed. A
-field is an argument unless something says otherwise, so `Init[T]` is
-there to say that out loud and changes nothing — it is `NoInit` that
-does the work, by forbidding both ways at once.
+`Init` and `NoInit` say *whether* a field is an argument at all. `Kw`,
+`Positional` and the `...Only` pairs say *how* it may be passed. A field
+is an argument unless something says otherwise, so `Init[T]` changes
+nothing. `NoInit` does the work by forbidding both ways at once.
 
-That is also why `NotKwOnly` means "by position as well" and
-`NotPositionalOnly` means "by name as well": each negates its own name
-and leaves the other half alone, which makes them aliases for
-`Positional` and `Kw` rather than opposites of `KwOnly` and
-`PositionalOnly`.
+`NotKwOnly` means "by position as well" and `NotPositionalOnly` means "by
+name as well": each negates its own name and leaves the other half alone.
+This makes them aliases for `Positional` and `Kw`.
 
-One thing to know before reaching for `Positional` or `NotKwOnly` on a
-`kw_only=True` class: a field that can be passed by position moves to the
-front of the signature, ahead of the keyword-only ones, whatever order it
-was declared in.
+One thing to know: on a `kw_only=True` class, a field that can be passed by
+position moves to the front of the signature, ahead of the keyword-only
+fields, regardless of its declaration order.
 
 ```python
 class Point(Magic, kw_only=True):
@@ -704,7 +662,7 @@ class Point(Magic, kw_only=True):
 Point(a=2, x=1)
 ```
 
-`x` is declared second and is the first positional argument.
+`x` is declared second but becomes the first positional argument.
 
 Anything you cannot say with one of these, say with `Field(...)` inside an
 `Annotated`: `x: Annotated[int, Field(alias="ex", metadata={"unit": "m"})]`.
@@ -746,19 +704,16 @@ class Thing(Magic, frozen=True, kw_only=True, slots=True):
 | `reverse` | `False` | list a subclass's own fields before inherited ones |
 | `doc` | `True` | add the field table to the class docstring |
 
-Most of them also take a string instead of `True`, which writes the method
-under that name — handy when you want to call the generated one from your own.
-`order` gives the name to its `<` comparison; the class is then left with no
-comparison operators at all, so the method is there for you to call rather
-than to answer `<`.
+Most of them also accept a string instead of `True`, which binds the
+generated method under that name. This is useful when you want to call the
+generated method from your own.
 
 ---
 
 ## How it compares
 
 Close to [attrs][attrs] in spirit, with [pydantic][pydantic]'s habit of doing
-real work from your type hints — and inheritance where the others use
-decorators.
+real work from your type hints, and inheritance where the others use decorators.
 
 |  | dataclasses | attrs | pydantic | magic |
 | --- | --- | --- | --- | --- |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -4,18 +4,18 @@ icon: fontawesome/solid/scale-balanced
 
 # How it compares
 
-Four libraries solve overlapping problems, and picking between them is mostly a
-question of what you want the type hints to *do*.
+Four libraries solve overlapping problems. The choice depends on what you
+want the type hints to do.
 
-- **[dataclasses][]** is in the standard library and does the boring part:
-  `__init__`, `__repr__`, `__eq__`. It reads your hints but never acts on them.
-- **[attrs][]** does the same, better and with more control, and adds
-  converters and validators you write yourself.
-- **[pydantic][]** reads the hints and *acts* on them — parsing, coercing and
-  rejecting values — which is why it is everywhere in web and config code.
-- **`magic`** sits with attrs on API design and with pydantic on hints: nothing
-  is added to your class unless you ask for it, but when you do ask, the type
-  hint is what drives it.
+- **[dataclasses][]** is in the standard library. It generates `__init__`,
+  `__repr__`, `__eq__`. It reads your hints but never acts on them.
+- **[attrs][]** does the same, with more control, and adds converters and
+  validators you write yourself.
+- **[pydantic][]** reads the hints and acts on them: parsing, coercing and
+  rejecting values. This is why it dominates web and config code.
+- **`magic`** sits with attrs on API design and with pydantic on hints.
+  Nothing is added to your class unless you ask for it. When you do ask,
+  the type hint drives it.
 
 ## At a glance
 
@@ -100,42 +100,43 @@ question of what you want the type hints to *do*.
         tags: list = Field(default_factory=list)
     ```
 
-## Where each one is the better choice
+## Where each one fits best
 
-### Reach for dataclasses when…
+### dataclasses
 
-…you want no dependency at all and you only need the boring part. It is in the
-standard library, everyone recognises it, and every tool understands it. If
-your data is already the right type by the time it reaches you, the other three
-have nothing to add.
+Use it when you want no dependency and only need the basics. It is in the
+standard library, everyone recognises it, and every tool supports it. If
+your data is already the right type by the time it reaches you, the other
+three have nothing to add.
 
-### Reach for attrs when…
+### attrs
 
-…you want the boring part done well, with full control and no surprises. It is
-older and more battle-tested than either of the others, has no runtime
-dependency to speak of, and its validator library is excellent. `magic` follows
-its design lead — which means if you like attrs and want the type hints to do
-more of the work, `magic` should feel familiar rather than foreign.
+Use it when you want the basics done well, with full control and no
+surprises. It is older and more battle-tested than either of the others,
+has no heavy runtime dependency, and its validator library is excellent.
+`magic` follows its design lead. If you like attrs and want the type hints
+to do more of the work, `magic` should feel familiar.
 
-### Reach for pydantic when…
+### pydantic
 
-…you are parsing untrusted input at a boundary, and you want JSON schema,
-serialisation, and an enormous ecosystem of integrations. Nothing here competes
-with that. It also means your model class gains a large public API you did not
-write, which is fine at a boundary and less fine for a domain object.
+Use it when you are parsing untrusted input at a boundary, and you need
+JSON schema, serialisation, and a large ecosystem of integrations. Nothing
+here competes with that. It also means your model class gains a large
+public API you did not write. That is fine at a boundary and less fine for
+a domain object.
 
-### Reach for magic when…
+### magic
 
-…you want the hints to drive conversion and validation, but you want a plain
-class at the end of it — one where the only methods are the ones you wrote and
-the ones you asked for.
+Use it when you want the hints to drive conversion and validation, but you
+want a plain class at the end of it. One where the only methods are the
+ones you wrote and the ones you asked for.
 
 ## Things magic does that the others do not
 
 ### Settings are inherited
 
-Every other library re-applies its decorator per class. `magic` merges settings
-down the inheritance chain, so a base class sets the house style once:
+Every other library re-applies its decorator per class. `magic` merges
+settings down the inheritance chain. A base class sets the house style once:
 
 ```python
 from bagof.magic import Magic
@@ -154,14 +155,13 @@ User(name='ada', age=36)
 ```
 
 A subclass that changes a setting changes it for the fields it declares
-itself. Add `override=True` and it changes for the inherited fields too —
-except where a field asked for something in its own annotation, which always
-wins.
+itself. Add `override=True` and it changes inherited fields too. A field
+that asked for something in its own annotation always wins.
 
 ### Per-field behaviour is part of the annotation
 
-The others put it in a `field()` call on the right-hand side, which pushes the
-default out of the way and reads oddly once you use more than one:
+The others put it in a `field()` call on the right-hand side. That pushes
+the default out of the way and reads oddly once you use more than one:
 
 === "magic"
 
@@ -190,8 +190,8 @@ default out of the way and reads oddly once you use more than one:
 
 ### Instances can behave like dictionaries
 
-Useful for anything that is conceptually a record — a config section, a row, a
-header block:
+Useful for anything that is conceptually a record: a config section, a row,
+a header block:
 
 ```python
 from bagof.magic import Magic
@@ -206,8 +206,8 @@ class Header(Magic, mapping=True):
 {'content_type': 'text/plain', 'length': 12}
 ```
 
-A key is there while its field is holding a value, so a field that is only
-filled in later stays out of the view until it is.
+A key is present while its field holds a value. A field that is only filled
+in later stays out of the view until it is.
 
 ### The docstring writes itself
 
@@ -234,26 +234,22 @@ times : int, default=3
 
 ## Things the others do that magic does not
 
-Being honest about the gaps, with links to where they are being worked on:
-
-- **JSON schema and serialisation.** Pydantic's real draw, and `magic` has
-  neither yet.
-- **A recursive `asdict`.** `asdict` hands back the values as they are
-  stored, so a field holding another object gives you that object rather
-  than a dict of its fields. The others walk the whole tree, copying
-  lists and dicts as they go.
-- **A type parameter filled in where the object is built.** A subclass
-  fills one in — `class IntBox(Box[int])` gives `item` the type `int`, and
-  converts and validates against it — but the same thing written at the
-  point of use, `Box[int]("1")`, does not: that is a `typing` alias rather
-  than a class, so it builds a plain `Box` whose `item` is still `T`.
-  [Tracked here][generics]. Pydantic fills that one in too; `dataclasses`
+- **JSON schema and serialisation.** Pydantic's strongest feature. `magic`
+  has neither yet.
+- **A recursive `asdict`.** `asdict` returns values as stored. A field
+  holding another object gives you that object, not a dict of its fields.
+  The others walk the whole tree, copying lists and dicts on the way.
+- **A type parameter filled in at the call site.** A subclass fills one in:
+  `class IntBox(Box[int])` gives `item` the type `int`, and converts and
+  validates against it. But `Box[int]("1")` does not: that is a `typing`
+  alias, not a class, so it builds a plain `Box` whose `item` is still `T`.
+  [Tracked here][generics]. Pydantic fills that one in too. `dataclasses`
   and `attrs` fill in neither.
 - **Editor and type-checker support.** The others are understood by mypy and
-  pyright today, so your editor completes the constructor and catches a wrong
-  argument type. `magic` is not, yet — [tracked here][typing]. The route is
-  the same standard the others use, so most of it should follow; the part
-  that will not is a field written purely as an annotation
+  pyright today, so your editor completes the constructor and catches wrong
+  argument types. `magic` is not, yet ([tracked here][typing]). The route
+  is the same standard the others use, so most of it should follow. The
+  part that will not is a field written purely as an annotation
   (`tags: Factory[list]`), which a checker cannot see a default for.
 
 [dataclasses]: https://docs.python.org/3/library/dataclasses.html

--- a/src/bagof/magic/_api.py
+++ b/src/bagof/magic/_api.py
@@ -1,12 +1,10 @@
 """
 Functions you call on a Magic class or one of its instances.
 
-Everything here speaks the names the constructor uses. A field can be
-written under one name in the class body and reach `__init__` under
-another -- because it starts with an underscore, or because it was given
-an alias -- and it is that second name these functions use as a key, and
-that `replace` expects its keyword arguments to be named after. It is
-also the name `repr()` shows.
+Every function here uses the name the constructor takes. A field whose
+class-body name starts with an underscore, or that has an alias, reaches
+``__init__`` under a different name. That public name is the key in
+``fields_dict``, the keyword in ``replace``, and the label in ``repr``.
 """
 from __future__ import annotations
 
@@ -72,17 +70,21 @@ def _concrete(obj: tx.Any, caller: str) -> tx.Dict[str, Field]:
 
 def fields(cls: type) -> tx.Tuple[Field]:
     """
-    Get the fields of a Magic class.
+    Return the fields of a Magic class as a tuple.
+
+    Only concrete fields are included. ``ClassVar`` and ``InitVar``
+    fields are left out. A class that ``Magic`` never built has no
+    fields, so the result is an empty tuple.
 
     Parameters
     ----------
     cls : type
-        The class to get the fields of.
+        A Magic class (not an instance).
 
     Returns
     -------
-    fields : tuple[Field]
-        All concrete fields (that are not `ClassVar` or `InitVar`).
+    fields : tuple[Field, ...]
+        The class's concrete fields, in declaration order.
     """
     return tuple(
         field for field in getattr(cls, _FIELDS, {}).values()

--- a/src/bagof/magic/_fields.py
+++ b/src/bagof/magic/_fields.py
@@ -49,16 +49,14 @@ from ._utils import SlotsBase, _get_origin, slots
 T = tx.TypeVar("T")
 
 
-#: The class settings a field takes an answer from when it does not give
-#: one itself, and the field attributes each of them decides.
+#: Class settings that fill in a field's unset attributes, and which
+#: field attributes each setting controls.
 #:
-#: The two are not one for one -- `kw_only` and `positional_only` both
-#: decide the same pair, and `convert`, `validate` and `factory` each
-#: decide a pair of their own -- so the mapping is written out rather
-#: than guessed. It lists exactly what `Field.setdefault` reads from
-#: `Options`: `eq`, `order`, `hash` and `mapping` are not here, because
-#: a field works those out from itself rather than from its class, and
-#: there would be nothing to resolve again.
+#: The mapping is not one-to-one: `kw_only` and `positional_only` both
+#: control `kw` and `positional`, and `convert`, `validate` and `factory`
+#: each control a pair. Listed explicitly rather than inferred.
+#: `eq`, `order`, `hash` and `mapping` are absent because a field
+#: resolves those from its own values, not from its class.
 _OVERRIDABLE = {
     "convert": ("convert", "converter"),
     "factory": ("build", "factory"),
@@ -116,130 +114,111 @@ _RESOLVED_ATTRS = tuple(dict.fromkeys(
     'declared',
 )
 class Field(SlotsBase):
-    """A field in a `Magic`."""
+    """A single field in a Magic class.
+
+    Every annotation in a Magic class body becomes a `Field`. You rarely
+    create one directly. The annotation family (`Factory`, `KwOnly`,
+    `ConvertTo`, ...) and the `field()` function are the usual ways in.
+    """
 
     def __init__(self, *arg, **kwargs) -> None:
         """
         Parameters
         ----------
         name : str
-            The name of the field.
+            The field's name in the class body.
         type : type or type hint
-            The type of the field.
-            This is used for type checking, validation, and conversion.
+            The field's type. Used for conversion, validation and
+            factory defaults when those are turned on.
         default : any
-            The default value for the field.
+            The default value.
         build : bool, default=`Options().factory`
-            Whether this field's default is built by calling something,
-            once per instance, instead of being one shared value.
+            Build a fresh default per instance by calling something,
+            rather than sharing one value across all instances.
         factory : Callable[[], any], optional
-            What is called to build it. Leave it out to have one worked
-            out from the field's type. Passing a callable here turns
-            `build` on, and passing `factory=True` turns it on without
-            naming one.
+            What to call. Omit it and one is worked out from the type.
+            Passing a callable turns `build` on. Passing `factory=True`
+            turns it on without naming a callable.
         init : bool, optional
-            Whether this field is a parameter of the generated `__init__`.
-            It is not stored but worked out from `kw` and `positional`:
-            reading it gives `kw or positional`, so a field that can be
-            passed neither by name nor by position is no parameter at
-            all. Passing `init=False` here forbids both ways; passing
-            `init=True` says nothing, since a field is a parameter
-            unless something says otherwise. Assigning to `field.init`
-            afterwards always sets both.
-            Whether that method is generated at all is the class-level
-            `init` option, which is a separate question.
+            Whether this field appears in `__init__`. Not stored
+            directly: it reads as `kw or positional`. Setting
+            `init=False` forbids both ways. Setting `init=True` changes
+            nothing (a field is a parameter unless something says
+            otherwise). Assigning `field.init = value` afterwards sets
+            both `kw` and `positional`.
         repr : bool, default=True (False for a pseudo-field)
-            Whether to include this field in the generated `__repr__`.
-        hash : bool, default=None (follow this field's `eq`)
-            Whether to include this field in the generated `__hash__`.
-            Equal instances must hash equally, so a field left out of
-            the comparison is left out of the hash unless you say
-            otherwise.
+            Include this field in the generated `__repr__`.
+        hash : bool, default=None (follows `eq`)
+            Include this field in the generated `__hash__`. Defaults to
+            following `eq`, since equal instances must hash equally.
         eq : bool, default=True
-            Whether to include this field in the generated `__eq__`.
-        order : bool, default=the field's `eq`
-            Whether to include this field in the generated ordering. A
-            field out of the comparison is out of the ordering too;
-            asking for the reverse explicitly is an error.
+            Include this field in the generated `__eq__`.
+        order : bool, default=follows `eq`
+            Include this field in the generated ordering. A field out
+            of `__eq__` is out of ordering too. Setting `eq=False` with
+            `order=True` is an error.
         metadata : dict, optional
-            User-defined metadata for this field.
+            Arbitrary user-defined metadata.
         kw : bool, default=`not Options().positional_only`
-            Make this field a keyword argument in the generated `__init__`
-            method. To make the field keyword-only, set `positional=False`
-            as well; with both set to False the field is no argument at
-            all, the same as `init=False`.
+            Allow this field to be passed by keyword. To make it
+            keyword-only, also set `positional=False`. With both set to
+            False, the field takes its default (same as `init=False`).
         positional : bool, default=`not Options().kw_only`
-            Make this field a positional argument in the generated `__init__`
-            method. To make the field positional-only, set `kw=False` as well.
+            Allow this field to be passed by position. To make it
+            positional-only, also set `kw=False`.
         frozen : bool, default=`Options().frozen`
-            Whether to make this field immutable after initialization.
+            Forbid assignment after construction.
         convert : bool, default=`Options().convert`
-            Whether the value handed to this field is converted.
+            Convert the incoming value.
         converter : Callable[[any], any], optional
-            What converts it. Leave it out to have one worked out from
-            the field's type. Passing a callable here turns `convert`
-            on, and passing `converter=True` turns it on without naming
-            one.
+            What converts it. Omit it and one is worked out from the
+            type. Passing a callable turns `convert` on.
         validate : bool, default=`Options().validate`
-            Whether the value handed to this field is validated.
+            Validate the incoming value.
         validator : Callable[[any], any], optional
-            What validates it: it returns the value unchanged when it is
-            valid, and raises when it is not. Leave it out to have one
-            worked out from the field's type. Passing a callable here
-            turns `validate` on, and passing `validator=True` turns it
-            on without naming one.
+            What validates it: returns the value unchanged when valid,
+            raises when not. Omit it and one is worked out from the
+            type. Passing a callable turns `validate` on.
         derived : tuple of str, optional
             Which of `converter`, `validator` and `factory` were worked
-            out from the field's type rather than handed over ready
-            made. A subclass that fills in a type variable builds those
-            again from the type it filled in, and leaves the ones you
-            passed alone.
+            out from the type rather than provided. When a subclass
+            fills in a type variable, these are rebuilt from the new
+            type. Manually provided callables are left alone.
         var : bool, default=False
-            Whether this field is a pseudo-field (InitVar or ClassVar).
-            Pseudo-fields are not set by the generated `__init__` method,
-            but may be one of its arguments (when `init=True`), or used
-            in the generated `__repr__` method (when `init=False,
-            repr=True`).
-            It is often more readable to use the `InitVar` and `ClassVar`
-            annotations.
+            Mark this as a pseudo-field. An `InitVar` is passed to the
+            constructor but not stored. A `ClassVar` is a class
+            attribute, shared by every instance and absent from the
+            constructor. Using the `InitVar` and `ClassVar` annotations
+            is usually clearer.
         doc : str, optional
-            A docstring for this field.
-            The `typing_extensions.Doc` annotation can also be used to
-            set this.
+            Documentation for this field. Also settable through the
+            `Doc` annotation.
         key : bool | str, default=`Options().mapping`
-            Whether to include this field in the generated dict-like
-            interface. If a string, it will be used as the key.
+            Include this field in the dict-like interface. A string
+            value is used as the key name.
         alias : str, default=`name.lstrip("_")`
-            An alternative name for this field in the generated methods.
-            This is useful when the field name is not a valid Python
-            identifier, or when you want to use a different name in the
-            generated methods for readability or consistency with an
-            external API.
-            By default, names that start with an underscore will have
-            the underscore stripped in the alias.
+            The name used in generated methods (constructor parameter,
+            repr output, dict key). Useful when the field name is not a
+            good public name, or when matching an external API.
         declared : dict, optional
-            What this field asked for by itself, before a class filled
-            in everything it left unsaid. It is recorded the first time
-            the field is resolved against a class, and is what the
-            `override` class setting restores from when a subclass
-            resolves the field again against its own settings. There is
-            no reason to pass it by hand.
+            What this field asked for before the class filled in the
+            rest. Recorded the first time the field is resolved against
+            a class. Used by `override` to restore the field's own
+            preferences. No reason to pass it by hand.
 
         Other Parameters
         ----------------
         compare : bool, optional
-            Alias for setting both `eq` and `order` at the same time.
+            Shorthand for setting both `eq` and `order` at once.
         """
-        # The positional argument is a special case in which `Field``
-        # acts as the opposite of `Var`.
+        # The positional argument lets Field act as the opposite of Var.
         if arg and arg[0] is not MISSING:
             kwargs["var"] = not arg[0]
-        # Converting, validating and building a default are each two
-        # questions -- whether the step happens, and what does it -- and
-        # each has a slot for both. Naming the callable is the short way
-        # of asking for the step: `converter=int` converts with `int`,
-        # `converter=True` converts with whatever the field's type calls
-        # for, and `converter=False` does not convert.
+        # Each pipeline step (convert, validate, build) has two slots:
+        # a flag for "whether" and a callable for "what". Naming the
+        # callable implies the flag: `converter=int` turns convert on,
+        # `converter=True` turns it on without naming a callable, and
+        # `converter=False` turns it off.
         for call, flag in _PIPELINE.items():
             given = kwargs.get(call, MISSING)
             if given is MISSING:
@@ -249,18 +228,14 @@ class Field(SlotsBase):
                 del kwargs[call]
             else:
                 kwargs.setdefault(flag, True)
-        # `compare` is a special alias for setting both `eq` and `order`
-        # at the same time.
+        # `compare` sets both `eq` and `order` at once.
         compare = kwargs.get("compare", MISSING)
         if compare is not MISSING:
             kwargs.setdefault("eq", compare)
             kwargs.setdefault("order", compare)
-        # `init` has no slot of its own, for the same reason `compare`
-        # has none: a field is an argument of the generated `__init__`
-        # when it can be passed by name, by position, or both, so `init`
-        # sets that pair. Only `init=False` says anything, though -- a
-        # field is an argument unless something says otherwise, so
-        # `init=True` is what it already would have been.
+        # `init` has no slot: it maps to the `kw` and `positional` pair.
+        # `init=False` forbids both. `init=True` is the default and
+        # changes nothing.
         init = kwargs.pop("init", MISSING)
         if init is True:
             init = MISSING
@@ -271,10 +246,8 @@ class Field(SlotsBase):
         super().__init__(**kwargs)
 
     def __class_getitem__(cls, t: tx.Union[type, tx.Tuple]) -> tx.TypeAlias:
-        # Allow using Field as an annotation.
-        # It will likely never be used directly on the `Field` class,
-        # but will be useful for subclasses: e.g., `Factory[list]` is
-        # more concise than `Annotated[T, Field(factory=list)]`.
+        # Support subscript syntax: `Factory[list]` becomes
+        # `Annotated[list, Factory(build=True)]`.
         if not isinstance(t, tuple):
             t = (t,)
         t, *args = t
@@ -282,25 +255,16 @@ class Field(SlotsBase):
 
     @property
     def init(self) -> bool:
-        """Whether the generated `__init__` takes this field as an
-        argument.
+        """Whether the generated `__init__` takes this field.
 
-        A field is an argument when it can be passed by keyword, by
-        position, or both, and is no argument at all when it can be
-        passed neither way. Reading this works that out from `kw` and
-        `positional`.
+        True when the field can be passed by keyword, by position, or
+        both. False when it can be passed neither way. Computed from
+        `kw` and `positional`.
 
-        There are three ways to say it, and they do not all say the
-        same thing:
-
-        - `field.init = True` or `field.init = False` sets both `kw`
-          and `positional` to that, replacing whatever they held.
-          Assignment comes after the declarations have been read, so
-          there is nothing left for it to defer to.
-        - `Field(init=False)`, like `NoInit`, forbids both ways.
-        - `Field(init=True)`, like `Init`, says nothing at all: a field
-          is an argument unless something says otherwise, so how it may
-          be passed is left to `kw`, `positional` and the class.
+        Setting `field.init = True` or `field.init = False` sets both
+        `kw` and `positional` to that value. `Field(init=False)` (or
+        `NoInit`) forbids both ways. `Field(init=True)` (or `Init`)
+        changes nothing, since a field is a parameter by default.
         """
         return bool(self.kw or self.positional)
 
@@ -357,21 +321,16 @@ class Field(SlotsBase):
         return field
 
     def copy(self) -> tx.Self:
-        # A field is mutated in place while its class is built, and so
-        # is the record of what it declared: a copy must share neither
-        # with the field it was copied from. `update` copies slots by
-        # reference and would share the record; nothing hands it a
-        # resolved field today, but a caller that does has to copy the
-        # record the way this does.
+        # A field is mutated in place during class building, so a copy
+        # must not share its `declared` dict with the original.
         new = super().copy()
         if new.declared is not MISSING:
             new.declared = dict(new.declared)
         return new
 
     def __repr__(self) -> str:
-        # Everything but the record of what was declared, which is
-        # bookkeeping for `override` and would double the length of
-        # every field's repr.
+        # Omit `declared` from repr since it is bookkeeping for
+        # `override` and would double every repr's length.
         shown = (
             slot for slot in self._slots()
             if slot != "declared"
@@ -383,9 +342,8 @@ class Field(SlotsBase):
         return f"{type(self).__name__}({params})"
 
     def _redeclare(self, **values) -> None:
-        # Record a value as if this field had asked for it itself, so
-        # that re-resolving against another class's options leaves it
-        # alone.
+        # Set a value and mark it as the field's own preference, so
+        # re-resolving against a different class's options preserves it.
         for attr, value in values.items():
             setattr(self, attr, value)
             if self.declared is not MISSING and attr in self.declared:
@@ -397,9 +355,8 @@ class Field(SlotsBase):
         attrs: tx.Sequence[str],
         hints: tx.Optional[Hints] = None,
     ) -> None:
-        # Forget what a class filled in for `attrs`, and work those out
-        # again from `options`. Whatever the field asked for itself is
-        # restored unchanged, so it survives.
+        # Reset `attrs` to the field's own declarations, then resolve
+        # them again from `options`. The field's own preferences survive.
         for attr in attrs:
             setattr(self, attr, self.declared[attr])
         self.setdefault(options, hints)
@@ -407,18 +364,13 @@ class Field(SlotsBase):
     def setdefault(
         self, options: Options, hints: tx.Optional[Hints] = None
     ) -> None:
-        # When field options are not explicitly set (MISSING), they are
-        # inherited from the class options.
+        # Fill in unset field attributes from the class options.
         #
-        # `hints` says where to look up a type this field was annotated
-        # with by name -- a class that names itself, a type imported for
-        # type checking only -- when the converter, validator or factory
-        # built here is first used.
+        # `hints` tells where to look up a forward-referenced type when
+        # the converter, validator or factory is first used.
         #
-        # What the field asked for is kept as it was, so that a subclass
-        # can fill the rest in again from its own options -- that is the
-        # `override` class option, and `_reresolve` above is the other
-        # half of it.
+        # The field's own preferences are preserved so that `override`
+        # on a subclass can restore and re-resolve them.
         if self.declared is MISSING:
             self.declared = {
                 attr: getattr(self, attr) for attr in _RESOLVED_ATTRS
@@ -431,17 +383,13 @@ class Field(SlotsBase):
             self.doc = None
         if self.var is MISSING:
             self.var = False
-        # `repr`, `eq` and `order` are deliberately *not* read from the
-        # class options. Those decide whether a method is generated at
-        # all; this decides whether a field takes part in one. Conflating
-        # them made every generated method on a class that had opted out
-        # cover no fields -- so `__magic_eq__` on an `eq=False` class
-        # compared nothing and answered True for any two instances.
+        # `repr`, `eq` and `order` are not read from the class options.
+        # The class option decides whether the method is generated. The
+        # field attribute decides whether this field takes part in it.
         if self.repr is MISSING:
             # A sentinel on the class option is a per-field instruction
-            # ("show it only when it has a value"), so it propagates;
-            # a plain bool is only about whether `__repr__` is
-            # generated, which is not this field's business.
+            # ("show only when it has a value"), so it propagates. A
+            # plain bool controls whether __repr__ is generated at all.
             sentinel = (
                 isinstance(options.repr, SHOW_ATTR)
                 or options.repr is HIDE_IF_NONE
@@ -450,14 +398,10 @@ class Field(SlotsBase):
                 options.repr if sentinel and not self.var else not self.var
             )
         if self.hash is MISSING:
-            # `None` means "follow `eq`", which `_hash_add` reads. Forcing
-            # True here made a field excluded from `__eq__` still count
-            # towards `__hash__`, so two equal instances hashed apart and
-            # a set kept both.
+            # None means "follow eq", which _hash_add reads.
             self.hash = None
-        # `repr` and `key` each answer two questions -- whether the
-        # field takes part, and under which name -- so once resolved
-        # they are held as a `SHOW_ATTR` rather than as a plain value.
+        # `repr` and `key` encode both "whether" and "under which name",
+        # so once resolved they are stored as a SHOW_ATTR.
         if self.repr is HIDE_IF_NONE:
             if self.var:
                 self.repr = SHOW_ATTR(False)
@@ -466,12 +410,9 @@ class Field(SlotsBase):
         if not isinstance(self.repr, SHOW_ATTR):
             self.repr = SHOW_ATTR(self.repr)
         if self.key is MISSING:
-            # Like `repr`, and for the same reason: the class option
-            # says whether there is a dict-like view at all, which is
-            # not this field's business. What is the field's business is
-            # whether it belongs in one -- and a real field does, so
-            # that a class turning `mapping` on later, or a subclass
-            # turning it on, finds every field already in the view.
+            # The class option controls whether the dict-like view
+            # exists. A real field defaults to being in the view, so
+            # it is already included when mapping is turned on later.
             self.key = not self.var
         if self.key is HIDE_IF_NONE:
             self.key = HIDE_IF_NONE(self.public_name)
@@ -480,9 +421,7 @@ class Field(SlotsBase):
         if self.eq is MISSING:
             self.eq = True
         if self.order is MISSING:
-            # A field out of the comparison is out of the ordering too.
-            # Only an explicit `Field(eq=False, order=True)` is a
-            # contradiction, and that is still an error.
+            # A field out of eq is out of ordering too.
             self.order = self.eq
         if options.kw_only:
             if self.kw is MISSING:
@@ -507,12 +446,9 @@ class Field(SlotsBase):
             self.validate = options.validate
         if self.build is MISSING:
             self.build = options.factory
-        # A step that is on and was given nothing to do it with is done
-        # by something worked out from the field's type. Which of the
-        # three those are is worth remembering: a subclass that fills in
-        # a type variable has to build those again from the type it
-        # filled in, and must leave a converter, validator or factory
-        # that was handed over ready made exactly as it is.
+        # An active step with no callable gets one from the field's type.
+        # Track which ones came from the type, so that filling in a type
+        # variable rebuilds only those (not manually provided callables).
         for attr in _FROM_TYPE:
             if getattr(self, attr) is MISSING:
                 setattr(self, attr, None)
@@ -523,23 +459,19 @@ class Field(SlotsBase):
         self._rebuild(hints)
 
     def _rebuild(self, hints: tx.Optional[Hints] = None) -> None:
-        # Work out again, from the field's type, whatever was worked out
-        # from it the first time round.
+        # Rebuild the type-derived callables from the current type.
         for attr in self.derived or ():
             setattr(self, attr, _FROM_TYPE[attr](self.type, hints, self.name))
 
 
-#: How each of the three is built, for a field that asked for it to be
-#: worked out from its type.
+#: How each type-derived callable is built.
 _FROM_TYPE = {
     "converter": _make_converter,
     "validator": _make_validator,
     "factory": _make_factory,
 }
 
-#: Each step's callable slot, and the slot beside it that says whether
-#: the step happens at all. Reading the second is the only way to tell
-#: "no step" from "a step done by something that happens to be falsy".
+#: Each pipeline step's callable slot mapped to its flag slot.
 _PIPELINE = {
     "converter": "convert",
     "validator": "validate",
@@ -548,11 +480,10 @@ _PIPELINE = {
 
 
 def _stored(obj: tx.Any, field: Field) -> tx.Tuple[bool, tx.Any]:
-    """The value a field holds on an object, and whether it holds one.
+    """Return (has_value, value) for a field on an object.
 
-    A field that is not a constructor argument and has no default is
-    only ever set by hand, so an object can be perfectly usable and
-    still have nothing under this name.
+    A field with no constructor parameter and no default only gets a
+    value when set by hand, so (False, None) is a normal result.
     """
     try:
         return True, getattr(obj, field.name)
@@ -564,7 +495,7 @@ def _stored(obj: tx.Any, field: Field) -> tx.Tuple[bool, tx.Any]:
 # Annotations
 def field(**kwargs: tx.Any) -> tx.Any:
     """
-    Describe one field, for use as its default.
+    Describe one field, for use as its default value.
 
     ```python
     class Task(Magic):
@@ -573,14 +504,10 @@ def field(**kwargs: tx.Any) -> tx.Any:
         token: str = field(default="", repr=False)
     ```
 
-    Takes exactly what `Field` takes, and does the same thing. The
-    difference is what a type checker makes of it: this says it produces
-    whatever the field is annotated as, so `tags: list = field(...)`
-    reads as a `list` with a default rather than as a `Field` assigned to
-    a `list`.
-
-    Writing `Field(...)` in that position still works, and still builds
-    the same object.
+    Takes the same arguments as `Field` and produces the same object.
+    The difference is for type checkers: `field(...)` declares its
+    return type as the annotated type, so `tags: list = field(...)` reads
+    cleanly. `Field(...)` in that position also works.
     """
     return Field(**kwargs)
 
@@ -653,10 +580,8 @@ class BoolAnnotatedField(AnnotatedField):
         if not isinstance(args, tuple):
             args = (args,)
         t, *args = args
-        # No positional value: every slot takes the value its own
-        # declaring class set, so an inverse comes out `False` and a
-        # mixed pair (`KwOnly`) keeps one of each. Anything after the
-        # type stays metadata.
+        # No positional value: each slot takes the value its declaring
+        # class set. Anything after the type stays as metadata.
         return tx.Annotated[(t, cls()) + tuple(args)]
 
 

--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -6,151 +6,87 @@
 #   class creation time, rather than looping through fields at run-time.
 #   This is already done for __init__, but not for the other ones.
 """
-A `Magic` acts like a python `dataclass`, except that it operates
-via inheritance, rather than via a decorator (although the @magic
-decorator can be used if preferred).
+The class builder: ``MetaMagic``, ``Magic``, and the ``magic`` decorator.
 
-The options typically specified in the @dataclass decorator are instead
-specified as class keyword arguments, and are inherited (or overloaded)
-by subclasses.
+``MetaMagic`` is the metaclass that reads annotations, resolves options,
+and writes the generated methods (``__init__``, ``__repr__``, ``__eq__``,
+and the rest) into the class namespace before the class object exists.
 
-```python
-class Point(Magic, frozen=True):
-    x: float
-    y: float
+``Magic`` is the base class most users inherit from. ``magic`` is a
+decorator that does the same thing for a class that does not inherit
+from ``Magic``.
 
-# --- or ---
+Options are class keyword arguments and are inherited by subclasses::
 
-@magic(frozen=True)
-class Point:
-    x: float
-    y: float
-```
+    class Point(Magic, frozen=True):
+        x: float
+        y: float
 
-Most options supported by dataclasses are supported, but there are
-some differences. Additional options are also implemented:
+Per-field behaviour is written in the annotation::
+
+    x: Factory[list]          # default factory
+    x: ConvertTo[int]         # convert on the way in
+    x: KwOnly[bool] = False   # keyword-only with a default
 
 Parameters
 ----------
 init : bool | str, default=True
-    Generate `__init__` method
+    Generate ``__init__`` method.
 repr : bool | str, default=True
-    Generate `__repr__` method; a field holding no value is left out
+    Generate ``__repr__`` method. A field holding no value is left out.
 eq : bool | str, default=True
-    Generate `__eq__` method; two objects are equal when the same
-    fields are holding values and those values match
+    Generate ``__eq__`` method. Two objects are equal when the same
+    fields hold values and those values match.
 order : bool | str, default=False
-    Generate `__lt__`, `__le__`, `__gt__` and `__ge__` methods; a field
-    holding no value stops the comparison
+    Generate ``__lt__``, ``__le__``, ``__gt__`` and ``__ge__`` methods.
 hash : bool | str, default=None
-    Generate `__hash__` method; if `None`, decide automatically
+    Generate ``__hash__`` method. If None, decide automatically.
 unsafe_hash : bool, default=False
-    Always generate `__hash__` method
+    Always generate ``__hash__`` method.
 frozen : bool, default=False
-    Disable `__setattr__` and `__delattr__`
+    Disable ``__setattr__`` and ``__delattr__``.
 match_args : bool | str, default=False
-    Generate `__match_args__` for pattern matching
+    Generate ``__match_args__`` for pattern matching.
 kw_only : bool, default=False
-    Make all fields keyword-only by default
+    Make all fields keyword-only by default.
 positional_only : bool, default=False
-    Make all fields positional-only by default
+    Make all fields positional-only by default.
 slots : bool, default=False
-    Generate `__slots__` and remove `__dict__`
+    Generate ``__slots__`` and remove ``__dict__``.
 weakref_slot : bool, default=False
-    Generate a weakref slot in `__slots__`
+    Generate a weakref slot in ``__slots__``.
 factory : bool, default=False
-    Use field type as factory if none is provided
+    Use field type as factory if none is provided.
 mutable_default : str, default="factory"
-    What to do with a mutable default such as `x: list = []`
+    What to do with a mutable default such as ``x: list = []``.
+    "factory" gives each instance its own copy, "raise" refuses the
+    class, "allow" shares one object between instances.
 convert : bool, default=False
-    Use field type as converter if none is provided
+    Use field type as converter if none is provided.
 validate : bool, default=False
-    Use field type as validator if none is provided
+    Use field type as validator if none is provided.
 convert_defaults : bool, default=True
-    Convert a value that came from a field's own default
+    Convert a value that came from a field's own default.
 validate_defaults : bool, default=True
-    Validate a value that came from a field's own default
+    Validate a value that came from a field's own default.
 unresolved_hints : str, default="warn"
-    What to do when a type hint still names something undefined the
-    first time a field needs it: "warn", "raise" or "ignore"
+    What to do when a type hint names something still undefined the
+    first time a field needs it. "warn", "raise" or "ignore".
 mapping : bool, default=False
-    Implement the `Mapping` protocol; a subclass inherits the dict-like
-    methods and cannot turn them off. Only a field that is holding a
-    value is a key
+    Implement the Mapping protocol. Only a field holding a value is
+    a key.
 override : bool | str | list, default=False
-    Decide the settings of an inherited field again from this class;
-    a name, or a list of names, decides only those
+    Resolve an inherited field's settings again from this class.
 polymorphic : bool | str, default=False
     Build one of this class's subclasses instead of this class,
-    chosen from the arguments it was given. A subclass says which
-    arguments it stands for with `on=` on its own class statement.
-    With "strict", a call matching none of them is refused rather
-    than building this class.
-pin_discriminant : {"pin", "classvar", "keep"}, default="pin"
-    What a subclass does with a field it matches on exactly. "pin"
-    gives the field that value as its default, so it still shows in
-    the repr and survives a round trip; "classvar" makes it a class
-    attribute that is not stored per instance, still accepted by the
-    constructor and discarded; "keep" leaves the field alone.
+    chosen from the arguments it was given.
+pin_discriminant : str, default="pin"
+    What a subclass does with a field it matches on exactly.
+    "pin", "classvar" or "keep".
 reverse : bool, default=False
-    Use the reverse MRO order to determine field order
+    Use the reverse MRO order to determine field order.
 doc : bool | str, default=True
-    Add field documentation to class docstring
-
-Examples
---------
-It also differs from a standard dataclass in that field-specific options
-are assigned via annotations, rather than via a `field` function:
-
-```python
-# - Default factories
-#   instead of x: list = field(factory=list)
-x: Factory[list, list_factory]
-x: Annotated[list, Factory(list_factory)]
-
-#   if no factory is provided, it will use the type as the default factory
-x: Factory[list] -> x: Annotated[list, Factory(list)]
-
-# - Include in the init method
-#   instead of x: int = field(init=True)
-x: Init[int]
-x: Annotated[int, Init()]
-x: Annotated[int, Init(True)]
-x: NoInit[int]
-x: Annotated[int, NoInit()]
-x: Annotated[int, Init(False)]
-
-# - Keyword-only arguments
-#   instead of x: int = field(kw_only=True)
-x: KwOnly[int]
-x: Annotated[int, KwOnly()]
-x: Annotated[int, KwOnly(True)]
-x: NotKwOnly[int]
-x: Annotated[int, NotKwOnly()]
-x: Annotated[int, KwOnly(False)]
-```
-
-It supports additional features such as automatic conversion of field
-values via annotations:
-
-```python
-x: ConvertTo[int, partial(int, base=16)]
-x: Annotated[int, ConvertTo(partial(int, base=16))]
-
-# if no converter is provided, it will use the type as the default converter
-x: ConvertTo[int] -> x: Annotated[int, ConvertTo(int)]
-```
-
-Frozen or unfrozen fields:
-
-```python
-x: Frozen[int]
-x: Annotated[int, Frozen()]
-x: Annotated[int, Frozen(True)]
-x: NotFrozen[int]
-x: Annotated[int, NotFrozen()]
-x: Annotated[int, Frozen(False)]
-```
+    Add field documentation to class docstring.
 """
 from __future__ import annotations
 
@@ -3078,21 +3014,10 @@ def _dispatching(metacls: type) -> type:
 )
 class MetaMagic(ABCMeta):
     """
-    Examples
-    --------
-    ```python
-    # Functional API
-    MetaMagic(name, bases, namespace, **options) -> type: ...
+    Metaclass that builds a Magic class.
 
-    # Class-based API
-    class Magic(*bases, metaclass=MetaMagic, **options):
-        ...
-
-    # Decorator API
-    @magic(**options)
-    class MyStruct:
-        ...
-    ```
+    Most users never name ``MetaMagic`` directly. Inherit from
+    ``Magic`` instead, or use the ``@magic`` decorator.
 
     Parameters
     ----------
@@ -3106,101 +3031,69 @@ class MetaMagic(ABCMeta):
     Other Parameters
     ----------------
     init : bool | str, default=True
-        Generate `__init__` method.
+        Generate ``__init__`` method.
     repr : bool | str, default=True
-        Generate `__repr__` method. A field is shown while it is
-        holding a value, so a field the constructor does not take, with
-        no default, is left out until something sets it.
+        Generate ``__repr__`` method. A field is shown while it holds
+        a value. A field the constructor does not take, with no
+        default, is left out until something sets it.
     eq : bool | str, default=True
-        Generate `__eq__` method. Two objects are equal when the same
-        fields are holding values and those values match: one that has
-        been given a value is never equal to one that is still without.
+        Generate ``__eq__`` method. Two objects are equal when the
+        same fields hold values and those values match.
     order : bool | str, default=False
-        Generate `__lt__`, `__le__`, `__gt__` and `__ge__` methods.
-        Given a name, generate the `<` comparison under that name; the
-        class is then left with none of the four comparison operators,
-        including any it would otherwise inherit. A field holding no
-        value stops the comparison and says so, since an order over
-        part of an object is not an order over the object.
+        Generate ``__lt__``, ``__le__``, ``__gt__`` and ``__ge__``
+        methods. Given a name, generate the ``<`` comparison under
+        that name.
     hash : bool | str, default=None
-        Generate `__hash__` method.
-        If `None`, decide automatically.
+        Generate ``__hash__`` method. If None, decide automatically.
     unsafe_hash : bool, default=False
-        Always generate `__hash__` method.
+        Always generate ``__hash__`` method.
     frozen : bool, default=False
-        Disable `__setattr__` and `__delattr__`.
+        Disable ``__setattr__`` and ``__delattr__``.
     match_args : bool | str, default=False
-        Generate `__match_args__` for pattern matching.
+        Generate ``__match_args__`` for pattern matching.
     kw_only : bool, default=False
         Make all fields keyword-only by default.
     positional_only : bool, default=False
         Make all fields positional-only by default.
     slots : bool, default=False
-        Generate `__slots__` and remove `__dict__`.
+        Generate ``__slots__`` and remove ``__dict__``.
     weakref_slot : bool, default=False
-        Generate a weakref slot in `__slots__`.
+        Generate a weakref slot in ``__slots__``.
     factory : bool, default=False
         Use field type as factory if none is provided.
-    mutable_default : {"factory", "raise", "allow"}, default="factory"
-        What to do with a mutable default such as `x: list = []`.
-        "factory" gives each instance its own copy, "raise" refuses the
-        class, and "allow" shares one object between instances.
+    mutable_default : str, default="factory"
+        What to do with a mutable default such as ``x: list = []``.
+        "factory" gives each instance its own copy, "raise" refuses
+        the class, "allow" shares one object between instances.
     convert : bool, default=False
         Use field type as converter if none is provided.
     validate : bool, default=False
         Use field type as validator if none is provided.
     convert_defaults : bool, default=True
-        Convert a value that came from a field's own default, the same
-        way a value passed to the constructor is converted. Set it to
-        False to leave the defaults written in the class alone and
-        convert only what a caller passes.
+        Convert a value that came from a field's own default.
     validate_defaults : bool, default=True
-        Validate a value that came from a field's own default, the same
-        way a value passed to the constructor is validated. Set it to
-        False to leave the defaults written in the class alone and
-        check only what a caller passes.
+        Validate a value that came from a field's own default.
     unresolved_hints : str, default="warn"
-        What to do when a field is annotated with a type that is still
-        not defined the first time the field needs it. "warn" says so
-        once and carries on without converting or validating, "raise"
-        turns it into an error, and "ignore" says nothing. A default
-        value that cannot be built raises whichever is chosen, since
-        there is no value to hand back.
+        What to do when a type hint names something still undefined
+        the first time a field needs it. "warn" says so once, "raise"
+        turns it into an error, "ignore" says nothing.
     mapping : bool, default=False
-        Implement the `Mapping` protocol. A subclass cannot turn it off
-        again: it would inherit these methods, and they answer with the
-        fields of the class they were generated for. Only a field that
-        is holding a value is a key, so which keys an instance has is a
-        question about that instance: the length can differ between two
-        instances of one class, and can change over an instance's life.
+        Implement the Mapping protocol. Only a field holding a value
+        is a key.
     override : bool | str | list, default=False
-        Decide the settings of an inherited field again from this
-        class. A field is resolved against the settings of the class
-        that declares it and keeps those answers, so by default
-        `frozen=False` on a subclass only reaches the fields that
-        subclass declares itself; `override=True` applies this class's
-        settings to the fields it inherits as well. What a field asked
-        for in its own annotation always wins, whichever way this is
-        set. Give the name of a setting, or a list of names, to decide
-        only those again: frozen, kw_only, positional_only, convert,
-        validate, factory and repr are the ones a field takes from its
-        class.
+        Resolve an inherited field's settings again from this class.
+        ``override=True`` applies to all inherited fields. A name or
+        list of names applies to those settings only.
     polymorphic : bool | str, default=False
         Build one of this class's subclasses instead of this class,
-        chosen from the arguments it was given. A subclass says which
-        arguments it stands for with `on=` on its own class statement.
-        With "strict", a call matching none of them is refused rather
-        than building this class.
-    pin_discriminant : {"pin", "classvar", "keep"}, default="pin"
+        chosen from the arguments it was given. With "strict", a call
+        matching no subclass is refused.
+    pin_discriminant : str, default="pin"
         What a subclass does with a field it matches on exactly. "pin"
-        gives the field that value as its default, so it still shows in
-        the repr and survives a round trip; "classvar" makes it a class
-        attribute that is not stored per instance, still accepted by the
-        constructor and discarded; "keep" leaves the field alone.
+        gives it a default, "classvar" makes it a class attribute,
+        "keep" leaves it alone.
     reverse : bool, default=False
         Use the reverse MRO order to determine field order.
-        This only affects the relative order of the fields of one class
-        with respect to the fields of its base classes.
     doc : bool | str, default=True
         Add field documentation to class docstring.
 
@@ -3327,114 +3220,86 @@ class MetaMagic(ABCMeta):
 
 class Magic(metaclass=MetaMagic):
     """
-    Base class for data structures.
+    Base class for data structures driven by type hints.
+
+    Inherit from ``Magic`` to get a generated ``__init__``, ``__repr__``
+    and ``__eq__``. Options are class keyword arguments and are
+    inherited by subclasses.
 
     Examples
     --------
-    ```python
-    class Point(Magic, frozen=True):
-        x: float
-        y: float
-    ```
+    ::
+
+        class Point(Magic, frozen=True):
+            x: float
+            y: float
 
     Parameters
     ----------
     init : bool | str, default=True
-        Generate `__init__` method.
+        Generate ``__init__`` method.
     repr : bool | str, default=True
-        Generate `__repr__` method. A field is shown while it is
-        holding a value, so a field the constructor does not take, with
-        no default, is left out until something sets it.
+        Generate ``__repr__`` method. A field is shown while it holds
+        a value. A field the constructor does not take, with no
+        default, is left out until something sets it.
     eq : bool | str, default=True
-        Generate `__eq__` method. Two objects are equal when the same
-        fields are holding values and those values match: one that has
-        been given a value is never equal to one that is still without.
+        Generate ``__eq__`` method. Two objects are equal when the
+        same fields hold values and those values match.
     order : bool | str, default=False
-        Generate `__lt__`, `__le__`, `__gt__` and `__ge__` methods.
-        Given a name, generate the `<` comparison under that name; the
-        class is then left with none of the four comparison operators,
-        including any it would otherwise inherit. A field holding no
-        value stops the comparison and says so, since an order over
-        part of an object is not an order over the object.
+        Generate ``__lt__``, ``__le__``, ``__gt__`` and ``__ge__``
+        methods. Given a name, generate the ``<`` comparison under
+        that name.
     hash : bool | str, default=None
-        Generate `__hash__` method.
-        If `None`, decide automatically.
+        Generate ``__hash__`` method. If None, decide automatically.
     unsafe_hash : bool, default=False
-        Always generate `__hash__` method.
+        Always generate ``__hash__`` method.
     frozen : bool, default=False
-        Disable `__setattr__` and `__delattr__`.
+        Disable ``__setattr__`` and ``__delattr__``.
     match_args : bool | str, default=False
-        Generate `__match_args__` for pattern matching.
+        Generate ``__match_args__`` for pattern matching.
     kw_only : bool, default=False
         Make all fields keyword-only by default.
     positional_only : bool, default=False
         Make all fields positional-only by default.
     slots : bool, default=False
-        Generate `__slots__` and remove `__dict__`.
+        Generate ``__slots__`` and remove ``__dict__``.
     weakref_slot : bool, default=False
-        Generate a weakref slot in `__slots__`.
+        Generate a weakref slot in ``__slots__``.
     factory : bool, default=False
         Use field type as factory if none is provided.
-    mutable_default : {"factory", "raise", "allow"}, default="factory"
-        What to do with a mutable default such as `x: list = []`.
-        "factory" gives each instance its own copy, "raise" refuses the
-        class, and "allow" shares one object between instances.
+    mutable_default : str, default="factory"
+        What to do with a mutable default such as ``x: list = []``.
+        "factory" gives each instance its own copy, "raise" refuses
+        the class, "allow" shares one object between instances.
     convert : bool, default=False
         Use field type as converter if none is provided.
     validate : bool, default=False
         Use field type as validator if none is provided.
     convert_defaults : bool, default=True
-        Convert a value that came from a field's own default, the same
-        way a value passed to the constructor is converted. Set it to
-        False to leave the defaults written in the class alone and
-        convert only what a caller passes.
+        Convert a value that came from a field's own default.
     validate_defaults : bool, default=True
-        Validate a value that came from a field's own default, the same
-        way a value passed to the constructor is validated. Set it to
-        False to leave the defaults written in the class alone and
-        check only what a caller passes.
+        Validate a value that came from a field's own default.
     unresolved_hints : str, default="warn"
-        What to do when a field is annotated with a type that is still
-        not defined the first time the field needs it. "warn" says so
-        once and carries on without converting or validating, "raise"
-        turns it into an error, and "ignore" says nothing. A default
-        value that cannot be built raises whichever is chosen, since
-        there is no value to hand back.
+        What to do when a type hint names something still undefined
+        the first time a field needs it. "warn" says so once, "raise"
+        turns it into an error, "ignore" says nothing.
     mapping : bool, default=False
-        Implement the `Mapping` protocol. A subclass cannot turn it off
-        again: it would inherit these methods, and they answer with the
-        fields of the class they were generated for. Only a field that
-        is holding a value is a key, so which keys an instance has is a
-        question about that instance: the length can differ between two
-        instances of one class, and can change over an instance's life.
+        Implement the Mapping protocol. Only a field holding a value
+        is a key.
     override : bool | str | list, default=False
-        Decide the settings of an inherited field again from this
-        class. A field is resolved against the settings of the class
-        that declares it and keeps those answers, so by default
-        `frozen=False` on a subclass only reaches the fields that
-        subclass declares itself; `override=True` applies this class's
-        settings to the fields it inherits as well. What a field asked
-        for in its own annotation always wins, whichever way this is
-        set. Give the name of a setting, or a list of names, to decide
-        only those again: frozen, kw_only, positional_only, convert,
-        validate, factory and repr are the ones a field takes from its
-        class.
+        Resolve an inherited field's settings again from this class.
+        ``override=True`` applies to all inherited fields. A name or
+        list of names applies to those settings only.
     polymorphic : bool | str, default=False
         Build one of this class's subclasses instead of this class,
-        chosen from the arguments it was given. A subclass says which
-        arguments it stands for with `on=` on its own class statement.
-        With "strict", a call matching none of them is refused rather
-        than building this class.
-    pin_discriminant : {"pin", "classvar", "keep"}, default="pin"
+        chosen from the arguments it was given. With "strict", a call
+        matching no subclass is refused.
+    pin_discriminant : str, default="pin"
         What a subclass does with a field it matches on exactly. "pin"
-        gives the field that value as its default, so it still shows in
-        the repr and survives a round trip; "classvar" makes it a class
-        attribute that is not stored per instance, still accepted by the
-        constructor and discarded; "keep" leaves the field alone.
+        gives it a default, "classvar" makes it a class attribute,
+        "keep" leaves it alone.
     reverse : bool, default=False
         Use the reverse MRO order to determine field order.
-        This only affects the relative order of the fields of one class
-        with respect to the fields of its base classes.
     doc : bool | str, default=True
         Add field documentation to class docstring.
     """
@@ -3479,8 +3344,10 @@ def magic(cls: type, **kwargs) -> type: ...
 )
 def magic(cls: tx.Optional[type] = None, **kwargs):
     """
-    Decorator for defining a Magic class.
-    See `Magic` for parameters and examples.
+    Build a Magic class from a plain class.
+
+    Takes the same options as ``Magic``. Use this when inheritance is
+    not an option.
     """
     if cls is None:
         return partial(magic, **kwargs)

--- a/src/bagof/magic/_options.py
+++ b/src/bagof/magic/_options.py
@@ -36,18 +36,15 @@ from ._utils import SlotsBase, slots
 )
 class Options(SlotsBase):
     """
-    The resolved set of class-level options for a `Magic` class.
+    The resolved set of class-level options for a Magic class.
 
-    `MetaMagic` builds one `Options` instance per class from the keyword
-    arguments passed to the class statement (or to the `magic` decorator),
-    merged with the options inherited from base classes in MRO order --
-    a base class's value is used unless a derived class explicitly sets
-    its own. The result is stored on the class as `cls.__magic_options__`
-    and, together with each field's own overrides, decides which dunder
-    methods (`__init__`, `__repr__`, `__eq__`, ...) get generated and how.
+    Each Magic class gets one ``Options`` instance, built from the
+    keyword arguments on the class statement (or the ``@magic``
+    decorator), merged with the options inherited from base classes in
+    MRO order. A base class's value is used unless a derived class
+    explicitly sets its own.
 
-    See `Magic` for the full list of supported options and their
-    defaults.
+    See ``Magic`` for the full list of options and their defaults.
     """
 
     _DEFAULTS: tx.Dict[str, tx.Any] = dict(


### PR DESCRIPTION
A substantive rewrite of every user-facing string in the package. No behaviour changes anywhere — only prose, docstrings, comments, and CLAUDE.md.

## What changed

**README.md** (net −130 lines). Restructured, not just rephrased. Paragraphs that explained implementation rather than usage are cut. Each section leads with what to write and follows with what happens. Examples speak for themselves; surrounding prose is there only when the example doesn't say it all.

**docs/comparison.md** (net −20 lines). Rewritten as a quick reference for someone arriving from dataclasses, attrs, or pydantic. Each library gets a short "when to use it" paragraph. The side-by-side table and four-way code sample are kept.

**`_magic.py` module docstring** (replaced entirely). The old one narrated the library's relationship to dataclasses and showed invented `->` pseudo-code. The new one is a concise description with the option list that `test_options_are_documented` requires, plus real annotation examples.

**`MetaMagic` and `Magic` class docstrings.** Option descriptions are plainer. Set-notation (`{"factory","raise","allow"}`) replaced with prose (the docstrings go through `str.format()`). Every option still present — the test checks.

**`Field.__init__` numpydoc block** in `_fields.py` (net −100 lines). Rewritten to be practical rather than exhaustive. Each parameter says what it does in one or two sentences. Internal implementation details removed.

**`_api.py` module and function docstrings.** Tightened. `fields()`, `fields_dict()`, `asdict()`, `astuple()`, `replace()` each say what they do without naming internals.

**`_options.py`** `Options` docstring simplified.

**Code comments** across all touched files. Same substance, direct voice. No "we now", no changelog-speak, no `--` connectors.

**CLAUDE.md** documentation-style section. Rewritten to describe the new standard: lead with what the user writes, cut implementation details from public docs, short sentences. Fixed stale `Factory(factory=True)` example to `Factory(build=True)`.

## Scope

| | before | after |
| --- | --- | --- |
| Lines across 7 files | 6884 | 6614 (net −270) |
| Additions | — | 529 |
| Deletions | — | 799 |

Files left unchanged after review: `_arguments.py`, `_constants.py`, `_errors.py`, `_polymorph.py`, `_generics.py`, `_resolve.py`, `_utils.py` — their writing was already in good shape.

## Verification

All 1008 tests pass (1 skipped), excluding 4 pre-existing `test_dataclass_transform` failures. `ruff check` clean. Every `pycon` block still runs on 3.8+. Every option still appears in all three numpydoc blocks and the README settings table.