### PR TITLE
Recurse into Magic instances in asdict/astuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,8 +298,8 @@ Point(x=1.0, y=20.0)
 validation and init hooks all run on the new values. This is also why it
 works on a frozen class. The other side of that: a `__post_init__` that
 derives one field from another will derive it again from the already-derived
-value. `asdict` returns values exactly as stored, without copying or
-recursing. A field with no value is left out. `astuple` raises instead,
+value. `asdict` recurses into nested Magic instances. Everything else is
+returned as-is. A field with no value is left out. `astuple` raises instead,
 because a missing position would shift everything after it.
 
 There is also `fields` and `fields_dict` for the fields themselves, and

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -46,7 +46,7 @@ want the type hints to do.
 | | | | | |
 | **Around the edges** | | | | |
 | Copy with changes | `replace` | `evolve` | `model_copy` | **`replace`** |
-| Convert to a plain `dict` | `asdict` | `asdict` | `model_dump` | **`asdict`**, *without recursing* |
+| Convert to a plain `dict` | `asdict` | `asdict` | `model_dump` | **`asdict`** |
 | JSON schema | no | no | yes | no |
 | Generic classes | yes | yes | yes | **yes**, *[named subclass only][generics]* |
 | Runtime dependency | none | `attrs` | `pydantic-core` (compiled) | the `bagof` packages |
@@ -236,9 +236,9 @@ times : int, default=3
 
 - **JSON schema and serialisation.** Pydantic's strongest feature. `magic`
   has neither yet.
-- **A recursive `asdict`.** `asdict` returns values as stored. A field
-  holding another object gives you that object, not a dict of its fields.
-  The others walk the whole tree, copying lists and dicts on the way.
+- **Deep-copying leaves.** `dataclasses.asdict` deep-copies every non-dataclass
+  value; `magic`'s `asdict` returns non-Magic values as-is. This is deliberate:
+  a field holding a NumPy array or a large object should not be silently copied.
 - **A type parameter filled in at the call site.** A subclass fills one in:
   `class IntBox(Box[int])` gives `item` the type `int`, and converts and
   validates against it. But `Box[int]("1")` does not: that is a `typing`

--- a/src/bagof/magic/_api.py
+++ b/src/bagof/magic/_api.py
@@ -23,6 +23,50 @@ __all__ = [
 ]
 
 
+def _asdict_inner(obj: tx.Any) -> tx.Any:
+    """Walk a value, recursing into Magic instances and containers."""
+    cls = type(obj)
+    if getattr(cls, _FIELDS, None) is not None:
+        return {
+            name: _asdict_inner(value)
+            for name, field in _keyed(
+                f for f in getattr(cls, _FIELDS).values() if not f.var
+            ).items()
+            for has_value, value in (_stored(obj, field),)
+            if has_value
+        }
+    if isinstance(obj, tuple) and hasattr(obj, "_fields"):
+        return type(obj)(*(_asdict_inner(v) for v in obj))
+    if isinstance(obj, (list, tuple)):
+        return type(obj)(_asdict_inner(v) for v in obj)
+    if isinstance(obj, dict):
+        return type(obj)(
+            (_asdict_inner(k), _asdict_inner(v)) for k, v in obj.items()
+        )
+    return obj
+
+
+def _astuple_inner(obj: tx.Any) -> tx.Any:
+    """Walk a value, recursing into Magic instances and containers."""
+    cls = type(obj)
+    if getattr(cls, _FIELDS, None) is not None:
+        return tuple(
+            _astuple_inner(_value(obj, field, "astuple"))
+            for field in _keyed(
+                f for f in getattr(cls, _FIELDS).values() if not f.var
+            ).values()
+        )
+    if isinstance(obj, tuple) and hasattr(obj, "_fields"):
+        return type(obj)(*(_astuple_inner(v) for v in obj))
+    if isinstance(obj, (list, tuple)):
+        return type(obj)(_astuple_inner(v) for v in obj)
+    if isinstance(obj, dict):
+        return type(obj)(
+            (_astuple_inner(k), _astuple_inner(v)) for k, v in obj.items()
+        )
+    return obj
+
+
 def _field_table(obj: tx.Any, caller: str) -> tx.Dict[str, Field]:
     """Every field of an instance's class, pseudo-fields included.
 
@@ -133,12 +177,9 @@ def asdict(obj: tx.Any) -> tx.Dict[str, tx.Any]:
     """
     Get an object's fields as a plain `dict`.
 
