### PR TITLE
Collapse the pipeline flag slots into guarded properties

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,19 @@ Tests that exercise internals import them from the module that defines them
   `try` costs nothing while nothing fails.
 - **Options are inherited by merging down the MRO** (`Options.update` per base,
   in reverse MRO order), so a derived class only overrides what it states.
+- **Each pipeline step is one tri-state `Field` slot**, not a flag plus a
+  callable: `converter` / `validator` / `factory` each hold `False` (off),
+  `True` (on, work the callable out from the type) or a callable (on, use it).
+  The booleans `convert` / `validate` / `build` are **read-only properties**
+  returning `slot is not False` — every "is this step on?" read goes through
+  them, so a falsy callable can't turn itself off (the concern that once split
+  these into two slots each; a property is enough, a second slot is not). The
+  `convert=`/`validate=`/`build=` constructor keywords are aliases folded onto
+  the slot in `Field.__init__`. Internal code that sets a step writes the slot
+  directly (`field.factory = False`, `_redeclare(factory=...)`), never the
+  property. `_declared` (what the field asked for, for `override`) and
+  `_derived` (which callables came from the type, for rebuild-on-substitution)
+  are private bookkeeping — not constructor arguments, kept out of repr.
 
 ### Reading annotations
 

--- a/src/bagof/magic/_fields.py
+++ b/src/bagof/magic/_fields.py
@@ -58,13 +58,13 @@ T = tx.TypeVar("T")
 #: `eq`, `order`, `hash` and `mapping` are absent because a field
 #: resolves those from its own values, not from its class.
 _OVERRIDABLE = {
-    "convert": ("convert", "converter"),
-    "factory": ("build", "factory"),
+    "convert": ("converter",),
+    "factory": ("factory",),
     "frozen": ("frozen",),
     "kw_only": ("kw", "positional"),
     "positional_only": ("kw", "positional"),
     "repr": ("repr",),
-    "validate": ("validate", "validator"),
+    "validate": ("validator",),
 }
 
 #: Every field attribute a class setting decides, in a stable order.
@@ -77,8 +77,7 @@ _RESOLVED_ATTRS = tuple(dict.fromkeys(
     'name',             # Field name
     'type',             # Field type (or type hint)
     'default',          # Default value for this field.
-    'build',            # True if default is built by calling something.
-    'factory',          # Default factory (None = from hint).
+    'factory',          # Default: False (none), True (from hint), callable.
     'repr',             # Include this field in the generated __repr__ method.
     'hash',             # Include this field in the generated __hash__ method.
     'eq',               # Include this field in the generated __eq__ method.
@@ -87,16 +86,14 @@ _RESOLVED_ATTRS = tuple(dict.fromkeys(
     'kw',               # Field is a keyword argument in __init__.
     'positional',       # Field is a positional argument in __init__.
     'frozen',           # Make this field immutable after initialization.
-    'convert',          # Whether the value handed to this field is converted.
-    'converter',        # Value converter (None = from hint)
-    'validate',         # Whether the value handed to this field is validated.
-    'validator',        # Value validator (None = from hint)
-    'derived',          # List of hint-derived tools
+    'converter',        # Convert: False (no), True (from hint), callable.
+    'validator',        # Validate: False (no), True (from hint), callable.
+    '_derived',         # Which tools were worked out from the hint.
     'var',              # Whether this field is a pseudo-field
     'doc',              # Docstring for this field.
     'key',              # Field is a key in the dict-like interface.
     'alias',            # Alternative names for this field.
-    'declared',         # See description below.
+    '_declared',        # What the field asked for (bookkeeping for override).
 )
 class Field(SlotsBase):
     """A single field in a Magic class.
@@ -117,13 +114,13 @@ class Field(SlotsBase):
             factory defaults when those are turned on.
         default : any
             The default value.
-        build : bool, default=`Options().factory`
-            Build a fresh default per instance by calling something,
-            rather than sharing one value across all instances.
-        factory : Callable[[], any], optional
-            What to call. Omit it and one is worked out from the type.
-            Passing a callable turns `build` on. Passing `factory=True`
-            turns it on without naming a callable.
+        factory : bool or Callable[[], any], default=`Options().factory`
+            How a fresh default is built per instance, rather than one
+            value shared across instances: `False` builds nothing,
+            `True` works the factory out from the type, and a callable
+            is called to build it. The `build` property reads this as a
+            plain "is a default built?" boolean. The `build=` keyword is
+            an alias that sets this: `build=True`/`build=False`.
         init : bool, optional
             Whether this field appears in `__init__`. Not stored
             directly: it reads as `kw or positional`. Setting
@@ -153,22 +150,17 @@ class Field(SlotsBase):
             positional-only, also set `kw=False`.
         frozen : bool, default=`Options().frozen`
             Forbid assignment after construction.
-        convert : bool, default=`Options().convert`
-            Convert the incoming value.
-        converter : Callable[[any], any], optional
-            What converts it. Omit it and one is worked out from the
-            type. Passing a callable turns `convert` on.
-        validate : bool, default=`Options().validate`
-            Validate the incoming value.
-        validator : Callable[[any], any], optional
-            What validates it: returns the value unchanged when valid,
-            raises when not. Omit it and one is worked out from the
-            type. Passing a callable turns `validate` on.
-        derived : tuple of str, optional
-            Which of `converter`, `validator` and `factory` were worked
-            out from the type rather than provided. When a subclass
-            fills in a type variable, these are rebuilt from the new
-            type. Manually provided callables are left alone.
+        converter : bool or Callable[[any], any], default=`Options().convert`
+            How the incoming value is converted: `False` not at all,
+            `True` using a converter worked out from the type, or a
+            callable that converts it. The `convert` property reads this
+            as a boolean. The `convert=` keyword is an alias that sets
+            this: `convert=True`/`convert=False`.
+        validator : bool or Callable[[any], any], default=`Options().validate`
+            How the incoming value is validated, in the same three forms
+            as `converter` (a validator returns the value unchanged when
+            valid and raises when not). The `validate` property reads
+            this as a boolean; `validate=` is an alias that sets it.
         var : bool, default=False
             Mark this as a pseudo-field. An `InitVar` is passed to the
             constructor but not stored. A `ClassVar` is a class
@@ -185,11 +177,6 @@ class Field(SlotsBase):
             The name used in generated methods (constructor parameter,
             repr output, dict key). Useful when the field name is not a
             good public name, or when matching an external API.
-        declared : dict, optional
-            What this field asked for before the class filled in the
-            rest. Recorded the first time the field is resolved against
-            a class. Used by `override` to restore the field's own
-            preferences. No reason to pass it by hand.
 
         Other Parameters
         ----------------
@@ -199,20 +186,14 @@ class Field(SlotsBase):
         # The positional argument lets Field act as the opposite of Var.
         if arg and arg[0] is not MISSING:
             kwargs["var"] = not arg[0]
-        # Each pipeline step (convert, validate, build) has two slots:
-        # a flag for "whether" and a callable for "what". Naming the
-        # callable implies the flag: `converter=int` turns convert on,
-        # `converter=True` turns it on without naming a callable, and
-        # `converter=False` turns it off.
-        for call, flag in _PIPELINE.items():
-            given = kwargs.get(call, MISSING)
-            if given is MISSING:
-                continue
-            if given is True or given is False:
-                kwargs.setdefault(flag, given)
-                del kwargs[call]
-            else:
-                kwargs.setdefault(flag, True)
+        # Each pipeline step has one tri-state slot: `False` (off),
+        # `True` (on, work the callable out from the type) or a callable
+        # (on, use it). `convert`/`validate`/`build` are aliases that set
+        # the same slot -- `convert=True` is `converter=True` -- and the
+        # callable spelling wins if both are given.
+        for flag, call in _FLAG_TO_CALL.items():
+            if flag in kwargs:
+                kwargs.setdefault(call, kwargs.pop(flag))
         # `compare` sets both `eq` and `order` at once.
         compare = kwargs.get("compare", MISSING)
         if compare is not MISSING:
@@ -256,6 +237,33 @@ class Field(SlotsBase):
     @init.setter
     def init(self, value: bool) -> None:
         self.kw = self.positional = value
+
+    @property
+    def convert(self) -> bool:
+        """Whether the incoming value is converted.
+
+        Reads `converter`: `True` for a converter worked out from the
+        type or a callable given directly, `False` when conversion is
+        off. Set conversion through `converter`, or the `convert=`
+        keyword when building the field.
+        """
+        return self.converter is not False
+
+    @property
+    def validate(self) -> bool:
+        """Whether the incoming value is validated.
+
+        Reads `validator`, the same way `convert` reads `converter`.
+        """
+        return self.validator is not False
+
+    @property
+    def build(self) -> bool:
+        """Whether a fresh default is built for this field per instance.
+
+        Reads `factory`, the same way `convert` reads `converter`.
+        """
+        return self.factory is not False
 
     @property
     def public_name(self) -> str:
@@ -307,18 +315,19 @@ class Field(SlotsBase):
 
     def copy(self) -> tx.Self:
         # A field is mutated in place during class building, so a copy
-        # must not share its `declared` dict with the original.
+        # must not share its `_declared` dict with the original.
         new = super().copy()
-        if new.declared is not MISSING:
-            new.declared = dict(new.declared)
+        if new._declared is not MISSING:
+            new._declared = dict(new._declared)
         return new
 
     def __repr__(self) -> str:
-        # Omit `declared` from repr since it is bookkeeping for
-        # `override` and would double every repr's length.
+        # Omit the two bookkeeping slots from repr: they are internal to
+        # `override` and rebuild-on-substitution, and would only make
+        # every repr longer.
         shown = (
             slot for slot in self._slots()
-            if slot != "declared"
+            if slot not in ("_declared", "_derived")
             and getattr(self, slot, MISSING) is not MISSING
         )
         params = ", ".join(
@@ -331,8 +340,8 @@ class Field(SlotsBase):
         # re-resolving against a different class's options preserves it.
         for attr, value in values.items():
             setattr(self, attr, value)
-            if self.declared is not MISSING and attr in self.declared:
-                self.declared[attr] = value
+            if self._declared is not MISSING and attr in self._declared:
+                self._declared[attr] = value
 
     def _reresolve(
         self,
@@ -343,7 +352,7 @@ class Field(SlotsBase):
         # Reset `attrs` to the field's own declarations, then resolve
         # them again from `options`. The field's own preferences survive.
         for attr in attrs:
-            setattr(self, attr, self.declared[attr])
+            setattr(self, attr, self._declared[attr])
         self.setdefault(options, hints)
 
     def setdefault(
@@ -356,8 +365,8 @@ class Field(SlotsBase):
         #
         # The field's own preferences are preserved so that `override`
         # on a subclass can restore and re-resolve them.
-        if self.declared is MISSING:
-            self.declared = {
+        if self._declared is MISSING:
+            self._declared = {
                 attr: getattr(self, attr) for attr in _RESOLVED_ATTRS
             }
         if options.kw_only and options.positional_only:
@@ -425,27 +434,26 @@ class Field(SlotsBase):
                 self.positional = True
         if self.frozen is MISSING:
             self.frozen = options.frozen
-        if self.convert is MISSING:
-            self.convert = options.convert
-        if self.validate is MISSING:
-            self.validate = options.validate
-        if self.build is MISSING:
-            self.build = options.factory
-        # An active step with no callable gets one from the field's type.
-        # Track which ones came from the type, so that filling in a type
-        # variable rebuilds only those (not manually provided callables).
-        for attr in _FROM_TYPE:
-            if getattr(self, attr) is MISSING:
-                setattr(self, attr, None)
-        self.derived = tuple(
-            attr for attr in _FROM_TYPE
-            if getattr(self, _PIPELINE[attr]) and getattr(self, attr) is None
+        # Each pipeline slot the field left unset takes the class option:
+        # `True` (on, from the type) or `False` (off).
+        if self.converter is MISSING:
+            self.converter = options.convert
+        if self.validator is MISSING:
+            self.validator = options.validate
+        if self.factory is MISSING:
+            self.factory = options.factory
+        # A slot left as `True` is on but named no callable, so one is
+        # worked out from the field's type. Track which, so that filling
+        # in a type variable rebuilds only those, not a callable given
+        # by hand.
+        self._derived = tuple(
+            attr for attr in _FROM_TYPE if getattr(self, attr) is True
         )
         self._rebuild(hints)
 
     def _rebuild(self, hints: tx.Optional[Hints] = None) -> None:
         # Rebuild the type-derived callables from the current type.
-        for attr in self.derived or ():
+        for attr in self._derived or ():
             setattr(self, attr, _FROM_TYPE[attr](self.type, hints, self.name))
 
 
@@ -456,11 +464,12 @@ _FROM_TYPE = {
     "factory": _make_factory,
 }
 
-#: Each pipeline step's callable slot mapped to its flag slot.
-_PIPELINE = {
-    "converter": "convert",
-    "validator": "validate",
-    "factory": "build",
+#: The `convert`/`validate`/`build` keyword aliases, each mapped to the
+#: tri-state slot it sets.
+_FLAG_TO_CALL = {
+    "convert": "converter",
+    "validate": "validator",
+    "build": "factory",
 }
 
 
@@ -616,13 +625,13 @@ class Factory(AnnotatedField):
     !!! example "How it lowers"
         ```pycon
         >>> Factory()
-        Factory(build=True)
+        Factory(factory=True)
         >>> Factory(list)
-        Factory(build=True, factory=<class 'list'>)
+        Factory(factory=<class 'list'>)
         >>> Factory[list]
-        typing.Annotated[list, Factory(build=True)]
+        typing.Annotated[list, Factory(factory=True)]
         >>> Factory[list, tuple]
-        typing.Annotated[list, Factory(build=True, factory=<class 'tuple'>)]
+        typing.Annotated[list, Factory(factory=<class 'tuple'>)]
         ```
 
     !!! example "In a class"
@@ -649,11 +658,11 @@ class ConvertTo(AnnotatedField):
     !!! example "How it lowers"
         ```pycon
         >>> ConvertTo()
-        ConvertTo(convert=True)
+        ConvertTo(converter=True)
         >>> ConvertTo(int)
-        ConvertTo(convert=True, converter=<class 'int'>)
+        ConvertTo(converter=<class 'int'>)
         >>> ConvertTo[int]
-        typing.Annotated[int, ConvertTo(convert=True)]
+        typing.Annotated[int, ConvertTo(converter=True)]
         ```
 
     !!! example "In a class"
@@ -681,9 +690,9 @@ class Validate(AnnotatedField):
     !!! example "How it lowers"
         ```pycon
         >>> Validate()
-        Validate(validate=True)
+        Validate(validator=True)
         >>> Validate[str]
-        typing.Annotated[str, Validate(validate=True)]
+        typing.Annotated[str, Validate(validator=True)]
         ```
 
     !!! example "In a class"

--- a/src/bagof/magic/_magic.py
+++ b/src/bagof/magic/_magic.py
@@ -1124,8 +1124,7 @@ def _pin_discriminants(
         # The pin is the value, so a default the field would otherwise
         # have built for itself no longer applies -- and nothing is left
         # behind to build it with.
-        field.build = False
-        field.factory = None
+        field.factory = False
         if action == "classvar":
             field.var = True
             field.repr = SHOW_ATTR(False)
@@ -1207,7 +1206,7 @@ def _handle_mutable_default(field: Field, action: str) -> bool:
     # written as `lambda: copy(default)` would give.
     # Recorded as the field's own, so that a subclass resolving the
     # field again against its own settings does not undo it.
-    field._redeclare(build=True, factory=partial(copy.copy, default))
+    field._redeclare(factory=partial(copy.copy, default))
     field.default = MISSING
     return True
 
@@ -2126,7 +2125,7 @@ def _is_class_attribute(field: Field) -> bool:
     # may not be passed by name, on a class where nothing may be passed
     # by position, is an `InitVar` whose two settings cancelled out, and
     # nothing is ever stored on the class for it.
-    declared = field.declared if field.declared is not MISSING else {}
+    declared = field._declared if field._declared is not MISSING else {}
     return declared.get("kw") is False and declared.get("positional") is False
 
 

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -3183,10 +3183,10 @@ class TestDeclaredValues:
 
     def test_it_is_taken_before_anything_is_filled_in(self) -> None:
         field = Field.from_hint("x", Frozen[int])
-        assert field.declared is MISSING
+        assert field._declared is MISSING
         field.setdefault(Options.make_default())
-        assert field.declared["frozen"] is True
-        assert field.declared["converter"] is MISSING
+        assert field._declared["frozen"] is True
+        assert field._declared["converter"] is MISSING
 
     def test_it_is_taken_once(self) -> None:
         field = Field.from_hint("x", int)
@@ -3195,7 +3195,7 @@ class TestDeclaredValues:
         field.setdefault(Options.make_default())
         # Already answered, so a second pass changes nothing.
         assert field.frozen is True
-        assert field.declared["frozen"] is MISSING
+        assert field._declared["frozen"] is MISSING
 
     def test_a_copy_shares_nothing_with_its_original(self) -> None:
         class Base(Magic, frozen=True):
@@ -3206,13 +3206,13 @@ class TestDeclaredValues:
 
         base_field = _api.fields(Base)[0]
         sub_field = _api.fields(Sub)[0]
-        assert sub_field.declared is not base_field.declared
+        assert sub_field._declared is not base_field._declared
         assert base_field.frozen is True
         assert sub_field.frozen is False
 
     def test_a_field_that_declared_nothing_copies_cleanly(self) -> None:
         field = Field(name="x")
-        assert field.copy().declared is MISSING
+        assert field.copy()._declared is MISSING
 
     def test_it_stays_out_of_the_repr(self) -> None:
         field = Field.from_hint("x", int)
@@ -3224,7 +3224,7 @@ class TestDeclaredValues:
         field = Field(name="x")
         field._redeclare(factory=list)
         assert field.factory is list
-        assert field.declared is MISSING
+        assert field._declared is MISSING
 
 
 class TestOverridableSettings:
@@ -5810,8 +5810,8 @@ class TestFillingATypeParameterIn:
             worked_out: _T
 
         fields = _api.fields_dict(Box)
-        assert fields["given"].derived == ()
-        assert fields["worked_out"].derived == ("converter",)
+        assert fields["given"]._derived == ()
+        assert fields["worked_out"]._derived == ("converter",)
 
     def test_a_type_still_written_as_a_name_is_filled_in_too(self) -> None:
         class Box(Magic, tx.Generic[_T], convert=True):

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1296,6 +1296,15 @@ class TestConvertTo:
         assert p.x == 1
         assert p.y == 2.5
 
+    def test_the_flag_keyword_folds_onto_the_slot(self) -> None:
+        # `convert=`/`validate=`/`build=` are aliases for the tri-state
+        # slot; the callable spelling wins when both are given.
+        assert Field(name="x", convert=True).converter is True
+        assert Field(name="x", convert=False).converter is False
+        assert Field(name="x", validate=True).validator is True
+        assert Field(name="x", build=True).factory is True
+        assert Field(name="x", convert=True, converter=int).converter is int
+
 
 # ======================================================================
 # Validate


### PR DESCRIPTION
## Summary

Each pipeline step was two `Field` slots since #92 — a flag (`convert` / `validate` / `build`) and a callable (`converter` / `validator` / `factory`) — which meant two attributes per step on every `Field`, and two names for one concept when reading one back. This folds each step to a **single tri-state slot** plus a **guarded property**:

- `converter` / `validator` / `factory` now hold `False` (off), `True` (on, work the callable out from the type) or a callable (on, use it).
- `convert` / `validate` / `build` become read-only **`@property`** returning `slot is not False`.

```pycon
>>> f = fields_dict(Server)["port"]   # port: ConvertTo[int]
>>> f.converter          # the tri-state slot
<class 'int'>
>>> f.convert            # the guarded boolean
True
```

## Why

#92 split them because reading the single slot as a boolean — `if field.converter:` — asked "on?" and "with what?" at once, and *a callable that happened to be falsy turned itself off*. But a falsy callable is rare — only an instance whose type defines a falsy `__bool__`/`__len__`; plain functions, lambdas, `partial` and classes are all truthy — and the real fix for it is a **guard, not a second slot**. The `convert`/`validate`/`build` properties are that guard: every "is this step on?" read (~35 sites) goes through `slot is not False`, so the safety #92 wanted is kept with one accessor instead of a duplicated slot.

Verified no site reads a callable slot as a boolean — the on/off question always goes through the property, the call sites only ever call the callable.

## Also

- The `convert=`/`validate=`/`build=` constructor keywords still work (folded onto the slot in `Field.__init__`), and the public annotation spellings (`ConvertTo(int)`, `Factory()`, …) are unchanged.
- `declared` → `_declared` and `derived` → `_derived`: the two bookkeeping attributes (the `override` snapshot, and which callables came from the type) are private now — neither is a constructor argument, and both are dropped from the public docs and the repr.

## Test plan

- [x] Full suite **1052 passed**, 1 skipped; the only failures are the 4 pre-existing `test_dataclass_transform` mypy-environment cases (fail on `main` too — no mypy in the runner).
- [x] Behaviour identical on **Python 3.8 and 3.13**.
- [x] `ruff check src tests` and `codespell src tests` clean; docstring examples (the annotation-family reprs) updated and passing.

## Docs

A note in `CLAUDE.md` records the tri-state-slot + guarded-property model and why it is one slot, not two, so it isn't re-split later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmpiy2TdP6eZv6mRvfMLi2)_