-    Values come back exactly as they are stored: nothing is copied,
-    converted, or looked inside. A field holding a list gives you *that*
-    list, and a field holding another Magic object gives you the object
-    itself, not a dict of its fields. If you want a copy, or a nested
-    object turned into a dict too, do it yourself -- that way you decide
-    how deep to go and what to do with the things that are neither.
+    A field holding another Magic object is turned into a dict of *its*
+    fields, and so on all the way down. Everything else is returned
+    as-is.
 
     Keys are the names the constructor takes, which for an aliased or
     underscored field is not the name the class body uses.
@@ -164,6 +205,25 @@ def asdict(obj: tx.Any) -> tx.Dict[str, tx.Any]:
         {'x': 1, 'y': 2}
         ```
 
+    !!! example "Nested Magic objects become dicts"
+        ```pycon
+        >>> class Point(Magic):
+        ...     x: int
+        ...     y: int
+        ...
+        >>> class Line(Magic):
+        ...     start: Point
+        ...     end: Point
+        ...
+        >>> asdict(Line(Point(0, 0), Point(1, 2)))
+        {'start': {'x': 0, 'y': 0}, 'end': {'x': 1, 'y': 2}}
+        >>> class Path(Magic):
+        ...     points: list
+        ...
+        >>> asdict(Path([Point(0, 0), Point(1, 2)]))
+        {'points': [{'x': 0, 'y': 0}, {'x': 1, 'y': 2}]}
+        ```
+
     !!! note "A field with no value is left out"
         A field the constructor does not take, and that has no default,
         holds nothing until something sets it -- so it is simply absent,
@@ -187,20 +247,6 @@ def asdict(obj: tx.Any) -> tx.Dict[str, tx.Any]:
         field it belongs to, a position does not, so a tuple is only
         readable while every field is in it.
 
-    !!! example "A nested object is left alone"
-        ```pycon
-        >>> class Point(Magic):
-        ...     x: int
-        ...     y: int
-        ...
-        >>> class Line(Magic):
-        ...     start: Point
-        ...     end: Point
-        ...
-        >>> asdict(Line(Point(0, 0), Point(1, 2)))
-        {'start': Point(x=0, y=0), 'end': Point(x=1, y=2)}
-        ```
-
     !!! note "Not the same as `dict(obj)`"
         A class written with `mapping=True` can be passed to `dict`
         directly, and that covers the fields marked as keys, under the
@@ -222,7 +268,7 @@ def asdict(obj: tx.Any) -> tx.Dict[str, tx.Any]:
     for name, field in _concrete(obj, "asdict").items():
         has_value, value = _stored(obj, field)
         if has_value:
-            found[name] = value
+            found[name] = _asdict_inner(value)
     return found
 
 
@@ -230,8 +276,8 @@ def astuple(obj: tx.Any) -> tx.Tuple[tx.Any, ...]:
     """
     Get an object's field values as a tuple, in field order.
 
-    Values come back exactly as they are stored, the same way `asdict`
-    returns them: nothing is copied, converted, or looked inside.
+    Like `asdict`, a nested Magic instance is turned into a tuple of
+    its own fields. Everything else is returned as-is.
 
     Parameters
     ----------
@@ -268,13 +314,8 @@ def astuple(obj: tx.Any) -> tx.Tuple[tx.Any, ...]:
         index would stand for a different field from one instance to
         the next, with nothing in the tuple to show it.
     """
-    # The same fields `asdict` reports, worked out the same way: a class
-    # whose fields cannot be told apart by name is refused by both,
-    # rather than answering a tuple here and an error there. A field
-    # holding no value is where the two part: a caller can see that a
-    # key is missing, but a short tuple looks like any other.
     return tuple(
-        _value(obj, field, "astuple")
+        _astuple_inner(_value(obj, field, "astuple"))
         for field in _concrete(obj, "astuple").values()
     )
 

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -6093,6 +6093,31 @@ class TestParityHelpers:
         sentinel = object()
         assert _api.astuple(Outer(sentinel))[0] is sentinel
 
+    def test_astuple_recurses_into_dicts(self) -> None:
+        class Inner(Magic):
+            n: int
+
+        class Outer(Magic):
+            mapping: dict
+
+        result = _api.astuple(Outer({"a": Inner(1)}))
+        assert result == ({"a": (1,)},)
+
+    def test_astuple_recurses_into_namedtuples(self) -> None:
+        from collections import namedtuple
+
+        Pair = namedtuple("Pair", "a b")
+
+        class Inner(Magic):
+            n: int
+
+        class Outer(Magic):
+            pair: tuple
+
+        result = _api.astuple(Outer(Pair(Inner(1), 2)))
+        assert type(result[0]).__name__ == "Pair"
+        assert result[0] == Pair((1,), 2)
+
     def test_astuple_skips_pseudo_fields(self) -> None:
         class Shifted(Magic):
             x: int

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -5968,19 +5968,54 @@ class TestParityHelpers:
         assert _api.asdict(Point(1, 2)) == {"x": 1, "y": 2}
         assert list(_api.asdict(Point(1, 2))) == ["x", "y"]
 
-    def test_asdict_does_not_recurse_or_copy(self) -> None:
+    def test_asdict_recurses_into_magic(self) -> None:
         class Inner(Magic):
             n: int
 
         class Outer(Magic):
             inner: Inner
-            items: list
 
-        items = [1, 2]
-        outer = Outer(Inner(1), items)
-        assert _api.asdict(outer) == {"inner": Inner(1), "items": [1, 2]}
-        assert isinstance(_api.asdict(outer)["inner"], Inner)
-        assert _api.asdict(outer)["items"] is items
+        assert _api.asdict(Outer(Inner(1))) == {"inner": {"n": 1}}
+
+    def test_asdict_recurses_into_containers(self) -> None:
+        class Inner(Magic):
+            n: int
+
+        class Outer(Magic):
+            items: list
+            mapping: dict
+            pair: tuple
+
+        outer = Outer([Inner(1), Inner(2)], {"a": Inner(3)}, (Inner(4),))
+        result = _api.asdict(outer)
+        assert result == {
+            "items": [{"n": 1}, {"n": 2}],
+            "mapping": {"a": {"n": 3}},
+            "pair": ({"n": 4},),
+        }
+
+    def test_asdict_does_not_copy_non_magic_leaves(self) -> None:
+        sentinel = object()
+
+        class Outer(Magic):
+            obj: object
+
+        assert _api.asdict(Outer(sentinel))["obj"] is sentinel
+
+    def test_asdict_preserves_namedtuple_type(self) -> None:
+        from collections import namedtuple
+
+        Pair = namedtuple("Pair", "a b")
+
+        class Inner(Magic):
+            n: int
+
+        class Outer(Magic):
+            pair: tuple
+
+        result = _api.asdict(Outer(Pair(Inner(1), 2)))
+        assert type(result["pair"]).__name__ == "Pair"
+        assert result["pair"] == Pair({"n": 1}, 2)
 
     def test_asdict_keys_by_the_constructor_name(self) -> None:
         class Account(Magic):
@@ -6032,16 +6067,31 @@ class TestParityHelpers:
         assert _api.astuple(Derived(1, 2)) == (1, 2)
         assert _api.asdict(Derived(1, 2)) == {"b": 1, "a": 2}
 
-    def test_astuple_does_not_recurse_or_copy(self) -> None:
+    def test_astuple_recurses_into_magic(self) -> None:
         class Inner(Magic):
             n: int
 
         class Outer(Magic):
             inner: Inner
 
-        inner = Inner(1)
-        assert _api.astuple(Outer(inner)) == (inner,)
-        assert _api.astuple(Outer(inner))[0] is inner
+        assert _api.astuple(Outer(Inner(1))) == ((1,),)
+
+    def test_astuple_recurses_into_containers(self) -> None:
+        class Inner(Magic):
+            n: int
+
+        class Outer(Magic):
+            items: list
+
+        result = _api.astuple(Outer([Inner(1), Inner(2)]))
+        assert result == ([(1,), (2,)],)
+
+    def test_astuple_does_not_copy_non_magic(self) -> None:
+        class Outer(Magic):
+            obj: object
+
+        sentinel = object()
+        assert _api.astuple(Outer(sentinel))[0] is sentinel
 
     def test_astuple_skips_pseudo_fields(self) -> None:
         class Shifted(Magic):


### PR DESCRIPTION
## Summary

- `asdict` and `astuple` now recurse into nested Magic instances, matching what `dataclasses.asdict`, `attrs.asdict` and `pydantic.model_dump` all do. A nested Magic object becomes a dict (or tuple), including inside lists, tuples and dicts. Everything else is returned as-is — no deepcopy.
- Updated docstrings, README and comparison table to reflect the new behaviour.
- Replaced the old "does not recurse" tests with ones that cover nested Magic, Magic inside containers, non-Magic leaves kept by identity, and namedtuple preservation.

Checked: all three neighbours agree on recursing into their own instances and containers.

## Test plan

- [x] All 1013 non-mypy tests pass (the 4 `test_dataclass_transform` failures are pre-existing mypy environment issues)
- [x] All 41 docstring tests pass (including the new examples)
- [x] `ruff check` clean
- [x] `codespell` clean on changed files


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_